### PR TITLE
Fix: Added permissions to access DynamoDB tables to the command handler lambda

### DIFF
--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/application-stack.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/application-stack.ts
@@ -45,7 +45,7 @@ function setupPermissions(
   commandsLambda.addToRolePolicy(
     new PolicyStatement({
       resources: [eventsStream.streamArn],
-      actions: ['kinesis:Put*'],
+      actions: ['kinesis:Put*', 'dynamodb:Query*', 'dynamodb:Put*'],
     })
   )
 


### PR DESCRIPTION
This fixes an error preventing command handlers from fetching the current state of an entity, as discussed [in this Spectrum thread](https://spectrum.chat/boostercloud/general/how-to-fetchentities~3b33be68-5cc2-411c-a30a-530638ebbcd6).