### PR TITLE
fix: Add better hints to concept errors

### DIFF
--- a/packages/framework-core/src/decorators/command.ts
+++ b/packages/framework-core/src/decorators/command.ts
@@ -11,7 +11,8 @@ export function Command(attributes: RoleAccess): (commandClass: Class<CommandInt
   return (commandClass) => {
     Booster.configureCurrentEnv((config): void => {
       if (config.commandHandlers[commandClass.name]) {
-        throw new Error(`A command called ${commandClass.name} is already registered.`)
+        throw new Error(`A command called ${commandClass.name} is already registered.
+        If you think that this is an error, try performing a clean build.`)
       }
 
       config.commandHandlers[commandClass.name] = {

--- a/packages/framework-core/src/decorators/entity.ts
+++ b/packages/framework-core/src/decorators/entity.ts
@@ -9,7 +9,8 @@ import 'reflect-metadata'
 export function Entity<TEntity extends EntityInterface>(entityClass: Class<TEntity>): void {
   Booster.configureCurrentEnv((config): void => {
     if (config.entities[entityClass.name]) {
-      throw new Error(`An entity called ${entityClass.name} is already registered.`)
+      throw new Error(`An entity called ${entityClass.name} is already registered
+        If you think that this is an error, try performing a clean build..`)
     }
 
     config.entities[entityClass.name] = {
@@ -44,7 +45,8 @@ function registerReducer(eventName: string, reducerMethod: ReducerMetadata): voi
     const reducerPath = config.reducers[eventName]
     if (reducerPath) {
       throw new Error(
-        `Error registering reducer: The event ${eventName} was already registered to be reduced by method ${reducerPath.methodName} in the entity ${reducerPath.class.name}.`
+        `Error registering reducer: The event ${eventName} was already registered to be reduced by method ${reducerPath.methodName} in the entity ${reducerPath.class.name}.
+        If you think that this is an error, try performing a clean build.`
       )
     }
 

--- a/packages/framework-core/src/decorators/read-model.ts
+++ b/packages/framework-core/src/decorators/read-model.ts
@@ -10,7 +10,8 @@ export function ReadModel(attributes: RoleAccess): (readModelClass: Class<ReadMo
   return (readModelClass) => {
     Booster.configureCurrentEnv((config): void => {
       if (config.readModels[readModelClass.name]) {
-        throw new Error(`A read model called ${readModelClass.name} is already registered.`)
+        throw new Error(`A read model called ${readModelClass.name} is already registered.
+        If you think that this is an error, try performing a clean build.`)
       }
 
       config.readModels[readModelClass.name] = {


### PR DESCRIPTION
I got to a situation where I had to rename the file of a read model, but not the class.

When performing a `boost deploy` an interesting thing happened:

```
Read model XXXXX is already registered.
```

What was happening underneath is that the TS compiler was compiling the new file, but the old one was still in the output file folder (`dist`).

Given that Booster imports all the files, it was importing both the old one and the new one. I thought about forcing a clean build on deploy, but that would be too slow for many cases. Added a better hint to the error message.