### PR TITLE
Create the packages for the local provider

### DIFF
--- a/packages/framework-provider-local-infrastructure/.eslintignore
+++ b/packages/framework-provider-local-infrastructure/.eslintignore
@@ -1,0 +1,3 @@
+dist
+lib
+node_modules

--- a/packages/framework-provider-local-infrastructure/package.json
+++ b/packages/framework-provider-local-infrastructure/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@boostercloud/framework-provider-local-infrastructure",
+  "version": "0.1.4",
+  "description": "Handle the Booster running process of the local runtime",
+  "keywords": [
+    "framework-provider-local-infrastructure"
+  ],
+  "author": "Booster Cloud",
+  "homepage": "https://booster.cloud",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/boostercloud/booster.git"
+  },
+  "dependencies": {
+    "@boostercloud/framework-types": "^0.1.4",
+    "@boostercloud/framework-provider-aws": "^0.1.4"
+  },
+  "scripts": {
+    "lint": "eslint --ext '.js,.ts' **/*.ts",
+    "fix-lint": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
+    "compile": "tsc -b tsconfig.json",
+    "clean": "rimraf ./dist tsconfig.tsbuildinfo",
+    "prepack": "tsc -b tsconfig.json",
+    "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
+  },
+  "bugs": {
+    "url": "https://github.com/boostercloud/booster/issues"
+  },
+  "devDependencies": {}
+}

--- a/packages/framework-provider-local-infrastructure/src/index.ts
+++ b/packages/framework-provider-local-infrastructure/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = () => 'Hello I will be the local provider infrastructure! 💻'

--- a/packages/framework-provider-local-infrastructure/test/mocha.opts
+++ b/packages/framework-provider-local-infrastructure/test/mocha.opts
@@ -1,0 +1,5 @@
+--require ts-node/register
+--watch-extensions ts
+--recursive
+--reporter spec
+--timeout 5000

--- a/packages/framework-provider-local-infrastructure/tsconfig.eslint.json
+++ b/packages/framework-provider-local-infrastructure/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}

--- a/packages/framework-provider-local-infrastructure/tsconfig.json
+++ b/packages/framework-provider-local-infrastructure/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/framework-provider-local/.eslintignore
+++ b/packages/framework-provider-local/.eslintignore
@@ -1,0 +1,3 @@
+dist
+lib
+node_modules

--- a/packages/framework-provider-local/package.json
+++ b/packages/framework-provider-local/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@boostercloud/framework-provider-local",
+  "version": "0.1.4",
+  "description": "Debug your Booster projects locally",
+  "keywords": [
+    "framework-provider-aws"
+  ],
+  "author": "Booster Cloud",
+  "homepage": "https://booster.cloud",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/boostercloud/booster.git"
+  },
+  "dependencies": {
+    "@boostercloud/framework-types": "^0.1.4"
+  },
+  "scripts": {
+    "lint": "eslint --ext '.js,.ts' **/*.ts",
+    "fix-lint": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
+    "compile": "tsc -b tsconfig.json",
+    "clean": "rimraf ./dist tsconfig.tsbuildinfo",
+    "prepack": "tsc -b tsconfig.json",
+    "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
+  },
+  "bugs": {
+    "url": "https://github.com/boostercloud/booster/issues"
+  },
+  "devDependencies": {},
+  "gitHead": "121816dbe55d57df5860b54a871c06dcda761101"
+}

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = () => console.log('Hello, I will be the local provider! 🚀')

--- a/packages/framework-provider-local/test/mocha.opts
+++ b/packages/framework-provider-local/test/mocha.opts
@@ -1,0 +1,5 @@
+--require ts-node/register
+--watch-extensions ts
+--recursive
+--reporter spec
+--timeout 5000

--- a/packages/framework-provider-local/tsconfig.eslint.json
+++ b/packages/framework-provider-local/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}

--- a/packages/framework-provider-local/tsconfig.json
+++ b/packages/framework-provider-local/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
This PR essentially duplicates the `aws-provider` and `aws-provider-infrastructure` and removes all the unnecessary things like the dependencies and the code.

I'm currently targeting the branch started with #16 in order to be up to date.