### PR TITLE
Fix typo on read models

### DIFF
--- a/docs/documentation/09-rest-api.md
+++ b/docs/documentation/09-rest-api.md
@@ -32,16 +32,16 @@ Body:
 
 ### Get a list
 
-`GET https://<baseURL>/read-models/<read model class name>`
+`GET https://<baseURL>/readmodels/<read model class name>`
 
 Example:
 
-`GET https://<baseURL>/read-models/CartReadModel`
+`GET https://<baseURL>/readmodels/CartReadModel`
 
 ### Get a specific read model
 
-`GET https://<baseURL>/read-models/<read model class name>/<read model ID>`
+`GET https://<baseURL>/readmodels/<read model class name>/<read model ID>`
 
 Example:
 
-`GET https://<baseURL>/read-models/CartReadModel/42`
+`GET https://<baseURL>/readmodels/CartReadModel/42`


### PR DESCRIPTION
A [user pointed out](https://spectrum.chat/boostercloud/general/api-endpoint-empty-response~06306d66-18a5-434f-9643-e1150d7494c2) that they were having issues with the read models endpoint. This is because the docs had a typo and pointed to a wrong endpoint.