### PR TITLE
Ensure that the project name is properly formatted

### DIFF
--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -10,6 +10,8 @@ import {
 } from '../../services/project-initializer'
 import { Provider } from '@boostercloud/framework-types'
 import Prompter from '../../services/user-prompt'
+import { assertNameIsWithinBounds } from '../../services/provider-service'
+
 
 export default class Project extends Command {
   public static description = 'create a new project from scratch'
@@ -56,6 +58,7 @@ export default class Project extends Command {
     const { args, flags } = this.parse(Project)
     if (!args.projectName)
       return Promise.reject("You haven't provided a project name, but it is required, run with --help for usage")
+    assertNameIsWithinBounds(args.projectName)
     const parsedFlags = {
       projectName: args.projectName,
       ...flags,

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -10,7 +10,7 @@ import {
 } from '../../services/project-initializer'
 import { Provider } from '@boostercloud/framework-types'
 import Prompter from '../../services/user-prompt'
-import { assertNameIsWithinBounds } from '../../services/provider-service'
+import { assertNameIsCorrect } from '../../services/provider-service'
 
 
 export default class Project extends Command {
@@ -58,7 +58,7 @@ export default class Project extends Command {
     const { args, flags } = this.parse(Project)
     if (!args.projectName)
       return Promise.reject("You haven't provided a project name, but it is required, run with --help for usage")
-    assertNameIsWithinBounds(args.projectName)
+    assertNameIsCorrect(args.projectName)
     const parsedFlags = {
       projectName: args.projectName,
       ...flags,

--- a/packages/cli/src/services/provider-service.ts
+++ b/packages/cli/src/services/provider-service.ts
@@ -16,6 +16,11 @@ export function assertNameIsCorrect(name: string): void {
     throw new Error(`Project name cannot contain spaces:
 
     Found: '${name}'`)
+
+  if (name.toLowerCase() != name)
+    throw new Error(`Project name cannot contain uppercase letters:
+
+    Found: '${name}'`)
 }
 
 export const deployToCloudProvider = (configuration: BoosterConfig): Observable<string> => {

--- a/packages/cli/src/services/provider-service.ts
+++ b/packages/cli/src/services/provider-service.ts
@@ -2,7 +2,19 @@ import { BoosterConfig } from '@boostercloud/framework-types'
 import { Observable } from 'rxjs'
 import { Providers } from '@boostercloud/framework-core'
 
+export function assertNameIsWithinBounds(name: string): void {
+  // It is 55 because cloudformations max length is 63.
+  // Booster creates an S3 bucket ended in '-toolkit'
+  // which is 8 chars long. 63 - 8 = 55
+  const maxProjectNameLength = 55
+  if (name.length > maxProjectNameLength)
+    throw new Error(`Project name cannot be longer than ${maxProjectNameLength} chars long:
+
+    Found: ${name}`)
+}
+
 export const deployToCloudProvider = (configuration: BoosterConfig): Observable<string> => {
+  assertNameIsWithinBounds(configuration.appName)
   return Providers.getInfrastructure(configuration).deploy(configuration)
 }
 export const nukeCloudProviderResources = (configuration: BoosterConfig): Observable<string> => {

--- a/packages/cli/src/services/provider-service.ts
+++ b/packages/cli/src/services/provider-service.ts
@@ -2,7 +2,7 @@ import { BoosterConfig } from '@boostercloud/framework-types'
 import { Observable } from 'rxjs'
 import { Providers } from '@boostercloud/framework-core'
 
-export function assertNameIsWithinBounds(name: string): void {
+export function assertNameIsCorrect(name: string): void {
   // It is 55 because cloudformations max length is 63.
   // Booster creates an S3 bucket ended in '-toolkit'
   // which is 8 chars long. 63 - 8 = 55
@@ -10,11 +10,16 @@ export function assertNameIsWithinBounds(name: string): void {
   if (name.length > maxProjectNameLength)
     throw new Error(`Project name cannot be longer than ${maxProjectNameLength} chars long:
 
-    Found: ${name}`)
+    Found: '${name}'`)
+
+  if (name.includes(' '))
+    throw new Error(`Project name cannot contain spaces:
+
+    Found: '${name}'`)
 }
 
 export const deployToCloudProvider = (configuration: BoosterConfig): Observable<string> => {
-  assertNameIsWithinBounds(configuration.appName)
+  assertNameIsCorrect(configuration.appName)
   return Providers.getInfrastructure(configuration).deploy(configuration)
 }
 export const nukeCloudProviderResources = (configuration: BoosterConfig): Observable<string> => {


### PR DESCRIPTION
If this is not the case, the deploy fails in the middle of the deploy process, while we could save some time of the user if we check it beforehand. This PR addresses this issue.