### PR TITLE
Auth integration tests

### DIFF
--- a/packages/cli/src/common/script.ts
+++ b/packages/cli/src/common/script.ts
@@ -107,7 +107,7 @@ export class Script<TContext> {
         }, constVoid)
       )
     } catch (err) {
-      const defaultHandler = (e: Error): string => e.message
+      const defaultHandler = (e: Error): string => e.stack || e.message
       const handler = this.errorHandlers[err.name] || defaultHandler
       Script.logger.fail(handler(err))
     }

--- a/packages/cli/test/services/script-service.test.ts
+++ b/packages/cli/test/services/script-service.test.ts
@@ -97,7 +97,7 @@ describe('The Script class', () => {
 
       await Script.init(msg, initializer()).done()
 
-      expect(loggerFail).to.have.been.calledOnceWith(err.message)
+      expect(loggerFail).to.have.been.calledOnceWith(err.stack)
     })
   })
 
@@ -143,7 +143,7 @@ describe('The Script class', () => {
 
       expect(loggerStart).to.have.been.calledOnceWith(msg)
       expect(loggerSucceed).not.to.have.been.called
-      expect(loggerFail).to.have.been.calledOnceWith(err.message)
+      expect(loggerFail).to.have.been.calledOnceWith(err.stack)
       expect(stepFn).to.have.been.calledOnceWith(testContext)
     })
   })
@@ -170,7 +170,7 @@ describe('The Script class', () => {
         .catch('SyntaxError', () => msg)
         .done()
 
-      expect(loggerFail).to.have.been.calledOnceWith(msg)
+      expect(loggerFail).to.have.been.calledOnceWith(err.stack)
     })
   })
 })

--- a/packages/framework-integration-tests/integration/aws/auth.integration.ts
+++ b/packages/framework-integration-tests/integration/aws/auth.integration.ts
@@ -1,10 +1,10 @@
-import { graphQLClient, signUpURL, authClientID } from './utils'
+import { graphQLClient, signUpURL, authClientID, signInURL, confirmUser } from './utils'
 import gql from 'graphql-tag'
 import { expect } from 'chai'
 import fetch from 'cross-fetch'
 
 describe('With the auth API', () => {
-  describe('an internet rando', () => {
+  context('an internet rando', () => {
     xit("can't submit a secured command", async () => {
       const client = await graphQLClient()
 
@@ -92,8 +92,38 @@ describe('With the auth API', () => {
   })
 
   // The User role is configured in the test project to allow sign ups
-  describe('someone with a user account', () => {
-    it('can sign in their account and get a valid token')
+  context('someone with a user account', async () => {
+    // We'll confirm here the user account created in the previous test
+    await confirmUser('Su_morenito_19@example.com')
+    let accessToken: string
+
+    it('can sign in their account and get a valid token', async () => {
+      const url = await signInURL()
+      const clientId = await authClientID()
+
+      const response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify({
+          clientId: clientId,
+          username: 'Su_morenito_19@example.com', // Why this user name? Reasons: https://youtu.be/h6k5qbt72Os
+          password: 'Flama_69',
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      expect(response.status).to.equal(200)
+
+      const message = await response.json()
+      expect(message).not.to.be.empty
+      expect(message.accessToken).not.to.be.empty
+
+      // We save the access token for next tests
+      accessToken = message.accessToken
+      console.log('Yay! Got a User access token! ' + accessToken)
+    })
+
     it('can submit a secured command they have privileges for')
     it('can query a secured command they have privileges for')
     it("can't send a command they don't have privileges for")
@@ -101,7 +131,7 @@ describe('With the auth API', () => {
   })
 
   // The Admin role is configured in the test project to forbid sign ups
-  describe('someone with an admin account', () => {
+  context('someone with an admin account', () => {
     it('can sign in their account and get a valid token')
   })
 })

--- a/packages/framework-integration-tests/integration/aws/auth.integration.ts
+++ b/packages/framework-integration-tests/integration/aws/auth.integration.ts
@@ -64,13 +64,16 @@ describe('With the auth API', () => {
       expect(response.status).to.equal(200)
     })
 
-    xit("can't sign up for an admin account", async () => {
-      const request = fetch(await signUpURL(), {
+    it("can't sign up for an admin account", async () => {
+      const url = await signUpURL()
+      const clientId = await authClientID()
+
+      const response = await fetch(url, {
         method: 'post',
         body: JSON.stringify({
-          clientId: await authClientID(),
-          username: 'Su_morenito_19', // Why this user name? Reasons: https://youtu.be/h6k5qbt72Os
-          password: '123456',
+          clientId: clientId,
+          username: 'admin@example.com',
+          password: 'Flama_69',
           userAttributes: {
             roles: ['Admin'],
           },
@@ -80,8 +83,11 @@ describe('With the auth API', () => {
         },
       })
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      expect(request).to.be.rejected('non authorized')
+      const message = await response.json()
+      expect(message).not.to.be.empty
+      expect(message.message).to.match(/PreSignUp failed with error User with role Admin can't sign up by themselves/)
+
+      expect(response.status).to.equal(400)
     })
   })
 

--- a/packages/framework-integration-tests/integration/aws/auth.integration.ts
+++ b/packages/framework-integration-tests/integration/aws/auth.integration.ts
@@ -1,0 +1,101 @@
+import { graphQLClient, signUpURL, authClientID } from './utils'
+import gql from 'graphql-tag'
+import { expect } from 'chai'
+import fetch from 'cross-fetch'
+
+describe('With the auth API', () => {
+  describe('an internet rando', () => {
+    xit("can't submit a secured command", async () => {
+      const client = await graphQLClient()
+
+      const response = client.mutate({
+        mutation: gql`
+          mutation {
+            CreateProduct(input: {
+              product: {
+                id: '42f33598-75ba-4e76-b728-20144c8b74e8',
+                sku: 'P-42',
+                displayName: 'Yoga pants',
+                description: 'Pretty standard pair of yoga pants with not much to highlight in particular.',
+                price: {
+                  cents: 2000,
+                  currency: 'EUR'
+                },
+                pictures: [],
+                deleted: false
+              }
+            })
+          }
+        `,
+      })
+
+      // TODO: This is currently being rejected for the wrong causes,
+      // we must revisit this once GraphQL errors are fixed and work on Apollo Client
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      expect(response).to.have.been.rejected
+    })
+
+    it("can't query a secured read model")
+    it('can submit a public command')
+    it('can query a public read model')
+
+    it('can sign up for a user account', async () => {
+      const url = await signUpURL()
+      const clientId = await authClientID()
+
+      const response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify({
+          clientId: clientId,
+          username: 'Su_morenito_19@example.com', // Why this user name? Reasons: https://youtu.be/h6k5qbt72Os
+          password: 'Flama_69',
+          userAttributes: {
+            roles: ['User'],
+          },
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const message = await response.json()
+      expect(message).to.be.empty
+
+      expect(response.status).to.equal(200)
+    })
+
+    xit("can't sign up for an admin account", async () => {
+      const request = fetch(await signUpURL(), {
+        method: 'post',
+        body: JSON.stringify({
+          clientId: await authClientID(),
+          username: 'Su_morenito_19', // Why this user name? Reasons: https://youtu.be/h6k5qbt72Os
+          password: '123456',
+          userAttributes: {
+            roles: ['Admin'],
+          },
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      expect(request).to.be.rejected('non authorized')
+    })
+  })
+
+  // The User role is configured in the test project to allow sign ups
+  describe('someone with a user account', () => {
+    it('can sign in their account and get a valid token')
+    it('can submit a secured command they have privileges for')
+    it('can query a secured command they have privileges for')
+    it("can't send a command they don't have privileges for")
+    it("can't query a read model they don't have privileges for")
+  })
+
+  // The Admin role is configured in the test project to forbid sign ups
+  describe('someone with an admin account', () => {
+    it('can sign in their account and get a valid token')
+  })
+})

--- a/packages/framework-integration-tests/integration/aws/commands-api.integration.ts
+++ b/packages/framework-integration-tests/integration/aws/commands-api.integration.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import gql from 'graphql-tag'
 
 describe('the commands API', () => {
-  it('accepts a command successfully', async () => {
+  xit('accepts a command successfully', async () => {
     const client = await graphQLClient()
 
     const response = await client.mutate({

--- a/packages/framework-integration-tests/integration/aws/commands-api.integration.ts
+++ b/packages/framework-integration-tests/integration/aws/commands-api.integration.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import gql from 'graphql-tag'
 
 describe('the commands API', () => {
-  xit('accepts a command successfully', async () => {
+  it('accepts a command successfully', async () => {
     const client = await graphQLClient()
 
     const response = await client.mutate({

--- a/packages/framework-integration-tests/integration/aws/utils.ts
+++ b/packages/framework-integration-tests/integration/aws/utils.ts
@@ -1,11 +1,13 @@
 import { CloudFormation, CognitoIdentityServiceProvider } from 'aws-sdk'
-import { Stack } from 'aws-sdk/clients/cloudformation'
+import { Stack, StackResourceDetail } from 'aws-sdk/clients/cloudformation'
 import { ApolloClient } from 'apollo-client'
 import { InMemoryCache, NormalizedCacheObject } from 'apollo-cache-inmemory'
 import { HttpLink } from 'apollo-link-http'
 import fetch from 'cross-fetch'
 
+const userPoolId = 'userpool'
 const cloudFormation = new CloudFormation()
+const cognitoIdentityServiceProvider = new CognitoIdentityServiceProvider()
 
 function appStackName(): string {
   return `my-store-${process.env.BOOSTER_APP_SUFFIX}-application-stack`
@@ -25,33 +27,105 @@ export async function appStack(): Promise<Stack> {
   }
 }
 
-export async function userPool(): Promise<CloudFormation.StackResourceDetail> {
-  const userPoolId = 'userpool'
+export async function userPool(): Promise<StackResourceDetail> {
   const stackName = appStackName()
-  const { StackResourceDetail } = await cloudFormation
+
+  const userPoolDescription = await cloudFormation
     .describeStackResource({
       LogicalResourceId: userPoolId,
       StackName: stackName,
     })
     .promise()
 
-  if (StackResourceDetail) {
-    return StackResourceDetail
+  if (userPoolDescription?.StackResourceDetail) {
+    return userPoolDescription.StackResourceDetail
   } else {
-    throw `No user pool found in stack ${stackName} with id ${userPoolId}`
+    throw `No user pool details found in stack ${stackName} with resource Id ${userPoolId}`
   }
 }
 
-export async function confirmUser(username: string): Promise<void> {
+export async function userPoolPhysicalResourceId(): Promise<string> {
   const { PhysicalResourceId } = await userPool()
-  if (!PhysicalResourceId) throw 'Unable to get the UserPool PhisicalResourceId'
+  if (PhysicalResourceId) {
+    return PhysicalResourceId
+  } else {
+    throw 'Unable to get the PhisicalResourceId'
+  }
+}
 
-  const cognitoIdentityServiceProvider = new CognitoIdentityServiceProvider()
+export async function createAdmin(username: string, password: string): Promise<void> {
+  const physicalResourceId = await userPoolPhysicalResourceId()
+  const clientId = await authClientID()
+  const temporaryPassword = 'ChangeMePleas3!'
+
+  await cognitoIdentityServiceProvider
+    .adminCreateUser({
+      UserPoolId: physicalResourceId,
+      Username: username,
+      TemporaryPassword: temporaryPassword,
+      MessageAction: 'SUPPRESS',
+      UserAttributes: [
+        {
+          Name: 'email_verified',
+          Value: 'True',
+        },
+        {
+          Name: 'email',
+          Value: username,
+        },
+      ],
+    })
+    .promise()
+
+  // Setting the roles user attribute on creation triggers an error in the PreSignUp lambda, so we have to set them in a separate call
+  // > UserLambdaValidationException: PreSignUp failed with error User with role Admin can't sign up by themselves. Choose a different role or contact and administrator.
+  // TODO: Should this be the expected behavior taking into account that we're creating it via admin API?
+  // We might want to consider changing the pre-sign-up lambda to check for some kind of credentials to create admin users or something like that.
+  await cognitoIdentityServiceProvider
+    .adminUpdateUserAttributes({
+      UserPoolId: physicalResourceId,
+      Username: username,
+      UserAttributes: [
+        {
+          Name: 'custom:roles',
+          Value: 'Admin',
+        },
+      ],
+    })
+    .promise()
+
+  // A definitive password can't be set on creation, the user is created with a temporal password
+  // here we're simulating a user resetting their password.
+  const authTrialDetails = await cognitoIdentityServiceProvider
+    .initiateAuth({
+      AuthFlow: 'USER_PASSWORD_AUTH',
+      ClientId: clientId,
+      AuthParameters: {
+        USERNAME: username,
+        PASSWORD: temporaryPassword,
+      },
+    })
+    .promise()
+
+  await cognitoIdentityServiceProvider
+    .respondToAuthChallenge({
+      ChallengeName: authTrialDetails.ChallengeName ?? 'NEW_PASSWORD_REQUIRED',
+      ClientId: clientId,
+      ChallengeResponses: {
+        USERNAME: username,
+        NEW_PASSWORD: password,
+      },
+      Session: authTrialDetails.Session,
+    })
+    .promise()
+}
+
+export async function confirmUser(username: string): Promise<void> {
+  const physicalResourceId = await userPoolPhysicalResourceId()
   await cognitoIdentityServiceProvider
     .adminConfirmSignUp({
-      UserPoolId: PhysicalResourceId,
+      UserPoolId: physicalResourceId,
       Username: username,
-      ClientMetadata: {},
     })
     .promise()
 }
@@ -91,14 +165,14 @@ export async function graphQLClient(): Promise<ApolloClient<NormalizedCacheObjec
     link: link,
 
     // Provide some optional constructor fields
-    name: 'react-web-client',
-    version: '1.3',
-    queryDeduplication: false,
-    defaultOptions: {
-      watchQuery: {
-        fetchPolicy: 'cache-and-network',
-      },
-    },
+    // name: 'booster-graphql-client',
+    // version: '1.3',
+    // queryDeduplication: false,
+    // defaultOptions: {
+    //   watchQuery: {
+    //     fetchPolicy: 'cache-and-network',
+    //   },
+    // },
   })
 }
 

--- a/packages/framework-integration-tests/integration/aws/utils.ts
+++ b/packages/framework-integration-tests/integration/aws/utils.ts
@@ -33,8 +33,12 @@ export async function baseURL(): Promise<string> {
   if (url) {
     return url
   } else {
-    throw 'Unable to find the Base REST URL'
+    throw 'Unable to get the Base REST URL from the current stack'
   }
+}
+
+export async function signUpURL(): Promise<string> {
+  return new URL('auth/sign-up', await baseURL()).href
 }
 
 export async function graphQLClient(): Promise<ApolloClient<NormalizedCacheObject>> {
@@ -60,4 +64,17 @@ export async function graphQLClient(): Promise<ApolloClient<NormalizedCacheObjec
       },
     },
   })
+}
+
+export async function authClientID(): Promise<string> {
+  const { Outputs } = await appStack()
+  const clientId = Outputs?.find((output) => {
+    return output.OutputKey === 'clientID'
+  })?.OutputValue
+
+  if (clientId) {
+    return clientId
+  } else {
+    throw 'unable to find the clientID from the current stack'
+  }
 }

--- a/packages/framework-integration-tests/integration/aws/utils.ts
+++ b/packages/framework-integration-tests/integration/aws/utils.ts
@@ -182,11 +182,13 @@ export async function signInURL(): Promise<string> {
 
 // --- GraphQL helpers ---
 
-export async function graphQLClient(): Promise<ApolloClient<NormalizedCacheObject>> {
+export async function graphQLClient(authToken?: string): Promise<ApolloClient<NormalizedCacheObject>> {
   const url = await baseURL()
   const cache = new InMemoryCache()
+  const headers = authToken ? { 'Authorization': `Bearer ${authToken}` } : {}
   const link = new HttpLink({
     uri: new URL('graphql', url).href,
+    headers,
     fetch,
   })
 

--- a/packages/framework-integration-tests/integration/aws/utils.ts
+++ b/packages/framework-integration-tests/integration/aws/utils.ts
@@ -1,17 +1,18 @@
-import { CloudFormation } from 'aws-sdk'
+import { CloudFormation, CognitoIdentityServiceProvider } from 'aws-sdk'
 import { Stack } from 'aws-sdk/clients/cloudformation'
 import { ApolloClient } from 'apollo-client'
 import { InMemoryCache, NormalizedCacheObject } from 'apollo-cache-inmemory'
 import { HttpLink } from 'apollo-link-http'
 import fetch from 'cross-fetch'
 
+const cloudFormation = new CloudFormation()
+
 function appStackName(): string {
   return `my-store-${process.env.BOOSTER_APP_SUFFIX}-application-stack`
 }
 
 export async function appStack(): Promise<Stack> {
-  const cloudformation = new CloudFormation()
-  const { Stacks } = await cloudformation
+  const { Stacks } = await cloudFormation
     .describeStacks({
       StackName: appStackName(),
     })
@@ -22,6 +23,37 @@ export async function appStack(): Promise<Stack> {
   } else {
     throw `No stack found with name "${appStackName}"`
   }
+}
+
+export async function userPool(): Promise<CloudFormation.StackResourceDetail> {
+  const userPoolId = 'userpool'
+  const stackName = appStackName()
+  const { StackResourceDetail } = await cloudFormation
+    .describeStackResource({
+      LogicalResourceId: userPoolId,
+      StackName: stackName,
+    })
+    .promise()
+
+  if (StackResourceDetail) {
+    return StackResourceDetail
+  } else {
+    throw `No user pool found in stack ${stackName} with id ${userPoolId}`
+  }
+}
+
+export async function confirmUser(username: string): Promise<void> {
+  const { PhysicalResourceId } = await userPool()
+  if (!PhysicalResourceId) throw 'Unable to get the UserPool PhisicalResourceId'
+
+  const cognitoIdentityServiceProvider = new CognitoIdentityServiceProvider()
+  await cognitoIdentityServiceProvider
+    .adminConfirmSignUp({
+      UserPoolId: PhysicalResourceId,
+      Username: username,
+      ClientMetadata: {},
+    })
+    .promise()
 }
 
 export async function baseURL(): Promise<string> {
@@ -39,6 +71,10 @@ export async function baseURL(): Promise<string> {
 
 export async function signUpURL(): Promise<string> {
   return new URL('auth/sign-up', await baseURL()).href
+}
+
+export async function signInURL(): Promise<string> {
+  return new URL('auth/sign-in', await baseURL()).href
 }
 
 export async function graphQLClient(): Promise<ApolloClient<NormalizedCacheObject>> {

--- a/packages/framework-integration-tests/integration/aws/utils.ts
+++ b/packages/framework-integration-tests/integration/aws/utils.ts
@@ -195,3 +195,9 @@ export async function graphQLClient(): Promise<ApolloClient<NormalizedCacheObjec
     link: link,
   })
 }
+
+// --- Other helpers ---
+
+export async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/packages/framework-integration-tests/src/commands/create-product.ts
+++ b/packages/framework-integration-tests/src/commands/create-product.ts
@@ -1,17 +1,27 @@
 import { Command } from '@boostercloud/framework-core'
-import { Product } from '../entities/product'
 import { ProductCreated } from '../events/product-created'
 import { Register, UUID } from '@boostercloud/framework-types'
 import { User } from '../roles'
+import { SKU } from '../common/sku'
 
 @Command({
   authorize: [User],
 })
 export class CreateProduct {
-  public constructor(readonly product: Product) {}
+  public constructor(
+    readonly sku: SKU,
+    readonly displayName: string,
+    readonly description: string,
+    readonly priceInCents: number,
+    readonly currency: string
+  ) {}
 
   public handle(register: Register): void {
-    this.product.id = UUID.generate()
-    register.events(new ProductCreated(this.product))
+    register.events(
+      new ProductCreated(UUID.generate(), this.sku, this.displayName, this.description, {
+        cents: this.priceInCents,
+        currency: this.currency,
+      })
+    )
   }
 }

--- a/packages/framework-integration-tests/src/common/money.ts
+++ b/packages/framework-integration-tests/src/common/money.ts
@@ -1,9 +1,4 @@
-export enum Currency {
-  EUR = 'EUR',
-  USD = 'USD',
-}
-
 export interface Money {
   cents: number
-  currency: Currency
+  currency: string
 }

--- a/packages/framework-integration-tests/src/deploy.ts
+++ b/packages/framework-integration-tests/src/deploy.ts
@@ -73,5 +73,6 @@ export async function nuke(environmentName = 'production'): Promise<void> {
   await setEnv()
 
   // Nuke works in the cloud exclusively, no need for preparation
-  await run(`../cli/bin/run nuke -e ${environmentName} --force`)
+  const nukeScript = path.join('..', 'cli', 'bin', 'run')
+  await run(`${nukeScript} nuke -e ${environmentName} --force`)
 }

--- a/packages/framework-integration-tests/src/entities/product.ts
+++ b/packages/framework-integration-tests/src/entities/product.ts
@@ -26,7 +26,7 @@ export class Product {
 
   @Reduces(ProductCreated)
   public static create(event: ProductCreated): Product {
-    return event.product
+    return new Product(event.productId, event.sku, event.displayName, event.description, event.price, [])
   }
 
   @Reduces(ProductUpdated)

--- a/packages/framework-integration-tests/src/events/product-created.ts
+++ b/packages/framework-integration-tests/src/events/product-created.ts
@@ -1,12 +1,19 @@
 import { Event } from '@boostercloud/framework-core'
-import { Product } from '../entities/product'
 import { UUID } from '@boostercloud/framework-types'
+import { SKU } from '../common/sku'
+import { Money } from '../common/money'
 
 @Event
 export class ProductCreated {
-  public constructor(readonly product: Product) {}
+  public constructor(
+    readonly productId: UUID,
+    readonly sku: SKU,
+    readonly displayName: string,
+    readonly description: string,
+    readonly price: Money
+  ) {}
 
   public entityID(): UUID {
-    return this.product.id
+    return this.productId
   }
 }

--- a/packages/framework-integration-tests/src/read-models/product-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/product-read-model.ts
@@ -1,0 +1,40 @@
+import { ReadModel, Projects } from '@boostercloud/framework-core'
+import { User } from '../roles'
+import { UUID } from '@boostercloud/framework-types'
+import { Product } from '../entities/product'
+import { SKU } from '../common/sku'
+import { Money } from '../common/money'
+
+// This is an example read model for a possible admin-exclusive report to show last and previous updates to products
+@ReadModel({
+  authorize: [User],
+})
+export class ProductReadModel {
+  public constructor(
+    readonly id: UUID,
+    readonly sku: SKU,
+    readonly displayName: string,
+    readonly description: string,
+    readonly availability: number,
+    public deleted: boolean,
+    readonly price?: Money
+  ) {}
+
+  @Projects(Product, 'id')
+  public static updateWithProduct(product: Product): ProductReadModel {
+    if (product.deleted) {
+      // TODO: Consider solutions to delete read models from the database (see BOOST-587)
+      return new ProductReadModel(product.id, '<DELETED>', '', '', 0, true)
+    } else {
+      return new ProductReadModel(
+        product.id,
+        product.sku,
+        product.displayName,
+        product.description,
+        product.availability,
+        product.deleted,
+        product.price
+      )
+    }
+  }
+}

--- a/packages/framework-integration-tests/src/read-models/product-updates-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/product-updates-read-model.ts
@@ -1,0 +1,22 @@
+import { ReadModel, Projects } from '@boostercloud/framework-core'
+import { Admin } from '../roles'
+import { UUID } from '@boostercloud/framework-types'
+import { Product } from '../entities/product'
+
+// This is an example read model for a possible admin-exclusive report to show last and previous updates to products
+@ReadModel({
+  authorize: [Admin],
+})
+export class ProductUpdatesReadModel {
+  public constructor(
+    readonly id: UUID,
+    readonly availability: number,
+    readonly lastUpdate: Date,
+    readonly previousUpdate?: Date
+  ) {}
+
+  @Projects(Product, 'id')
+  public static updateWithProduct(product: Product, previous?: ProductUpdatesReadModel): ProductUpdatesReadModel {
+    return new ProductUpdatesReadModel(product.id, product.availability, new Date(), previous?.lastUpdate)
+  }
+}

--- a/packages/framework-provider-aws/test/library/read-model-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/read-model-adapter.test.ts
@@ -27,8 +27,7 @@ describe('the "fetchReadModel" method', () => {
       })
     )
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(fetchReadModel(db, config, logger, 'SomeReadModel', 'someReadModelID')).to.be.eventually.rejectedWith(
+    await expect(fetchReadModel(db, config, logger, 'SomeReadModel', 'someReadModelID')).to.be.eventually.rejectedWith(
       'not found'
     )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,18 +523,18 @@
     "@babel/highlight" "^7.8.3"
 
 "@babel/core@^7.7.5":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.6.tgz#d9aa1f580abf3b2286ef40b6904d390904c63376"
-  integrity sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
+  integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
   dependencies:
     "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.9.6"
+    "@babel/generator" "^7.9.0"
     "@babel/helper-module-transforms" "^7.9.0"
-    "@babel/helpers" "^7.9.6"
-    "@babel/parser" "^7.9.6"
+    "@babel/helpers" "^7.9.0"
+    "@babel/parser" "^7.9.0"
     "@babel/template" "^7.8.6"
-    "@babel/traverse" "^7.9.6"
-    "@babel/types" "^7.9.6"
+    "@babel/traverse" "^7.9.0"
+    "@babel/types" "^7.9.0"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.1"
@@ -544,12 +544,12 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.6.tgz#5408c82ac5de98cda0d77d8124e99fa1f2170a43"
-  integrity sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==
+"@babel/generator@^7.9.0", "@babel/generator@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.5.tgz#27f0917741acc41e6eaaced6d68f96c3fa9afaf9"
+  integrity sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==
   dependencies:
-    "@babel/types" "^7.9.6"
+    "@babel/types" "^7.9.5"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -605,14 +605,14 @@
     "@babel/types" "^7.8.3"
 
 "@babel/helper-replace-supers@^7.8.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz#03149d7e6a5586ab6764996cd31d6981a17e1444"
-  integrity sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz#5ada744fd5ad73203bf1d67459a27dcba67effc8"
+  integrity sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==
   dependencies:
     "@babel/helper-member-expression-to-functions" "^7.8.3"
     "@babel/helper-optimise-call-expression" "^7.8.3"
-    "@babel/traverse" "^7.9.6"
-    "@babel/types" "^7.9.6"
+    "@babel/traverse" "^7.8.6"
+    "@babel/types" "^7.8.6"
 
 "@babel/helper-simple-access@^7.8.3":
   version "7.8.3"
@@ -634,14 +634,14 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
   integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
 
-"@babel/helpers@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.6.tgz#092c774743471d0bb6c7de3ad465ab3d3486d580"
-  integrity sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==
+"@babel/helpers@^7.9.0":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.2.tgz#b42a81a811f1e7313b88cba8adc66b3d9ae6c09f"
+  integrity sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==
   dependencies:
     "@babel/template" "^7.8.3"
-    "@babel/traverse" "^7.9.6"
-    "@babel/types" "^7.9.6"
+    "@babel/traverse" "^7.9.0"
+    "@babel/types" "^7.9.0"
 
 "@babel/highlight@^7.8.3":
   version "7.9.0"
@@ -652,15 +652,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
-  integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
+"@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.4.tgz#68a35e6b0319bbc014465be43828300113f2f2e8"
+  integrity sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==
 
 "@babel/runtime@^7.9.2":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
-  integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -673,25 +673,25 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/traverse@^7.7.4", "@babel/traverse@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.6.tgz#5540d7577697bf619cc57b92aa0f1c231a94f442"
-  integrity sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==
+"@babel/traverse@^7.7.4", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.5.tgz#6e7c56b44e2ac7011a948c21e283ddd9d9db97a2"
+  integrity sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==
   dependencies:
     "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.9.6"
+    "@babel/generator" "^7.9.5"
     "@babel/helper-function-name" "^7.9.5"
     "@babel/helper-split-export-declaration" "^7.8.3"
-    "@babel/parser" "^7.9.6"
-    "@babel/types" "^7.9.6"
+    "@babel/parser" "^7.9.0"
+    "@babel/types" "^7.9.5"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
-  integrity sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==
+"@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.5.tgz#89231f82915a8a566a703b3b20133f73da6b9444"
+  integrity sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.9.5"
     lodash "^4.17.13"
@@ -1505,10 +1505,22 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@oclif/command@^1", "@oclif/command@^1.5.1", "@oclif/command@^1.5.13", "@oclif/command@^1.5.20":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.6.0.tgz#89a4d8466243ce014ccf9f2bdf84b0ec4305c117"
-  integrity sha512-jHLlsi8WzCNTlbSWFBkpNkYdhg7tOV7aV4Kfig+2hbFxuwgf8HTRVzVKBLDmhySWdbzjg1Z7yOpne8rU4hVc8g==
+"@oclif/command@^1", "@oclif/command@^1.5.13":
+  version "1.5.20"
+  resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.5.20.tgz#bb0693586d7d66a457c49b719e394c02ff0169a7"
+  integrity sha512-lzst5RU/STfoutJJv4TLE/cm1WtW3xy6Aqvqy3r1lPsGdNifgbEq4dCOYyc/ZEuhV/IStQLDFTnAlqTdolkz1Q==
+  dependencies:
+    "@oclif/config" "^1"
+    "@oclif/errors" "^1.2.2"
+    "@oclif/parser" "^3.8.3"
+    "@oclif/plugin-help" "^2"
+    debug "^4.1.1"
+    semver "^5.6.0"
+
+"@oclif/command@^1.5.1", "@oclif/command@^1.5.20":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.6.1.tgz#774e860f283f32a728377da1c2a90beb8aadf9f5"
+  integrity sha512-pvmMmfGn+zm4e4RwVw63mg9sIaqKqmVsFbImQoUrCO/43UmWzoSHWNXKdgEGigOezWrkZfFucaeZcSbp149OWg==
   dependencies:
     "@oclif/config" "^1.15.1"
     "@oclif/errors" "^1.2.2"
@@ -1753,9 +1765,9 @@
     "@octokit/plugin-rest-endpoint-methods" "3.8.0"
 
 "@octokit/types@^2.0.0", "@octokit/types@^2.0.1", "@octokit/types@^2.11.1", "@octokit/types@^2.12.1":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.13.0.tgz#b2de9983d79a3d8a000d9bf90293ddbbe611e561"
-  integrity sha512-aSHYeR01V/ZDyU6BaCGqndC8qAjUBH/OFw3Y6EmHdP2uVFsgoPtxUJLPJEfhhr8f7F2cGS9QZ0tUqnfItHxKug==
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.12.2.tgz#e9fbffa294adb54140946d436da9f73bc94b169c"
+  integrity sha512-1GHLI/Jll3j6F0GbYyZPFTcHZMGjAiRfkTEoRUyaVVk2IWbDdwEiClAJvXzfXCDayuGSNCqAUH8lpjZtqW9GDw==
   dependencies:
     "@types/node" ">= 8"
 
@@ -1843,11 +1855,12 @@
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
 "@types/express-serve-static-core@*":
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz#a00ac7dadd746ae82477443e4d480a6a93ea083c"
-  integrity sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.6.tgz#ec825455acb075e7fc804f4f7b7734e043003f43"
+  integrity sha512-U2oynuRIB17GIbEdvjFrrEACOy7GQkzsX7bPEBz1H41vZYEU4j0fLL97sawmHDwHUXpUQDBMHIyM9vejqP9o1A==
   dependencies:
     "@types/node" "*"
+    "@types/qs" "*"
     "@types/range-parser" "*"
 
 "@types/express@*", "@types/express@^4.17.2":
@@ -1949,9 +1962,9 @@
   integrity sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==
 
 "@types/qs@*":
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.1.tgz#937fab3194766256ee09fcd40b781740758617e7"
-  integrity sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.2.tgz#faab98ec4f96ee72c829b7ec0983af4f4d343113"
+  integrity sha512-a9bDi4Z3zCZf4Lv1X/vwnvbbDYSNz59h3i3KdyuYYN+YrLjSeJD0dnphdULDfySvUv6Exy/O0K6wX/kQpnPQ+A==
 
 "@types/range-parser@*":
   version "1.2.3"
@@ -2022,39 +2035,39 @@
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
 "@typescript-eslint/eslint-plugin@^2.18.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.31.0.tgz#942c921fec5e200b79593c71fafb1e3f57aa2e36"
-  integrity sha512-iIC0Pb8qDaoit+m80Ln/aaeu9zKQdOLF4SHcGLarSeY1gurW6aU4JsOPMjKQwXlw70MvWKZQc6S2NamA8SJ/gg==
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.30.0.tgz#312a37e80542a764d96e8ad88a105316cdcd7b05"
+  integrity sha512-PGejii0qIZ9Q40RB2jIHyUpRWs1GJuHP1pkoCiaeicfwO9z7Fx03NQzupuyzAmv+q9/gFNHu7lo1ByMXe8PNyg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.31.0"
+    "@typescript-eslint/experimental-utils" "2.30.0"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.31.0.tgz#a9ec514bf7fd5e5e82bc10dcb6a86d58baae9508"
-  integrity sha512-MI6IWkutLYQYTQgZ48IVnRXmLR/0Q6oAyJgiOror74arUMh7EWjJkADfirZhRsUMHeLJ85U2iySDwHTSnNi9vA==
+"@typescript-eslint/experimental-utils@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.30.0.tgz#9845e868c01f3aed66472c561d4b6bac44809dd0"
+  integrity sha512-L3/tS9t+hAHksy8xuorhOzhdefN0ERPDWmR9CclsIGOUqGKy6tqc/P+SoXeJRye5gazkuPO0cK9MQRnolykzkA==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.31.0"
+    "@typescript-eslint/typescript-estree" "2.30.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
 "@typescript-eslint/parser@^2.18.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.31.0.tgz#beddd4e8efe64995108b229b2862cd5752d40d6f"
-  integrity sha512-uph+w6xUOlyV2DLSC6o+fBDzZ5i7+3/TxAsH4h3eC64tlga57oMb96vVlXoMwjR/nN+xyWlsnxtbDkB46M2EPQ==
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.30.0.tgz#7681c305a6f4341ae2579f5e3a75846c29eee9ce"
+  integrity sha512-9kDOxzp0K85UnpmPJqUzdWaCNorYYgk1yZmf4IKzpeTlSAclnFsrLjfwD9mQExctLoLoGAUXq1co+fbr+3HeFw==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.31.0"
-    "@typescript-eslint/typescript-estree" "2.31.0"
+    "@typescript-eslint/experimental-utils" "2.30.0"
+    "@typescript-eslint/typescript-estree" "2.30.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.31.0.tgz#ac536c2d46672aa1f27ba0ec2140d53670635cfd"
-  integrity sha512-vxW149bXFXXuBrAak0eKHOzbcu9cvi6iNcJDzEtOkRwGHxJG15chiAQAwhLOsk+86p9GTr/TziYvw+H9kMaIgA==
+"@typescript-eslint/typescript-estree@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.30.0.tgz#1b8e848b55144270255ffbfe4c63291f8f766615"
+  integrity sha512-nI5WOechrA0qAhnr+DzqwmqHsx7Ulr/+0H7bWCcClDhhWkSyZR5BmTvnBEyONwJCTWHfc5PAQExX24VD26IAVw==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -2561,9 +2574,9 @@ aws-cdk@1.26.0:
     yargs "^15.0.2"
 
 aws-sdk@^2.625.0, aws-sdk@^2.656.0:
-  version "2.669.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.669.0.tgz#7e8e7985120102da6bdbf40a18d8b9d692dea1ba"
-  integrity sha512-kuVcSRpDzvkgmeSmMX6Q32eTOb8UeihhUdavMrvUOP6fzSU19cNWS9HAIkYOi/jrEDK85cCZxXjxqE3JGZIGcw==
+  version "2.665.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.665.0.tgz#5f2fd304c911a67c9e1202194ae59d5b2a2cd8ba"
+  integrity sha512-1V5b6yWgRTXFHtt0yB8Lg6nGTnqQ1EJ5KsbrQ2grpmEZsz7Rm0J/jIFdv3VUDcHqJOrFPKLC3L7a6FE36y0leg==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -8705,9 +8718,9 @@ ts-invariant@^0.4.0:
     tslib "^1.9.3"
 
 ts-node@^8.6.2:
-  version "8.10.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.1.tgz#77da0366ff8afbe733596361d2df9a60fc9c9bd3"
-  integrity sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.9.1.tgz#2f857f46c47e91dcd28a14e052482eb14cfd65a5"
+  integrity sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
@@ -8797,9 +8810,9 @@ typescript@^3.7.5, typescript@^3.8.3:
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@^3.1.4:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.2.tgz#012b74fb6a2e440d9ba1f79110a479d3b1f2d48d"
-  integrity sha512-zGVwKslUAD/EeqOrD1nQaBmXIHl1Vw371we8cvS8I6mYK9rmgX5tv8AAeJdfsQ3Kk5mGax2SVV/AizxdNGhl7Q==
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.1.tgz#a56a71c8caa2d36b5556cc1fd57df01ae3491539"
+  integrity sha512-JUPoL1jHsc9fOjVFHdQIhqEEJsQvfKDjlubcCilu8U26uZ73qOg8VsN8O1jbuei44ZPlwL7kmbAdM4tzaUvqnA==
   dependencies:
     commander "~2.20.3"
 


### PR DESCRIPTION
## Description

In this PR we're adding several tests for Booster's authentication API and authorization via GraphQL!

![](https://media.giphy.com/media/PZ9OkwDtk0Ex2/source.gif)

## Changes
Added integration tests for the following use cases:

* an internet rando
  - [x] can't submit a secured command
  - [x] can't query a secured read model
  - [x] can submit a public command
  - [x] can query a public read model
  - [x] can sign up for a user account
  - [x] can't sign up for an admin account
* someone with a user account
  - [x] can sign in their account and get a valid token
  - [x] can submit a secured command they have privileges for
  - [x] can query a secured command they have privileges for
  - [x] can't send a command they don't have privileges for
  - [x] can't query a read model they don't have privileges for
* someone with an admin account
  - [x] can sign in their account and get a valid token
  - [x] can query a read model they have privileges for
  - [x] can send a command they have privileges for

## Checks
- [x] Project Builds
- [x] Project passes tests and checks

## Additional information

Here you have a glorious screenshot of the tests passing in my computer:
<img width="527" alt="Screen Shot 2020-05-06 at 21 32 18" src="https://user-images.githubusercontent.com/175096/81226983-977b2680-8fe3-11ea-8f0b-ce64b13a3a29.png">

## BONUS!

* The CLI now prints the whole error stack instead of just the message. I did this because finding the error without the stack was a nighmare.
* This PR also adds a few utility functions to the integration test suite for dealing with AWS stuff

## Pending (for future PRs)
* Added a new task to check subscriptions authentication for the three profiles (BOOST-591)