### PR TITLE
fix: Generate read-models from CLI

### DIFF
--- a/packages/cli/src/commands/new/read-model.ts
+++ b/packages/cli/src/commands/new/read-model.ts
@@ -22,12 +22,12 @@ export default class ReadModel extends Oclif.Command {
     help: Oclif.flags.help({ char: 'h' }),
     fields: Oclif.flags.string({
       char: 'f',
-      description: 'fields that this entity will contain',
+      description: 'fields that this read model will contain',
       multiple: true,
     }),
     projects: Oclif.flags.string({
       char: 'p',
-      description: 'entities that this entity will project to build its state',
+      description: 'entities that this read model will project to build its state',
       multiple: true,
     }),
   }

--- a/packages/cli/src/commands/new/read-model.ts
+++ b/packages/cli/src/commands/new/read-model.ts
@@ -40,8 +40,8 @@ export default class ReadModel extends Oclif.Command {
 
   private async runWithErrors(): Promise<void> {
     const { args, flags } = this.parse(ReadModel)
-    const fields = flags.fields || []
-    const projections = flags.projects || []
+    const fields = flags.fields ?? []
+    const projections = flags.projects ?? []
     if (!args.readModelName)
       return Promise.reject("You haven't provided a read model name, but it is required, run with --help for usage")
     return run(args.readModelName, fields, projections)

--- a/packages/cli/src/commands/new/read-model.ts
+++ b/packages/cli/src/commands/new/read-model.ts
@@ -1,0 +1,97 @@
+import * as Oclif from '@oclif/command'
+import { Script } from '../../common/script'
+import Brand from '../../common/brand'
+import {
+  HasFields,
+  HasName,
+  joinParsers,
+  parseName,
+  parseFields,
+  ImportDeclaration,
+  HasProjections,
+  parseProjections,
+} from '../../services/generator/target'
+import * as path from 'path'
+import { generate } from '../../services/generator'
+import { templates } from '../../templates'
+import { checkItIsABoosterProject } from '../../services/project-checker'
+
+export default class ReadModel extends Oclif.Command {
+  public static description = 'create a new read model'
+  public static flags = {
+    help: Oclif.flags.help({ char: 'h' }),
+    fields: Oclif.flags.string({
+      char: 'f',
+      description: 'fields that this entity will contain',
+      multiple: true,
+    }),
+    projects: Oclif.flags.string({
+      char: 'p',
+      description: 'entities that this entity will project to build its state',
+      multiple: true,
+    }),
+  }
+
+  public static args = [{ name: 'readModelName' }]
+
+  public async run(): Promise<void> {
+    return this.runWithErrors().catch(console.error)
+  }
+
+  private async runWithErrors(): Promise<void> {
+    const { args, flags } = this.parse(ReadModel)
+    const fields = flags.fields || []
+    const projections = flags.projects || []
+    if (!args.readModelName)
+      return Promise.reject("You haven't provided a read model name, but it is required, run with --help for usage")
+    return run(args.readModelName, fields, projections)
+  }
+}
+
+type ReadModelInfo = HasName & HasFields & HasProjections
+
+const run = async (name: string, rawFields: Array<string>, rawProjections: Array<string>): Promise<void> =>
+  Script.init(
+    `boost ${Brand.energize('new:read-model')} 🚧`,
+    joinParsers(parseName(name), parseFields(rawFields), parseProjections(rawProjections))
+  )
+    .step('Verifying project', checkItIsABoosterProject)
+    .step('Creating new read model', generateReadModel)
+    .info('Read model generated!')
+    .done()
+
+function generateImports(info: ReadModelInfo): Array<ImportDeclaration> {
+  const eventsImports: Array<ImportDeclaration> = info.projections.map((projection) => ({
+    packagePath: `../entities/${projection.entityName}`,
+    commaSeparatedComponents: projection.entityName,
+  }))
+
+  const coreComponents = ['ReadModel']
+  if (info.projections.length > 0) {
+    coreComponents.push('Projects')
+  }
+
+  return [
+    {
+      packagePath: '@boostercloud/framework-core',
+      commaSeparatedComponents: coreComponents.join(', '),
+    },
+    {
+      packagePath: '@boostercloud/framework-types',
+      commaSeparatedComponents: 'UUID',
+    },
+    ...eventsImports,
+  ]
+}
+
+const generateReadModel = (info: ReadModelInfo): Promise<void> =>
+  generate({
+    name: info.name,
+    extension: '.ts',
+    placementDir: path.join('src', 'read-models'),
+    template: templates.readModel,
+    info: {
+      imports: generateImports(info),
+      ...info,
+    },
+  })

--- a/packages/cli/src/services/generator/target/parsing.ts
+++ b/packages/cli/src/services/generator/target/parsing.ts
@@ -1,4 +1,4 @@
-import { HasName, HasFields, Field, HasReaction, ReactionEvent } from './types'
+import { HasName, HasFields, Field, HasReaction, ReactionEvent, Projection, HasProjections } from './types'
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/generic-type-naming */
@@ -20,6 +20,21 @@ function parseField(rawField: string): Promise<Field> {
   }
 }
 
+export const parseProjections = (fields: Array<string>): Promise<HasProjections> =>
+  Promise.all(fields.map(parseProjection)).then((projections) => ({ projections }))
+
+function parseProjection(rawProjection: string): Promise<Projection> {
+  const splitInput = rawProjection.split(':')
+  if (splitInput.length != 2) {
+    return Promise.reject(projectionParsingError(rawProjection))
+  } else {
+    return Promise.resolve({
+      entityName: splitInput[0],
+      entityId: splitInput[1],
+    })
+  }
+}
+
 export const parseReaction = (rawEvents: Array<string>): Promise<HasReaction> =>
   Promise.all(rawEvents.map(parseReactionEvent)).then((events) => ({
     events,
@@ -29,6 +44,9 @@ const parseReactionEvent = (eventName: string): Promise<ReactionEvent> => Promis
 
 const fieldParsingError = (field: string): Error =>
   new Error(`Error parsing field ${field}. Fields must be in the form of <field name>:<field type>`)
+
+const projectionParsingError = (projection: string): Error =>
+  new Error(`Error parsing projection ${projection}. Projections must be in the form of <entity name>:<entity id>`)
 
 /**
  * Joins parsers together used to generate target information for generators.

--- a/packages/cli/src/services/generator/target/parsing.ts
+++ b/packages/cli/src/services/generator/target/parsing.ts
@@ -23,7 +23,7 @@ function parseField(rawField: string): Promise<Field> {
 export const parseProjections = (fields: Array<string>): Promise<HasProjections> =>
   Promise.all(fields.map(parseProjection)).then((projections) => ({ projections }))
 
-function async parseProjection(rawProjection: string): Promise<Projection> {
+async function parseProjection(rawProjection: string): Promise<Projection> {
   const splitInput = rawProjection.split(':')
   if (splitInput.length != 2) {
     throw projectionParsingError(rawProjection)

--- a/packages/cli/src/services/generator/target/parsing.ts
+++ b/packages/cli/src/services/generator/target/parsing.ts
@@ -23,15 +23,15 @@ function parseField(rawField: string): Promise<Field> {
 export const parseProjections = (fields: Array<string>): Promise<HasProjections> =>
   Promise.all(fields.map(parseProjection)).then((projections) => ({ projections }))
 
-function parseProjection(rawProjection: string): Promise<Projection> {
+function async parseProjection(rawProjection: string): Promise<Projection> {
   const splitInput = rawProjection.split(':')
   if (splitInput.length != 2) {
-    return Promise.reject(projectionParsingError(rawProjection))
+    throw projectionParsingError(rawProjection)
   } else {
-    return Promise.resolve({
+    return {
       entityName: splitInput[0],
       entityId: splitInput[1],
-    })
+    }
   }
 }
 

--- a/packages/cli/src/services/generator/target/types.ts
+++ b/packages/cli/src/services/generator/target/types.ts
@@ -6,6 +6,15 @@ export interface HasFields {
   fields: Array<Field>
 }
 
+export interface HasProjections {
+  projections: Array<Projection>
+}
+
+export interface Projection {
+  entityName: string
+  entityId: string
+}
+
 export interface Field {
   name: string
   type: string

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -3,6 +3,7 @@ import * as Entity from './entity'
 import * as Event from './event'
 import * as Type from './type'
 import * as Project from './project'
+import * as ReadModel from './read-model'
 
 export const templates = {
   command: Command.template,
@@ -10,4 +11,5 @@ export const templates = {
   event: Event.template,
   type: Type.template,
   project: Project.templates,
+  readModel: ReadModel.template,
 }

--- a/packages/cli/src/templates/read-model.ts
+++ b/packages/cli/src/templates/read-model.ts
@@ -3,7 +3,7 @@ import { {{commaSeparatedComponents}} } from '{{{packagePath}}}'
 {{/imports}}
 
 @ReadModel({
-  authorize: [],
+  authorize: // Specify authorized roles here. Use 'all' to authorize anyone
 })
 export class {{{name}}} {
   public constructor(

--- a/packages/cli/src/templates/read-model.ts
+++ b/packages/cli/src/templates/read-model.ts
@@ -1,0 +1,24 @@
+export const template = `{{#imports}}
+import { {{commaSeparatedComponents}} } from '{{{packagePath}}}'
+{{/imports}}
+
+@ReadModel({
+  authorize: [],
+})
+export class {{{name}}} {
+  public constructor(
+    public id: UUID,
+    {{#fields}}
+    readonly {{{name}}}: {{{type}}},
+    {{/fields}}
+  ) {}
+
+  {{#projections}}
+  @Projects({{{entityName}}}, {{{entityId}}})
+  public static project{{{entityName}}}(entity: {{{entityName}}}, current{{{name}}}?: {{{name}}}): {{{name}}} {
+    return /* NEW {{name}} HERE */
+  }
+
+  {{/projections}}
+}
+`


### PR DESCRIPTION
This PR adds the command 

```
new:readmodel <name> --fields ... --projects entityName:entityId
```

The user can specify many entities within `--projects` like with fields.