### PR TITLE
[BOOST-354] Refactor the ProviderLibrary type as a scoped interface

### DIFF
--- a/packages/cli/src/services/provider-service.ts
+++ b/packages/cli/src/services/provider-service.ts
@@ -24,7 +24,7 @@ export function assertNameIsCorrect(name: string): void {
 
 export const deployToCloudProvider = (config: BoosterConfig): Observable<string> => {
   assertNameIsCorrect(config.appName)
-  const deployMethod = config.provider.getInfrastructure().deploy
+  const deployMethod = config.provider.infrastructure().deploy
   if (!deployMethod) {
     throw new Error(
       'Attempted to deploy with a provider that does not support deploying the project, perhaps you meant `boost run`?'
@@ -35,7 +35,7 @@ export const deployToCloudProvider = (config: BoosterConfig): Observable<string>
 
 export async function runProvider(port: number, config: BoosterConfig): Promise<void> {
   assertNameIsCorrect(config.appName)
-  const runMethod = config.provider.getInfrastructure().run
+  const runMethod = config.provider.infrastructure().run
   if (!runMethod) {
     throw new Error(
       'Attempted to run with a provider that is does not support running the project, perhaps you meant `boost deploy`?'
@@ -45,5 +45,5 @@ export async function runProvider(port: number, config: BoosterConfig): Promise<
 }
 
 export const nukeCloudProviderResources = (config: BoosterConfig): Observable<string> => {
-  return config.provider.getInfrastructure().nuke(config)
+  return config.provider.infrastructure().nuke(config)
 }

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -2,7 +2,6 @@ import {
   BoosterConfig,
   Class,
   Logger,
-  ProviderAuthLibrary,
   UserEnvelope,
   RoleInterface,
   RoleAccess,
@@ -17,8 +16,7 @@ export class BoosterAuth {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public static checkSignUp(rawMessage: any, config: BoosterConfig, logger: Logger): any {
-    const provider: ProviderAuthLibrary = config.provider.auth
-    const userEnvelope = provider.rawSignUpDataToUserEnvelope(rawMessage)
+    const userEnvelope = config.provider.auth.fromRaw(rawMessage)
     logger.info('User envelope: ', userEnvelope)
 
     userEnvelope.roles.forEach((roleName: string) => {

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -12,12 +12,12 @@ import {
 export class BoosterAuth {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public static async authorizeRequest(rawMessage: any, config: BoosterConfig, logger: Logger): Promise<any> {
-    return config.provider.authorizeRequest(rawMessage, logger)
+    return config.provider.graphQL.authorizeRequest(rawMessage, logger)
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public static checkSignUp(rawMessage: any, config: BoosterConfig, logger: Logger): any {
-    const provider: ProviderAuthLibrary = config.provider
+    const provider: ProviderAuthLibrary = config.provider.auth
     const userEnvelope = provider.rawSignUpDataToUserEnvelope(rawMessage)
     logger.info('User envelope: ', userEnvelope)
 

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -16,7 +16,7 @@ export class BoosterAuth {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public static checkSignUp(rawMessage: any, config: BoosterConfig, logger: Logger): any {
-    const userEnvelope = config.provider.auth.fromRaw(rawMessage)
+    const userEnvelope = config.provider.auth.rawToEnvelope(rawMessage)
     logger.info('User envelope: ', userEnvelope)
 
     userEnvelope.roles.forEach((roleName: string) => {

--- a/packages/framework-core/src/booster-graphql-dispatcher.ts
+++ b/packages/framework-core/src/booster-graphql-dispatcher.ts
@@ -27,24 +27,24 @@ export class BoosterGraphQLDispatcher {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async dispatch(request: any): Promise<AsyncIterableIterator<ExecutionResult> | ExecutionResult> {
     try {
-      const envelope = await this.config.provider.rawGraphQLRequestToEnvelope(request, this.logger)
+      const envelope = await this.config.provider.graphQL.rawGraphQLRequestToEnvelope(request, this.logger)
       this.logger.debug('Received the following GraphQL envelope: ', envelope)
 
       switch (envelope.eventType) {
         case 'CONNECT': // TODO: This message is never coming now. Check this later to see if it is finally needed
-          return this.config.provider.handleGraphQLResult()
+          return this.config.provider.graphQL.handleGraphQLResult()
         case 'MESSAGE':
-          return this.config.provider.handleGraphQLResult(await this.handleMessage(envelope))
+          return this.config.provider.graphQL.handleGraphQLResult(await this.handleMessage(envelope))
         case 'DISCONNECT':
           // TODO: Remove subscriptions
-          return this.config.provider.handleGraphQLResult()
+          return this.config.provider.graphQL.handleGraphQLResult()
         default:
           throw new Error(`Unknown message type ${envelope.eventType}`)
       }
     } catch (e) {
       this.logger.error(e)
       const errors = Array.isArray(e) ? e : [new GraphQLError(e.message)]
-      return this.config.provider.handleGraphQLResult({ errors })
+      return this.config.provider.graphQL.handleGraphQLResult({ errors })
     }
   }
 

--- a/packages/framework-core/src/booster-graphql-dispatcher.ts
+++ b/packages/framework-core/src/booster-graphql-dispatcher.ts
@@ -27,24 +27,24 @@ export class BoosterGraphQLDispatcher {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async dispatch(request: any): Promise<AsyncIterableIterator<ExecutionResult> | ExecutionResult> {
     try {
-      const envelope = await this.config.provider.graphQL.rawGraphQLRequestToEnvelope(request, this.logger)
+      const envelope = await this.config.provider.graphQL.fromRaw(request, this.logger)
       this.logger.debug('Received the following GraphQL envelope: ', envelope)
 
       switch (envelope.eventType) {
         case 'CONNECT': // TODO: This message is never coming now. Check this later to see if it is finally needed
-          return this.config.provider.graphQL.handleGraphQLResult()
+          return this.config.provider.graphQL.handleResult()
         case 'MESSAGE':
-          return this.config.provider.graphQL.handleGraphQLResult(await this.handleMessage(envelope))
+          return this.config.provider.graphQL.handleResult(await this.handleMessage(envelope))
         case 'DISCONNECT':
           // TODO: Remove subscriptions
-          return this.config.provider.graphQL.handleGraphQLResult()
+          return this.config.provider.graphQL.handleResult()
         default:
           throw new Error(`Unknown message type ${envelope.eventType}`)
       }
     } catch (e) {
       this.logger.error(e)
       const errors = Array.isArray(e) ? e : [new GraphQLError(e.message)]
-      return this.config.provider.graphQL.handleGraphQLResult({ errors })
+      return this.config.provider.graphQL.handleResult({ errors })
     }
   }
 

--- a/packages/framework-core/src/booster-graphql-dispatcher.ts
+++ b/packages/framework-core/src/booster-graphql-dispatcher.ts
@@ -27,7 +27,7 @@ export class BoosterGraphQLDispatcher {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async dispatch(request: any): Promise<AsyncIterableIterator<ExecutionResult> | ExecutionResult> {
     try {
-      const envelope = await this.config.provider.graphQL.fromRaw(request, this.logger)
+      const envelope = await this.config.provider.graphQL.rawToEnvelope(request, this.logger)
       this.logger.debug('Received the following GraphQL envelope: ', envelope)
 
       switch (envelope.eventType) {

--- a/packages/framework-core/src/booster-read-model-dispatcher.ts
+++ b/packages/framework-core/src/booster-read-model-dispatcher.ts
@@ -80,6 +80,6 @@ export class BoosterReadModelDispatcher {
       connectionID,
       operation,
     }
-    return this.config.provider.subscribeToReadModel(this.config, this.logger, subscription)
+    return this.config.provider.readModels.subscribeToReadModel(this.config, this.logger, subscription)
   }
 }

--- a/packages/framework-core/src/booster-read-model-dispatcher.ts
+++ b/packages/framework-core/src/booster-read-model-dispatcher.ts
@@ -80,6 +80,6 @@ export class BoosterReadModelDispatcher {
       connectionID,
       operation,
     }
-    return this.config.provider.readModels.subscribeToReadModel(this.config, this.logger, subscription)
+    return this.config.provider.readModels.subscribe(this.config, this.logger, subscription)
   }
 }

--- a/packages/framework-core/src/booster-register-handler.ts
+++ b/packages/framework-core/src/booster-register-handler.ts
@@ -10,7 +10,7 @@ import {
 
 export class RegisterHandler {
   public static async handle(config: BoosterConfig, logger: Logger, register: Register): Promise<void> {
-    return config.provider.events.publishEvents(
+    return config.provider.events.publish(
       register.eventList.map(RegisterHandler.wrapEvent.bind(null, register, config)),
       config,
       logger

--- a/packages/framework-core/src/booster-register-handler.ts
+++ b/packages/framework-core/src/booster-register-handler.ts
@@ -10,7 +10,7 @@ import {
 
 export class RegisterHandler {
   public static async handle(config: BoosterConfig, logger: Logger, register: Register): Promise<void> {
-    return config.provider.publishEvents(
+    return config.provider.events.publishEvents(
       register.eventList.map(RegisterHandler.wrapEvent.bind(null, register, config)),
       config,
       logger

--- a/packages/framework-core/src/booster-subscribers-notifier.ts
+++ b/packages/framework-core/src/booster-subscribers-notifier.ts
@@ -30,7 +30,7 @@ export class BoosterSubscribersNotifier {
   public async dispatch(request: any): Promise<void> {
     try {
       this.logger.debug('Received the following event for subscription dispatching: ', request)
-      const readModelEnvelopes = await this.config.provider.rawReadModelEventsToEnvelopes(
+      const readModelEnvelopes = await this.config.provider.readModels.rawReadModelEventsToEnvelopes(
         this.config,
         this.logger,
         request
@@ -63,7 +63,9 @@ export class BoosterSubscribersNotifier {
     const readModelNames = readModelEnvelopes.map((readModelEnvelope) => readModelEnvelope.typeName)
     const readModelUniqueNames = [...new Set(readModelNames)]
     const subscriptionSets = await Promise.all(
-      readModelUniqueNames.map((name) => this.config.provider.fetchSubscriptions(this.config, this.logger, name))
+      readModelUniqueNames.map((name) =>
+        this.config.provider.readModels.fetchSubscriptions(this.config, this.logger, name)
+      )
     )
     return subscriptionSets.flat()
   }
@@ -125,7 +127,7 @@ export class BoosterSubscribersNotifier {
     }
     const readModel = result.data as ReadModelInterface
     this.logger.debug(`Notifying connectionID '${subscription.connectionID}' with read model: `, readModel)
-    await this.config.provider.notifySubscription(this.config, subscription.connectionID, readModel)
+    await this.config.provider.readModels.notifySubscription(this.config, subscription.connectionID, readModel)
     this.logger.debug('Notifications sent')
   }
 }

--- a/packages/framework-core/src/booster-subscribers-notifier.ts
+++ b/packages/framework-core/src/booster-subscribers-notifier.ts
@@ -30,11 +30,7 @@ export class BoosterSubscribersNotifier {
   public async dispatch(request: any): Promise<void> {
     try {
       this.logger.debug('Received the following event for subscription dispatching: ', request)
-      const readModelEnvelopes = await this.config.provider.readModels.rawReadModelEventsToEnvelopes(
-        this.config,
-        this.logger,
-        request
-      )
+      const readModelEnvelopes = await this.config.provider.readModels.fromRawArray(this.config, this.logger, request)
       this.logger.debug('[SubsciptionDispatcher] The following ReadModels were updated: ', readModelEnvelopes)
       const subscriptions = await this.getSubscriptions(readModelEnvelopes)
       this.logger.debug(

--- a/packages/framework-core/src/booster-subscribers-notifier.ts
+++ b/packages/framework-core/src/booster-subscribers-notifier.ts
@@ -30,7 +30,7 @@ export class BoosterSubscribersNotifier {
   public async dispatch(request: any): Promise<void> {
     try {
       this.logger.debug('Received the following event for subscription dispatching: ', request)
-      const readModelEnvelopes = await this.config.provider.readModels.fromRawArray(this.config, this.logger, request)
+      const readModelEnvelopes = await this.config.provider.readModels.rawToEnvelopes(this.config, this.logger, request)
       this.logger.debug('[SubsciptionDispatcher] The following ReadModels were updated: ', readModelEnvelopes)
       const subscriptions = await this.getSubscriptions(readModelEnvelopes)
       this.logger.debug(

--- a/packages/framework-core/src/booster.ts
+++ b/packages/framework-core/src/booster.ts
@@ -64,7 +64,7 @@ export class Booster {
   public static readModel<TReadModel extends ReadModelInterface>(
     readModelClass: Class<TReadModel>
   ): Searcher<TReadModel> {
-    const searchFunction = this.config.provider.searchReadModel.bind(null, this.config, this.logger)
+    const searchFunction = this.config.provider.readModels.searchReadModel.bind(null, this.config, this.logger)
     return new Searcher(readModelClass, searchFunction)
   }
 

--- a/packages/framework-core/src/booster.ts
+++ b/packages/framework-core/src/booster.ts
@@ -64,7 +64,7 @@ export class Booster {
   public static readModel<TReadModel extends ReadModelInterface>(
     readModelClass: Class<TReadModel>
   ): Searcher<TReadModel> {
-    const searchFunction = this.config.provider.readModels.searchReadModel.bind(null, this.config, this.logger)
+    const searchFunction = this.config.provider.readModels.search.bind(null, this.config, this.logger)
     return new Searcher(readModelClass, searchFunction)
   }
 

--- a/packages/framework-core/src/services/event-store.ts
+++ b/packages/framework-core/src/services/event-store.ts
@@ -72,7 +72,7 @@ export class EventStore {
     this.logger.debug(
       `[EventStore#loadLatestSnapshot] Loading latest snapshot for entity ${entityName} and ID ${entityID}`
     )
-    return this.provider.events.readEntityLatestSnapshot(this.config, this.logger, entityName, entityID)
+    return this.provider.events.latestEntitySnapshot(this.config, this.logger, entityName, entityID)
   }
 
   private loadEventStreamSince(entityTypeName: string, entityID: UUID, timestamp: string): Promise<EventEnvelope[]> {

--- a/packages/framework-core/src/services/event-store.ts
+++ b/packages/framework-core/src/services/event-store.ts
@@ -79,7 +79,7 @@ export class EventStore {
     this.logger.debug(
       `[EventStore#loadEventStreamSince] Loading list of pending events for entity ${entityTypeName} with ID ${entityID} since ${timestamp}`
     )
-    return this.provider.events.readEntityEventsSince(this.config, this.logger, entityTypeName, entityID, timestamp)
+    return this.provider.events.forEntitySince(this.config, this.logger, entityTypeName, entityID, timestamp)
   }
 
   private entityReducer(latestSnapshot: EventEnvelope | null, eventEnvelope: EventEnvelope): EventEnvelope {

--- a/packages/framework-core/src/services/event-store.ts
+++ b/packages/framework-core/src/services/event-store.ts
@@ -25,7 +25,7 @@ export class EventStore {
   public async append(eventEnvelope: EventEnvelope): Promise<void> {
     this.logger.debug('[EventStore#append] Appending event envelope in the events store:', eventEnvelope)
     try {
-      await this.provider.storeEvent(this.config, this.logger, eventEnvelope)
+      await this.provider.events.storeEvent(this.config, this.logger, eventEnvelope)
     } catch (e) {
       this.logger.error('[EventStore#append] Unhandled error while appending an event to the event store:', e)
       throw e
@@ -65,21 +65,21 @@ export class EventStore {
       `[EventStore#storeSnapshot] Max number of events after latest stored snapshot reached (${numberOfEventsBetweenSnapshots}). Storing snapshot in the event store:`,
       snapshot
     )
-    return await this.provider.storeEvent(this.config, this.logger, snapshot)
+    return await this.provider.events.storeEvent(this.config, this.logger, snapshot)
   }
 
   private loadLatestSnapshot(entityName: string, entityID: UUID): Promise<EventEnvelope | null> {
     this.logger.debug(
       `[EventStore#loadLatestSnapshot] Loading latest snapshot for entity ${entityName} and ID ${entityID}`
     )
-    return this.provider.readEntityLatestSnapshot(this.config, this.logger, entityName, entityID)
+    return this.provider.events.readEntityLatestSnapshot(this.config, this.logger, entityName, entityID)
   }
 
   private loadEventStreamSince(entityTypeName: string, entityID: UUID, timestamp: string): Promise<EventEnvelope[]> {
     this.logger.debug(
       `[EventStore#loadEventStreamSince] Loading list of pending events for entity ${entityTypeName} with ID ${entityID} since ${timestamp}`
     )
-    return this.provider.readEntityEventsSince(this.config, this.logger, entityTypeName, entityID, timestamp)
+    return this.provider.events.readEntityEventsSince(this.config, this.logger, entityTypeName, entityID, timestamp)
   }
 
   private entityReducer(latestSnapshot: EventEnvelope | null, eventEnvelope: EventEnvelope): EventEnvelope {

--- a/packages/framework-core/src/services/event-store.ts
+++ b/packages/framework-core/src/services/event-store.ts
@@ -25,7 +25,7 @@ export class EventStore {
   public async append(eventEnvelope: EventEnvelope): Promise<void> {
     this.logger.debug('[EventStore#append] Appending event envelope in the events store:', eventEnvelope)
     try {
-      await this.provider.events.storeEvent(this.config, this.logger, eventEnvelope)
+      await this.provider.events.store(this.config, this.logger, eventEnvelope)
     } catch (e) {
       this.logger.error('[EventStore#append] Unhandled error while appending an event to the event store:', e)
       throw e
@@ -65,7 +65,7 @@ export class EventStore {
       `[EventStore#storeSnapshot] Max number of events after latest stored snapshot reached (${numberOfEventsBetweenSnapshots}). Storing snapshot in the event store:`,
       snapshot
     )
-    return await this.provider.events.storeEvent(this.config, this.logger, snapshot)
+    return await this.provider.events.store(this.config, this.logger, snapshot)
   }
 
   private loadLatestSnapshot(entityName: string, entityID: UUID): Promise<EventEnvelope | null> {

--- a/packages/framework-core/src/services/raw-events-parser.ts
+++ b/packages/framework-core/src/services/raw-events-parser.ts
@@ -7,7 +7,7 @@ export class RawEventsParser {
     rawEvents: any,
     callbackFn: (eventEnvelope: EventEnvelope, config: BoosterConfig) => Promise<void>
   ): Promise<void> {
-    for (const event of config.provider.events.fromRawArray(rawEvents)) {
+    for (const event of config.provider.events.rawToEnvelopes(rawEvents)) {
       await callbackFn(event, config)
     }
   }

--- a/packages/framework-core/src/services/raw-events-parser.ts
+++ b/packages/framework-core/src/services/raw-events-parser.ts
@@ -7,7 +7,7 @@ export class RawEventsParser {
     rawEvents: any,
     callbackFn: (eventEnvelope: EventEnvelope, config: BoosterConfig) => Promise<void>
   ): Promise<void> {
-    for (const event of config.provider.events.rawEventsToEnvelopes(rawEvents)) {
+    for (const event of config.provider.events.fromRawArray(rawEvents)) {
       await callbackFn(event, config)
     }
   }

--- a/packages/framework-core/src/services/raw-events-parser.ts
+++ b/packages/framework-core/src/services/raw-events-parser.ts
@@ -7,7 +7,7 @@ export class RawEventsParser {
     rawEvents: any,
     callbackFn: (eventEnvelope: EventEnvelope, config: BoosterConfig) => Promise<void>
   ): Promise<void> {
-    for (const event of config.provider.rawEventsToEnvelopes(rawEvents)) {
+    for (const event of config.provider.events.rawEventsToEnvelopes(rawEvents)) {
       await callbackFn(event, config)
     }
   }

--- a/packages/framework-core/src/services/read-model-store.ts
+++ b/packages/framework-core/src/services/read-model-store.ts
@@ -47,7 +47,7 @@ export class ReadModelStore {
           `[ReadModelStore#project] Storing new version of read model ${readModelName} with ID ${readModelID}:`,
           newReadModel
         )
-        return this.provider.storeReadModel(this.config, this.logger, readModelName, newReadModel)
+        return this.provider.readModels.storeReadModel(this.config, this.logger, readModelName, newReadModel)
       })
     )
   }
@@ -56,7 +56,7 @@ export class ReadModelStore {
     this.logger.debug(
       `[ReadModelStore#fetchReadModel] Looking for existing version of read model ${readModelName} with ID ${readModelID}`
     )
-    return this.provider.fetchReadModel(this.config, this.logger, readModelName, readModelID)
+    return this.provider.readModels.fetchReadModel(this.config, this.logger, readModelName, readModelID)
   }
 
   private joinKeyForProjection(entitySnapshot: EntityInterface, projectionMetadata: ProjectionMetadata): UUID {

--- a/packages/framework-core/src/services/read-model-store.ts
+++ b/packages/framework-core/src/services/read-model-store.ts
@@ -47,7 +47,7 @@ export class ReadModelStore {
           `[ReadModelStore#project] Storing new version of read model ${readModelName} with ID ${readModelID}:`,
           newReadModel
         )
-        return this.provider.readModels.storeReadModel(this.config, this.logger, readModelName, newReadModel)
+        return this.provider.readModels.store(this.config, this.logger, readModelName, newReadModel)
       })
     )
   }
@@ -56,7 +56,7 @@ export class ReadModelStore {
     this.logger.debug(
       `[ReadModelStore#fetchReadModel] Looking for existing version of read model ${readModelName} with ID ${readModelID}`
     )
-    return this.provider.readModels.fetchReadModel(this.config, this.logger, readModelName, readModelID)
+    return this.provider.readModels.fetch(this.config, this.logger, readModelName, readModelID)
   }
 
   private joinKeyForProjection(entitySnapshot: EntityInterface, projectionMetadata: ProjectionMetadata): UUID {

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -25,7 +25,7 @@ describe('the "checkSignUp" method', () => {
   function buildBoosterConfig(): BoosterConfig {
     const config = new BoosterConfig('test')
     config.provider = ({
-      rawSignUpDataToUserEnvelope: () => {},
+      auth: { rawSignUpDataToUserEnvelope: () => {} },
     } as unknown) as ProviderLibrary
     config.roles['Admin'] = {
       allowSelfSignUp: false,
@@ -39,7 +39,7 @@ describe('the "checkSignUp" method', () => {
   it('throws when the user has a non-existing role', () => {
     const config = buildBoosterConfig()
     replace(
-      config.provider,
+      config.provider.auth,
       'rawSignUpDataToUserEnvelope',
       fake.returns({
         roles: ['Developer', 'NonExistingRole', 'Admin'],
@@ -52,7 +52,7 @@ describe('the "checkSignUp" method', () => {
   it('throws when the user has a role not allowed to self sign-up', () => {
     const config = buildBoosterConfig()
     replace(
-      config.provider,
+      config.provider.auth,
       'rawSignUpDataToUserEnvelope',
       fake.returns({
         roles: ['Developer', 'Admin'],
@@ -67,7 +67,7 @@ describe('the "checkSignUp" method', () => {
   it('succeeds user has a role allowed to self sign-up', () => {
     const config = buildBoosterConfig()
     replace(
-      config.provider,
+      config.provider.auth,
       'rawSignUpDataToUserEnvelope',
       fake.returns({
         roles: ['Developer'],
@@ -122,7 +122,9 @@ describe('the "authorizeRequest" method', () => {
     const config = new BoosterConfig('test')
     const fakeProviderAuthorizer = fake()
     config.provider = {
-      authorizeRequest: fakeProviderAuthorizer,
+      graphQL: {
+        authorizeRequest: fakeProviderAuthorizer,
+      },
     } as any
 
     await BoosterAuth.authorizeRequest(request, config, logger)

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -25,7 +25,7 @@ describe('the "checkSignUp" method', () => {
   function buildBoosterConfig(): BoosterConfig {
     const config = new BoosterConfig('test')
     config.provider = ({
-      auth: { fromRaw: () => {} },
+      auth: { rawToEnvelope: () => {} },
     } as unknown) as ProviderLibrary
     config.roles['Admin'] = {
       allowSelfSignUp: false,
@@ -40,7 +40,7 @@ describe('the "checkSignUp" method', () => {
     const config = buildBoosterConfig()
     replace(
       config.provider.auth,
-      'fromRaw',
+      'rawToEnvelope',
       fake.returns({
         roles: ['Developer', 'NonExistingRole', 'Admin'],
       })
@@ -53,7 +53,7 @@ describe('the "checkSignUp" method', () => {
     const config = buildBoosterConfig()
     replace(
       config.provider.auth,
-      'fromRaw',
+      'rawToEnvelope',
       fake.returns({
         roles: ['Developer', 'Admin'],
       })
@@ -68,7 +68,7 @@ describe('the "checkSignUp" method', () => {
     const config = buildBoosterConfig()
     replace(
       config.provider.auth,
-      'fromRaw',
+      'rawToEnvelope',
       fake.returns({
         roles: ['Developer'],
       })

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -25,7 +25,7 @@ describe('the "checkSignUp" method', () => {
   function buildBoosterConfig(): BoosterConfig {
     const config = new BoosterConfig('test')
     config.provider = ({
-      auth: { rawSignUpDataToUserEnvelope: () => {} },
+      auth: { fromRaw: () => {} },
     } as unknown) as ProviderLibrary
     config.roles['Admin'] = {
       allowSelfSignUp: false,
@@ -40,7 +40,7 @@ describe('the "checkSignUp" method', () => {
     const config = buildBoosterConfig()
     replace(
       config.provider.auth,
-      'rawSignUpDataToUserEnvelope',
+      'fromRaw',
       fake.returns({
         roles: ['Developer', 'NonExistingRole', 'Admin'],
       })
@@ -53,7 +53,7 @@ describe('the "checkSignUp" method', () => {
     const config = buildBoosterConfig()
     replace(
       config.provider.auth,
-      'rawSignUpDataToUserEnvelope',
+      'fromRaw',
       fake.returns({
         roles: ['Developer', 'Admin'],
       })
@@ -68,7 +68,7 @@ describe('the "checkSignUp" method', () => {
     const config = buildBoosterConfig()
     replace(
       config.provider.auth,
-      'rawSignUpDataToUserEnvelope',
+      'fromRaw',
       fake.returns({
         roles: ['Developer'],
       })

--- a/packages/framework-core/test/booster-graphql-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-graphql-dispatcher.test.ts
@@ -96,7 +96,7 @@ function mockConfigForGraphQLEnvelope(envelope: GraphQLRequestEnvelope): Booster
   const config = new BoosterConfig('test')
   config.provider = {
     graphQL: {
-      fromRaw: fake.resolves(envelope),
+      rawToEnvelope: fake.resolves(envelope),
       handleResult: fake(),
     },
   } as any

--- a/packages/framework-core/test/booster-graphql-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-graphql-dispatcher.test.ts
@@ -31,7 +31,7 @@ describe('the `BoosterGraphQLDispatcher`', () => {
 
       await dispatcher.dispatch({})
 
-      expect(config.provider.handleGraphQLResult).to.have.been.calledOnce
+      expect(config.provider.graphQL.handleGraphQLResult).to.have.been.calledOnce
     })
 
     it('calls the provider "handleGraphQLResult" when there is an error with the graphql execution', async () => {
@@ -52,7 +52,7 @@ describe('the `BoosterGraphQLDispatcher`', () => {
       await dispatcher.dispatch({})
 
       // Check that the handled error includes all the errors that GraphQL reported
-      expect(config.provider.handleGraphQLResult).to.have.been.calledWithExactly(graphQLError)
+      expect(config.provider.graphQL.handleGraphQLResult).to.have.been.calledWithExactly(graphQLError)
     })
 
     it('calls the the GraphQL engine with the passed envelope and handles the result', async () => {
@@ -87,7 +87,7 @@ describe('the `BoosterGraphQLDispatcher`', () => {
         document: match.any,
         contextValue: match(resolverContext),
       })
-      expect(config.provider.handleGraphQLResult).to.have.been.calledWithExactly(graphQLResult)
+      expect(config.provider.graphQL.handleGraphQLResult).to.have.been.calledWithExactly(graphQLResult)
     })
   })
 })
@@ -95,9 +95,11 @@ describe('the `BoosterGraphQLDispatcher`', () => {
 function mockConfigForGraphQLEnvelope(envelope: GraphQLRequestEnvelope): BoosterConfig {
   const config = new BoosterConfig('test')
   config.provider = {
-    rawGraphQLRequestToEnvelope: fake.resolves(envelope),
-    handleGraphQLError: fake(),
-    handleGraphQLResult: fake(),
+    graphQL: {
+      rawGraphQLRequestToEnvelope: fake.resolves(envelope),
+      handleGraphQLError: fake(),
+      handleGraphQLResult: fake(),
+    },
   } as any
   return config
 }

--- a/packages/framework-core/test/booster-graphql-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-graphql-dispatcher.test.ts
@@ -31,7 +31,7 @@ describe('the `BoosterGraphQLDispatcher`', () => {
 
       await dispatcher.dispatch({})
 
-      expect(config.provider.graphQL.handleGraphQLResult).to.have.been.calledOnce
+      expect(config.provider.graphQL.handleResult).to.have.been.calledOnce
     })
 
     it('calls the provider "handleGraphQLResult" when there is an error with the graphql execution', async () => {
@@ -52,7 +52,7 @@ describe('the `BoosterGraphQLDispatcher`', () => {
       await dispatcher.dispatch({})
 
       // Check that the handled error includes all the errors that GraphQL reported
-      expect(config.provider.graphQL.handleGraphQLResult).to.have.been.calledWithExactly(graphQLError)
+      expect(config.provider.graphQL.handleResult).to.have.been.calledWithExactly(graphQLError)
     })
 
     it('calls the the GraphQL engine with the passed envelope and handles the result', async () => {
@@ -87,7 +87,7 @@ describe('the `BoosterGraphQLDispatcher`', () => {
         document: match.any,
         contextValue: match(resolverContext),
       })
-      expect(config.provider.graphQL.handleGraphQLResult).to.have.been.calledWithExactly(graphQLResult)
+      expect(config.provider.graphQL.handleResult).to.have.been.calledWithExactly(graphQLResult)
     })
   })
 })
@@ -96,9 +96,8 @@ function mockConfigForGraphQLEnvelope(envelope: GraphQLRequestEnvelope): Booster
   const config = new BoosterConfig('test')
   config.provider = {
     graphQL: {
-      rawGraphQLRequestToEnvelope: fake.resolves(envelope),
-      handleGraphQLError: fake(),
-      handleGraphQLResult: fake(),
+      fromRaw: fake.resolves(envelope),
+      handleResult: fake(),
     },
   } as any
   return config

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -27,8 +27,7 @@ describe('the `RegisterHandler` class', () => {
     const config = new BoosterConfig('test')
     config.provider = {
       events: {
-        publishEvents: fake(),
-        submitCommands: fake(),
+        publish: fake(),
       },
     } as any
     config.reducers['SomeEvent'] = { class: SomeEntity, methodName: 'whatever' }
@@ -46,15 +45,14 @@ describe('the `RegisterHandler` class', () => {
     expect(registerHandler.wrapEvent).to.have.been.calledTwice
     expect(registerHandler.wrapEvent).to.have.been.calledWith(register, config, event1)
     expect(registerHandler.wrapEvent).to.have.been.calledWith(register, config, event2)
-    expect(config.provider.events.publishEvents).to.have.been.calledOnce
+    expect(config.provider.events.publish).to.have.been.calledOnce
   })
 
   it('publishes wrapped events', async () => {
     const config = new BoosterConfig('test')
     config.provider = {
       events: {
-        publishEvents: fake(),
-        submitCommands: fake(),
+        publish: fake(),
       },
     } as any
     config.reducers['SomeEvent'] = {
@@ -71,8 +69,8 @@ describe('the `RegisterHandler` class', () => {
 
     await RegisterHandler.handle(config, logger, register)
 
-    expect(config.provider.events.publishEvents).to.have.been.calledOnce
-    expect(config.provider.events.publishEvents).to.have.been.calledWithMatch(
+    expect(config.provider.events.publish).to.have.been.calledOnce
+    expect(config.provider.events.publish).to.have.been.calledWithMatch(
       [
         {
           createdAt: 'just the right time',

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -26,8 +26,10 @@ describe('the `RegisterHandler` class', () => {
   it('handles a register', async () => {
     const config = new BoosterConfig('test')
     config.provider = {
-      publishEvents: fake(),
-      submitCommands: fake(),
+      events: {
+        publishEvents: fake(),
+        submitCommands: fake(),
+      },
     } as any
     config.reducers['SomeEvent'] = { class: SomeEntity, methodName: 'whatever' }
 
@@ -44,14 +46,16 @@ describe('the `RegisterHandler` class', () => {
     expect(registerHandler.wrapEvent).to.have.been.calledTwice
     expect(registerHandler.wrapEvent).to.have.been.calledWith(register, config, event1)
     expect(registerHandler.wrapEvent).to.have.been.calledWith(register, config, event2)
-    expect(config.provider.publishEvents).to.have.been.calledOnce
+    expect(config.provider.events.publishEvents).to.have.been.calledOnce
   })
 
   it('publishes wrapped events', async () => {
     const config = new BoosterConfig('test')
     config.provider = {
-      publishEvents: fake(),
-      submitCommands: fake(),
+      events: {
+        publishEvents: fake(),
+        submitCommands: fake(),
+      },
     } as any
     config.reducers['SomeEvent'] = {
       class: SomeEntity,
@@ -67,8 +71,8 @@ describe('the `RegisterHandler` class', () => {
 
     await RegisterHandler.handle(config, logger, register)
 
-    expect(config.provider.publishEvents).to.have.been.calledOnce
-    expect(config.provider.publishEvents).to.have.been.calledWithMatch(
+    expect(config.provider.events.publishEvents).to.have.been.calledOnce
+    expect(config.provider.events.publishEvents).to.have.been.calledWithMatch(
       [
         {
           createdAt: 'just the right time',

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -34,9 +34,11 @@ describe('EventStore', () => {
 
   const config = new BoosterConfig('test')
   config.provider = ({
-    storeEvent: () => {},
-    readEntityLatestSnapshot: () => {},
-    readEntityEventsSince: () => {},
+    events: {
+      storeEvent: () => {},
+      readEntityLatestSnapshot: () => {},
+      readEntityEventsSince: () => {},
+    },
   } as any) as ProviderLibrary
   config.entities['ImportantConcept'] = { class: ImportantConcept }
   config.reducers['ImportantEvent'] = {
@@ -93,13 +95,13 @@ describe('EventStore', () => {
   describe('public methods', () => {
     describe('append', () => {
       it('appends an event to the event store', async () => {
-        replace(config.provider, 'storeEvent', fake())
+        replace(config.provider.events, 'storeEvent', fake())
         const eventStore = new EventStore(config, logger)
         const someEnvelope = eventEnvelopeFor(someEvent)
 
         await eventStore.append(someEnvelope)
 
-        expect(config.provider.storeEvent).to.have.been.calledOnceWith(config, logger, someEnvelope)
+        expect(config.provider.events.storeEvent).to.have.been.calledOnceWith(config, logger, someEnvelope)
       })
     })
 
@@ -442,7 +444,7 @@ describe('EventStore', () => {
 
     describe('storeSnapshot', () => {
       it('stores a snapshot in the event store', async () => {
-        replace(config.provider, 'storeEvent', fake())
+        replace(config.provider.events, 'storeEvent', fake())
 
         const someSnapshot = snapshotEnvelopeFor({
           id: '42',
@@ -451,19 +453,19 @@ describe('EventStore', () => {
 
         await eventStore.storeSnapshot(someSnapshot)
 
-        expect(config.provider.storeEvent).to.have.been.calledOnceWith(config, logger, someSnapshot)
+        expect(config.provider.events.storeEvent).to.have.been.calledOnceWith(config, logger, someSnapshot)
       })
     })
 
     describe('loadLatestSnapshot', () => {
       it('looks for the latest snapshot stored in the event stream', async () => {
-        replace(config.provider, 'readEntityLatestSnapshot', fake())
+        replace(config.provider.events, 'readEntityLatestSnapshot', fake())
 
         const entityTypeName = 'ImportantConcept'
         const entityID = '42'
         await eventStore.loadLatestSnapshot(entityTypeName, entityID)
 
-        expect(config.provider.readEntityLatestSnapshot).to.have.been.calledOnceWith(
+        expect(config.provider.events.readEntityLatestSnapshot).to.have.been.calledOnceWith(
           config,
           logger,
           entityTypeName,
@@ -474,13 +476,13 @@ describe('EventStore', () => {
 
     describe('loadEventStreamSince', () => {
       it('loads a event stream starting from a specific timestapm', async () => {
-        replace(config.provider, 'readEntityEventsSince', fake())
+        replace(config.provider.events, 'readEntityEventsSince', fake())
 
         const entityTypeName = 'ImportantConcept'
         const entityID = '42'
         await eventStore.loadEventStreamSince(entityTypeName, entityID, originOfTime)
 
-        expect(config.provider.readEntityEventsSince).to.have.been.calledOnceWith(
+        expect(config.provider.events.readEntityEventsSince).to.have.been.calledOnceWith(
           config,
           logger,
           entityTypeName,

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -35,7 +35,7 @@ describe('EventStore', () => {
   const config = new BoosterConfig('test')
   config.provider = ({
     events: {
-      storeEvent: () => {},
+      store: () => {},
       readEntityLatestSnapshot: () => {},
       readEntityEventsSince: () => {},
     },
@@ -95,13 +95,13 @@ describe('EventStore', () => {
   describe('public methods', () => {
     describe('append', () => {
       it('appends an event to the event store', async () => {
-        replace(config.provider.events, 'storeEvent', fake())
+        replace(config.provider.events, 'store', fake())
         const eventStore = new EventStore(config, logger)
         const someEnvelope = eventEnvelopeFor(someEvent)
 
         await eventStore.append(someEnvelope)
 
-        expect(config.provider.events.storeEvent).to.have.been.calledOnceWith(config, logger, someEnvelope)
+        expect(config.provider.events.store).to.have.been.calledOnceWith(config, logger, someEnvelope)
       })
     })
 
@@ -444,7 +444,7 @@ describe('EventStore', () => {
 
     describe('storeSnapshot', () => {
       it('stores a snapshot in the event store', async () => {
-        replace(config.provider.events, 'storeEvent', fake())
+        replace(config.provider.events, 'store', fake())
 
         const someSnapshot = snapshotEnvelopeFor({
           id: '42',
@@ -453,7 +453,7 @@ describe('EventStore', () => {
 
         await eventStore.storeSnapshot(someSnapshot)
 
-        expect(config.provider.events.storeEvent).to.have.been.calledOnceWith(config, logger, someSnapshot)
+        expect(config.provider.events.store).to.have.been.calledOnceWith(config, logger, someSnapshot)
       })
     })
 

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -37,7 +37,7 @@ describe('EventStore', () => {
     events: {
       store: () => {},
       readEntityLatestSnapshot: () => {},
-      readEntityEventsSince: () => {},
+      forEntitySince: () => {},
     },
   } as any) as ProviderLibrary
   config.entities['ImportantConcept'] = { class: ImportantConcept }
@@ -476,13 +476,13 @@ describe('EventStore', () => {
 
     describe('loadEventStreamSince', () => {
       it('loads a event stream starting from a specific timestapm', async () => {
-        replace(config.provider.events, 'readEntityEventsSince', fake())
+        replace(config.provider.events, 'forEntitySince', fake())
 
         const entityTypeName = 'ImportantConcept'
         const entityID = '42'
         await eventStore.loadEventStreamSince(entityTypeName, entityID, originOfTime)
 
-        expect(config.provider.events.readEntityEventsSince).to.have.been.calledOnceWith(
+        expect(config.provider.events.forEntitySince).to.have.been.calledOnceWith(
           config,
           logger,
           entityTypeName,

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -36,7 +36,7 @@ describe('EventStore', () => {
   config.provider = ({
     events: {
       store: () => {},
-      readEntityLatestSnapshot: () => {},
+      latestEntitySnapshot: () => {},
       forEntitySince: () => {},
     },
   } as any) as ProviderLibrary
@@ -459,13 +459,13 @@ describe('EventStore', () => {
 
     describe('loadLatestSnapshot', () => {
       it('looks for the latest snapshot stored in the event stream', async () => {
-        replace(config.provider.events, 'readEntityLatestSnapshot', fake())
+        replace(config.provider.events, 'latestEntitySnapshot', fake())
 
         const entityTypeName = 'ImportantConcept'
         const entityID = '42'
         await eventStore.loadLatestSnapshot(entityTypeName, entityID)
 
-        expect(config.provider.events.readEntityLatestSnapshot).to.have.been.calledOnceWith(
+        expect(config.provider.events.latestEntitySnapshot).to.have.been.calledOnceWith(
           config,
           logger,
           entityTypeName,

--- a/packages/framework-core/test/services/raw-events-parser.test.ts
+++ b/packages/framework-core/test/services/raw-events-parser.test.ts
@@ -19,7 +19,7 @@ describe('RawEventsParser', () => {
       }
       const providerLibrary = ({
         events: {
-          fromRawArray: fake.returns([anEvent, anotherEvent]),
+          rawToEnvelopes: fake.returns([anEvent, anotherEvent]),
         },
       } as unknown) as ProviderLibrary
       const callbackFn = fake()

--- a/packages/framework-core/test/services/raw-events-parser.test.ts
+++ b/packages/framework-core/test/services/raw-events-parser.test.ts
@@ -19,7 +19,7 @@ describe('RawEventsParser', () => {
       }
       const providerLibrary = ({
         events: {
-          rawEventsToEnvelopes: fake.returns([anEvent, anotherEvent]),
+          fromRawArray: fake.returns([anEvent, anotherEvent]),
         },
       } as unknown) as ProviderLibrary
       const callbackFn = fake()

--- a/packages/framework-core/test/services/raw-events-parser.test.ts
+++ b/packages/framework-core/test/services/raw-events-parser.test.ts
@@ -18,7 +18,9 @@ describe('RawEventsParser', () => {
         id: 2,
       }
       const providerLibrary = ({
-        rawEventsToEnvelopes: fake.returns([anEvent, anotherEvent]),
+        events: {
+          rawEventsToEnvelopes: fake.returns([anEvent, anotherEvent]),
+        },
       } as unknown) as ProviderLibrary
       const callbackFn = fake()
 

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -37,8 +37,10 @@ describe('ReadModelStore', () => {
 
   const config = new BoosterConfig('test')
   config.provider = ({
-    storeReadModel: () => {},
-    fetchReadModel: () => {},
+    readModels: {
+      storeReadModel: () => {},
+      fetchReadModel: () => {},
+    },
   } as unknown) as ProviderLibrary
   config.entities['ImportantConcept'] = { class: ImportantConcept }
   config.projections['ImportantConcept'] = [
@@ -80,20 +82,20 @@ describe('ReadModelStore', () => {
           createdAt: new Date().toISOString(),
         }
 
-        replace(config.provider, 'storeReadModel', fake())
+        replace(config.provider.readModels, 'storeReadModel', fake())
         const readModelStore = new ReadModelStore(config, logger)
         replace(readModelStore, 'fetchReadModel', fake.returns(null))
 
         await expect(readModelStore.project(entitySnapshotWithNoProjections)).to.eventually.be.fulfilled
 
-        expect(config.provider.storeReadModel).not.to.have.been.called
+        expect(config.provider.readModels.storeReadModel).not.to.have.been.called
         expect(readModelStore.fetchReadModel).not.to.have.been.called
       })
     })
 
     context("when the corresponding read models don't exist", () => {
       it('creates new instances of the read models', async () => {
-        replace(config.provider, 'storeReadModel', fake())
+        replace(config.provider.readModels, 'storeReadModel', fake())
         const readModelStore = new ReadModelStore(config, logger)
         replace(readModelStore, 'fetchReadModel', fake.returns(null))
         spy(SomeReadModel, 'someObserver')
@@ -108,13 +110,13 @@ describe('ReadModelStore', () => {
         expect(SomeReadModel.someObserver).to.have.returned({ id: 'joinColumnID', kind: 'some', count: 123 })
         expect(AnotherReadModel.anotherObserver).to.have.been.calledOnceWith(anEntitySnapshot.value, null)
         expect(AnotherReadModel.anotherObserver).to.have.returned({ id: 'joinColumnID', kind: 'another', count: 123 })
-        expect(config.provider.storeReadModel).to.have.been.calledTwice
-        expect(config.provider.storeReadModel).to.have.been.calledWith(config, logger, 'SomeReadModel', {
+        expect(config.provider.readModels.storeReadModel).to.have.been.calledTwice
+        expect(config.provider.readModels.storeReadModel).to.have.been.calledWith(config, logger, 'SomeReadModel', {
           id: 'joinColumnID',
           kind: 'some',
           count: 123,
         })
-        expect(config.provider.storeReadModel).to.have.been.calledWith(config, logger, 'AnotherReadModel', {
+        expect(config.provider.readModels.storeReadModel).to.have.been.calledWith(config, logger, 'AnotherReadModel', {
           id: 'joinColumnID',
           kind: 'another',
           count: 123,
@@ -124,7 +126,7 @@ describe('ReadModelStore', () => {
 
     context('when the corresponding read model did exist', () => {
       it('updates the read model', async () => {
-        replace(config.provider, 'storeReadModel', fake())
+        replace(config.provider.readModels, 'storeReadModel', fake())
         const readModelStore = new ReadModelStore(config, logger)
         replace(
           readModelStore,
@@ -157,13 +159,13 @@ describe('ReadModelStore', () => {
           count: 177,
         })
         expect(AnotherReadModel.anotherObserver).to.have.returned({ id: 'joinColumnID', kind: 'another', count: 300 })
-        expect(config.provider.storeReadModel).to.have.been.calledTwice
-        expect(config.provider.storeReadModel).to.have.been.calledWith(config, logger, 'SomeReadModel', {
+        expect(config.provider.readModels.storeReadModel).to.have.been.calledTwice
+        expect(config.provider.readModels.storeReadModel).to.have.been.calledWith(config, logger, 'SomeReadModel', {
           id: 'joinColumnID',
           kind: 'some',
           count: 200,
         })
-        expect(config.provider.storeReadModel).to.have.been.calledWith(config, logger, 'AnotherReadModel', {
+        expect(config.provider.readModels.storeReadModel).to.have.been.calledWith(config, logger, 'AnotherReadModel', {
           id: 'joinColumnID',
           kind: 'another',
           count: 300,
@@ -174,12 +176,12 @@ describe('ReadModelStore', () => {
 
   describe('the `fetchReadModel` method', () => {
     it("returns null when the read model doesn't exist", async () => {
-      replace(config.provider, 'fetchReadModel', fake.returns(null))
+      replace(config.provider.readModels, 'fetchReadModel', fake.returns(null))
       const readModelStore = new ReadModelStore(config, logger)
 
       const result = await readModelStore.fetchReadModel('SomeReadModel', 'joinColumnID')
 
-      expect(config.provider.fetchReadModel).to.have.been.calledOnceWithExactly(
+      expect(config.provider.readModels.fetchReadModel).to.have.been.calledOnceWithExactly(
         config,
         logger,
         'SomeReadModel',
@@ -189,12 +191,12 @@ describe('ReadModelStore', () => {
     })
 
     it('returns the current read model value when it exists', async () => {
-      replace(config.provider, 'fetchReadModel', fake.returns({ id: 'joinColumnID', count: 31415 }))
+      replace(config.provider.readModels, 'fetchReadModel', fake.returns({ id: 'joinColumnID', count: 31415 }))
       const readModelStore = new ReadModelStore(config, logger)
 
       const result = await readModelStore.fetchReadModel('SomeReadModel', 'joinColumnID')
 
-      expect(config.provider.fetchReadModel).to.have.been.calledOnceWithExactly(
+      expect(config.provider.readModels.fetchReadModel).to.have.been.calledOnceWithExactly(
         config,
         logger,
         'SomeReadModel',

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -38,8 +38,8 @@ describe('ReadModelStore', () => {
   const config = new BoosterConfig('test')
   config.provider = ({
     readModels: {
-      storeReadModel: () => {},
-      fetchReadModel: () => {},
+      store: () => {},
+      fetch: () => {},
     },
   } as unknown) as ProviderLibrary
   config.entities['ImportantConcept'] = { class: ImportantConcept }
@@ -82,20 +82,20 @@ describe('ReadModelStore', () => {
           createdAt: new Date().toISOString(),
         }
 
-        replace(config.provider.readModels, 'storeReadModel', fake())
+        replace(config.provider.readModels, 'store', fake())
         const readModelStore = new ReadModelStore(config, logger)
         replace(readModelStore, 'fetchReadModel', fake.returns(null))
 
         await expect(readModelStore.project(entitySnapshotWithNoProjections)).to.eventually.be.fulfilled
 
-        expect(config.provider.readModels.storeReadModel).not.to.have.been.called
+        expect(config.provider.readModels.store).not.to.have.been.called
         expect(readModelStore.fetchReadModel).not.to.have.been.called
       })
     })
 
     context("when the corresponding read models don't exist", () => {
       it('creates new instances of the read models', async () => {
-        replace(config.provider.readModels, 'storeReadModel', fake())
+        replace(config.provider.readModels, 'store', fake())
         const readModelStore = new ReadModelStore(config, logger)
         replace(readModelStore, 'fetchReadModel', fake.returns(null))
         spy(SomeReadModel, 'someObserver')
@@ -110,13 +110,13 @@ describe('ReadModelStore', () => {
         expect(SomeReadModel.someObserver).to.have.returned({ id: 'joinColumnID', kind: 'some', count: 123 })
         expect(AnotherReadModel.anotherObserver).to.have.been.calledOnceWith(anEntitySnapshot.value, null)
         expect(AnotherReadModel.anotherObserver).to.have.returned({ id: 'joinColumnID', kind: 'another', count: 123 })
-        expect(config.provider.readModels.storeReadModel).to.have.been.calledTwice
-        expect(config.provider.readModels.storeReadModel).to.have.been.calledWith(config, logger, 'SomeReadModel', {
+        expect(config.provider.readModels.store).to.have.been.calledTwice
+        expect(config.provider.readModels.store).to.have.been.calledWith(config, logger, 'SomeReadModel', {
           id: 'joinColumnID',
           kind: 'some',
           count: 123,
         })
-        expect(config.provider.readModels.storeReadModel).to.have.been.calledWith(config, logger, 'AnotherReadModel', {
+        expect(config.provider.readModels.store).to.have.been.calledWith(config, logger, 'AnotherReadModel', {
           id: 'joinColumnID',
           kind: 'another',
           count: 123,
@@ -126,7 +126,7 @@ describe('ReadModelStore', () => {
 
     context('when the corresponding read model did exist', () => {
       it('updates the read model', async () => {
-        replace(config.provider.readModels, 'storeReadModel', fake())
+        replace(config.provider.readModels, 'store', fake())
         const readModelStore = new ReadModelStore(config, logger)
         replace(
           readModelStore,
@@ -159,13 +159,13 @@ describe('ReadModelStore', () => {
           count: 177,
         })
         expect(AnotherReadModel.anotherObserver).to.have.returned({ id: 'joinColumnID', kind: 'another', count: 300 })
-        expect(config.provider.readModels.storeReadModel).to.have.been.calledTwice
-        expect(config.provider.readModels.storeReadModel).to.have.been.calledWith(config, logger, 'SomeReadModel', {
+        expect(config.provider.readModels.store).to.have.been.calledTwice
+        expect(config.provider.readModels.store).to.have.been.calledWith(config, logger, 'SomeReadModel', {
           id: 'joinColumnID',
           kind: 'some',
           count: 200,
         })
-        expect(config.provider.readModels.storeReadModel).to.have.been.calledWith(config, logger, 'AnotherReadModel', {
+        expect(config.provider.readModels.store).to.have.been.calledWith(config, logger, 'AnotherReadModel', {
           id: 'joinColumnID',
           kind: 'another',
           count: 300,
@@ -176,12 +176,12 @@ describe('ReadModelStore', () => {
 
   describe('the `fetchReadModel` method', () => {
     it("returns null when the read model doesn't exist", async () => {
-      replace(config.provider.readModels, 'fetchReadModel', fake.returns(null))
+      replace(config.provider.readModels, 'fetch', fake.returns(null))
       const readModelStore = new ReadModelStore(config, logger)
 
       const result = await readModelStore.fetchReadModel('SomeReadModel', 'joinColumnID')
 
-      expect(config.provider.readModels.fetchReadModel).to.have.been.calledOnceWithExactly(
+      expect(config.provider.readModels.fetch).to.have.been.calledOnceWithExactly(
         config,
         logger,
         'SomeReadModel',
@@ -191,12 +191,12 @@ describe('ReadModelStore', () => {
     })
 
     it('returns the current read model value when it exists', async () => {
-      replace(config.provider.readModels, 'fetchReadModel', fake.returns({ id: 'joinColumnID', count: 31415 }))
+      replace(config.provider.readModels, 'fetch', fake.returns({ id: 'joinColumnID', count: 31415 }))
       const readModelStore = new ReadModelStore(config, logger)
 
       const result = await readModelStore.fetchReadModel('SomeReadModel', 'joinColumnID')
 
-      expect(config.provider.readModels.fetchReadModel).to.have.been.calledOnceWithExactly(
+      expect(config.provider.readModels.fetch).to.have.been.calledOnceWithExactly(
         config,
         logger,
         'SomeReadModel',

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -27,9 +27,9 @@ const userPool = new CognitoIdentityServiceProvider()
 export const Provider: ProviderLibrary = {
   // ProviderEventsLibrary
   events: {
-    fromRawArray: rawEventsToEnvelopes,
+    rawToEnvelopes: rawEventsToEnvelopes,
     store: storeEvent.bind(null, dynamoDB),
-    readEntityEventsSince: readEntityEventsSince.bind(null, dynamoDB),
+    forEntitySince: readEntityEventsSince.bind(null, dynamoDB),
     readEntityLatestSnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
     publish: publishEvents.bind(null, eventsStream),
   },
@@ -38,7 +38,7 @@ export const Provider: ProviderLibrary = {
     fetch: fetchReadModel.bind(null, dynamoDB),
     search: searchReadModel.bind(null, dynamoDB),
     subscribe: subscribeToReadModel.bind(null, dynamoDB),
-    fromRawArray: rawReadModelEventsToEnvelopes,
+    rawToEnvelopes: rawReadModelEventsToEnvelopes,
     fetchSubscriptions: fetchSubscriptions.bind(null, dynamoDB),
     notifySubscription,
     store: storeReadModel.bind(null, dynamoDB),
@@ -46,12 +46,12 @@ export const Provider: ProviderLibrary = {
   // ProviderGraphQLLibrary
   graphQL: {
     authorizeRequest: authorizeRequest.bind(null, userPool),
-    fromRaw: rawGraphQLRequestToEnvelope,
+    rawToEnvelope: rawGraphQLRequestToEnvelope,
     handleResult: requestSucceeded,
   },
   // ProviderAuthLibrary
   auth: {
-    fromRaw: rawSignUpDataToUserEnvelope,
+    rawToEnvelope: rawSignUpDataToUserEnvelope,
   },
   // ProviderAPIHandling
   api: {

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -27,31 +27,31 @@ const userPool = new CognitoIdentityServiceProvider()
 export const Provider: ProviderLibrary = {
   // ProviderEventsLibrary
   events: {
-    rawEventsToEnvelopes,
-    storeEvent: storeEvent.bind(null, dynamoDB),
+    fromRawArray: rawEventsToEnvelopes,
+    store: storeEvent.bind(null, dynamoDB),
     readEntityEventsSince: readEntityEventsSince.bind(null, dynamoDB),
     readEntityLatestSnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
-    publishEvents: publishEvents.bind(null, eventsStream),
+    publish: publishEvents.bind(null, eventsStream),
   },
   // ProviderReadModelsLibrary
   readModels: {
-    fetchReadModel: fetchReadModel.bind(null, dynamoDB),
-    searchReadModel: searchReadModel.bind(null, dynamoDB),
-    subscribeToReadModel: subscribeToReadModel.bind(null, dynamoDB),
-    rawReadModelEventsToEnvelopes: rawReadModelEventsToEnvelopes,
+    fetch: fetchReadModel.bind(null, dynamoDB),
+    search: searchReadModel.bind(null, dynamoDB),
+    subscribe: subscribeToReadModel.bind(null, dynamoDB),
+    fromRawArray: rawReadModelEventsToEnvelopes,
     fetchSubscriptions: fetchSubscriptions.bind(null, dynamoDB),
     notifySubscription,
-    storeReadModel: storeReadModel.bind(null, dynamoDB),
+    store: storeReadModel.bind(null, dynamoDB),
   },
   // ProviderGraphQLLibrary
   graphQL: {
     authorizeRequest: authorizeRequest.bind(null, userPool),
-    rawGraphQLRequestToEnvelope: rawGraphQLRequestToEnvelope,
-    handleGraphQLResult: requestSucceeded,
+    fromRaw: rawGraphQLRequestToEnvelope,
+    handleResult: requestSucceeded,
   },
   // ProviderAuthLibrary
   auth: {
-    rawSignUpDataToUserEnvelope,
+    fromRaw: rawSignUpDataToUserEnvelope,
   },
   // ProviderAPIHandling
   api: {

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -30,7 +30,7 @@ export const Provider: ProviderLibrary = {
     rawToEnvelopes: rawEventsToEnvelopes,
     store: storeEvent.bind(null, dynamoDB),
     forEntitySince: readEntityEventsSince.bind(null, dynamoDB),
-    readEntityLatestSnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
+    latestEntitySnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
     publish: publishEvents.bind(null, eventsStream),
   },
   // ProviderReadModelsLibrary

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -26,35 +26,40 @@ const userPool = new CognitoIdentityServiceProvider()
 
 export const Provider: ProviderLibrary = {
   // ProviderEventsLibrary
-  rawEventsToEnvelopes,
-  storeEvent: storeEvent.bind(null, dynamoDB),
-  readEntityEventsSince: readEntityEventsSince.bind(null, dynamoDB),
-  readEntityLatestSnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
-  publishEvents: publishEvents.bind(null, eventsStream),
-
+  events: {
+    rawEventsToEnvelopes,
+    storeEvent: storeEvent.bind(null, dynamoDB),
+    readEntityEventsSince: readEntityEventsSince.bind(null, dynamoDB),
+    readEntityLatestSnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
+    publishEvents: publishEvents.bind(null, eventsStream),
+  },
   // ProviderReadModelsLibrary
-  fetchReadModel: fetchReadModel.bind(null, dynamoDB),
-  searchReadModel: searchReadModel.bind(null, dynamoDB),
-  subscribeToReadModel: subscribeToReadModel.bind(null, dynamoDB),
-  rawReadModelEventsToEnvelopes: rawReadModelEventsToEnvelopes,
-  fetchSubscriptions: fetchSubscriptions.bind(null, dynamoDB),
-  notifySubscription,
-  storeReadModel: storeReadModel.bind(null, dynamoDB),
-
+  readModels: {
+    fetchReadModel: fetchReadModel.bind(null, dynamoDB),
+    searchReadModel: searchReadModel.bind(null, dynamoDB),
+    subscribeToReadModel: subscribeToReadModel.bind(null, dynamoDB),
+    rawReadModelEventsToEnvelopes: rawReadModelEventsToEnvelopes,
+    fetchSubscriptions: fetchSubscriptions.bind(null, dynamoDB),
+    notifySubscription,
+    storeReadModel: storeReadModel.bind(null, dynamoDB),
+  },
   // ProviderGraphQLLibrary
-  authorizeRequest: authorizeRequest.bind(null, userPool),
-  rawGraphQLRequestToEnvelope: rawGraphQLRequestToEnvelope,
-  handleGraphQLResult: requestSucceeded,
-
+  graphQL: {
+    authorizeRequest: authorizeRequest.bind(null, userPool),
+    rawGraphQLRequestToEnvelope: rawGraphQLRequestToEnvelope,
+    handleGraphQLResult: requestSucceeded,
+  },
   // ProviderAuthLibrary
-  rawSignUpDataToUserEnvelope,
-
+  auth: {
+    rawSignUpDataToUserEnvelope,
+  },
   // ProviderAPIHandling
-  requestSucceeded,
-  requestFailed,
-
+  api: {
+    requestSucceeded,
+    requestFailed,
+  },
   // ProviderInfrastructureGetter
-  getInfrastructure: () =>
+  infrastructure: () =>
     require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure,
 }
 

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -14,46 +14,46 @@ export const Provider: ProviderLibrary = {
   // ProviderEventsLibrary
   events: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rawEventsToEnvelopes: undefined as any,
+    fromRawArray: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    storeEvent: undefined as any,
+    store: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readEntityEventsSince: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readEntityLatestSnapshot: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    publishEvents: publishEvents.bind(null, eventRegistry),
+    publish: publishEvents.bind(null, eventRegistry),
   },
   // ProviderReadModelsLibrary
   readModels: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fetchReadModel: undefined as any,
+    fetch: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    searchReadModel: undefined as any,
+    search: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    subscribeToReadModel: undefined as any,
+    subscribe: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rawReadModelEventsToEnvelopes: undefined as any,
+    fromRawArray: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fetchSubscriptions: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     notifySubscription: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    storeReadModel: undefined as any,
+    store: undefined as any,
   },
   // ProviderGraphQLLibrary
   graphQL: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     authorizeRequest: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rawGraphQLRequestToEnvelope: undefined as any,
+    fromRaw: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    handleGraphQLResult: undefined as any,
+    handleResult: undefined as any,
   },
   // ProviderAuthLibrary
   auth: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rawSignUpDataToUserEnvelope,
+    fromRaw: rawSignUpDataToUserEnvelope,
   },
   // ProviderAPIHandling
   api: {

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -12,52 +12,57 @@ const eventRegistry = new EventRegistry()
 
 export const Provider: ProviderLibrary = {
   // ProviderEventsLibrary
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rawEventsToEnvelopes: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  storeEvent: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readEntityEventsSince: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readEntityLatestSnapshot: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  publishEvents: publishEvents.bind(null, eventRegistry),
-
+  events: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rawEventsToEnvelopes: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    storeEvent: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readEntityEventsSince: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readEntityLatestSnapshot: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    publishEvents: publishEvents.bind(null, eventRegistry),
+  },
   // ProviderReadModelsLibrary
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fetchReadModel: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  searchReadModel: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  subscribeToReadModel: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rawReadModelEventsToEnvelopes: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fetchSubscriptions: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  notifySubscription: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  storeReadModel: undefined as any,
-
+  readModels: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fetchReadModel: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    searchReadModel: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subscribeToReadModel: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rawReadModelEventsToEnvelopes: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fetchSubscriptions: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    notifySubscription: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    storeReadModel: undefined as any,
+  },
   // ProviderGraphQLLibrary
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authorizeRequest: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rawGraphQLRequestToEnvelope: undefined as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handleGraphQLResult: undefined as any,
-
+  graphQL: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    authorizeRequest: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rawGraphQLRequestToEnvelope: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    handleGraphQLResult: undefined as any,
+  },
   // ProviderAuthLibrary
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rawSignUpDataToUserEnvelope,
-
+  auth: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rawSignUpDataToUserEnvelope,
+  },
   // ProviderAPIHandling
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  requestSucceeded,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  requestFailed,
-
+  api: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    requestSucceeded,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    requestFailed,
+  },
   // ProviderInfrastructureGetter
-  getInfrastructure: () =>
+  infrastructure: () =>
     require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure,
 }

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -14,11 +14,11 @@ export const Provider: ProviderLibrary = {
   // ProviderEventsLibrary
   events: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fromRawArray: undefined as any,
+    rawToEnvelopes: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     store: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readEntityEventsSince: undefined as any,
+    forEntitySince: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readEntityLatestSnapshot: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,7 +33,7 @@ export const Provider: ProviderLibrary = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subscribe: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fromRawArray: undefined as any,
+    rawToEnvelopes: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fetchSubscriptions: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,14 +46,14 @@ export const Provider: ProviderLibrary = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     authorizeRequest: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fromRaw: undefined as any,
+    rawToEnvelope: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handleResult: undefined as any,
   },
   // ProviderAuthLibrary
   auth: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fromRaw: rawSignUpDataToUserEnvelope,
+    rawToEnvelope: rawSignUpDataToUserEnvelope,
   },
   // ProviderAPIHandling
   api: {

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -20,7 +20,7 @@ export const Provider: ProviderLibrary = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     forEntitySince: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readEntityLatestSnapshot: undefined as any,
+    latestEntitySnapshot: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     publish: publishEvents.bind(null, eventRegistry),
   },

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -12,12 +12,14 @@ import { Logger } from './logger'
 import { ReadModelInterface, UUID } from './concepts'
 import { Filter } from './searcher'
 
-export type ProviderLibrary = ProviderEventsLibrary &
-  ProviderReadModelsLibrary &
-  ProviderAuthLibrary &
-  ProviderAPIHandling &
-  ProviderInfrastructureGetter &
-  ProviderGraphQLLibrary
+export interface ProviderLibrary {
+  events: ProviderEventsLibrary
+  readModels: ProviderReadModelsLibrary
+  auth: ProviderAuthLibrary
+  api: ProviderAPIHandling
+  infrastructure: () => ProviderInfrastructure
+  graphQL: ProviderGraphQLLibrary
+}
 
 export interface ProviderEventsLibrary {
   rawEventsToEnvelopes(rawEvents: any): Array<EventEnvelope>
@@ -85,10 +87,6 @@ export interface ProviderAuthLibrary {
 export interface ProviderAPIHandling {
   requestSucceeded(body?: any): Promise<any>
   requestFailed(error: Error): Promise<any>
-}
-
-export interface ProviderInfrastructureGetter {
-  getInfrastructure(): ProviderInfrastructure
 }
 
 export interface ProviderInfrastructure {

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -22,9 +22,9 @@ export interface ProviderLibrary {
 }
 
 export interface ProviderEventsLibrary {
-  rawEventsToEnvelopes(rawEvents: any): Array<EventEnvelope>
+  fromRawArray(rawEvents: any): Array<EventEnvelope>
   /** Stores an event in the event store */
-  storeEvent(config: BoosterConfig, logger: Logger, envelope: EventEnvelope): Promise<any>
+  store(config: BoosterConfig, logger: Logger, envelope: EventEnvelope): Promise<any>
   readEntityEventsSince(
     config: BoosterConfig,
     logger: Logger,
@@ -39,49 +39,35 @@ export interface ProviderEventsLibrary {
     entityID: UUID
   ): Promise<EventEnvelope | null>
   /** Streams an event to the corresponding event handler */
-  publishEvents(eventEnvelopes: Array<EventEnvelope>, config: BoosterConfig, logger: Logger): Promise<void>
+  publish(eventEnvelopes: Array<EventEnvelope>, config: BoosterConfig, logger: Logger): Promise<void>
 }
 export interface ProviderReadModelsLibrary {
-  fetchReadModel(
-    config: BoosterConfig,
-    logger: Logger,
-    readModelName: string,
-    readModelID: UUID
-  ): Promise<ReadModelInterface>
-  searchReadModel<TReadModel extends ReadModelInterface>(
+  fetch(config: BoosterConfig, logger: Logger, readModelName: string, readModelID: UUID): Promise<ReadModelInterface>
+  search<TReadModel extends ReadModelInterface>(
     config: BoosterConfig,
     logger: Logger,
     entityTypeName: string,
     filters: Record<string, Filter<any>>
   ): Promise<Array<TReadModel>>
-  subscribeToReadModel(config: BoosterConfig, logger: Logger, subscriptionEnvelope: SubscriptionEnvelope): Promise<void>
-  rawReadModelEventsToEnvelopes(
-    config: BoosterConfig,
-    logger: Logger,
-    rawEvents: any
-  ): Promise<Array<ReadModelEnvelope>>
+  subscribe(config: BoosterConfig, logger: Logger, subscriptionEnvelope: SubscriptionEnvelope): Promise<void>
+  fromRawArray(config: BoosterConfig, logger: Logger, rawEvents: any): Promise<Array<ReadModelEnvelope>>
   fetchSubscriptions(
     config: BoosterConfig,
     logger: Logger,
     subscriptionName: string
   ): Promise<Array<SubscriptionEnvelope>>
   notifySubscription(config: BoosterConfig, connectionID: string, data: Record<string, any>): Promise<void>
-  storeReadModel(
-    config: BoosterConfig,
-    logger: Logger,
-    readModelName: string,
-    readModel: ReadModelInterface
-  ): Promise<any>
+  store(config: BoosterConfig, logger: Logger, readModelName: string, readModel: ReadModelInterface): Promise<any>
 }
 
 export interface ProviderGraphQLLibrary {
   authorizeRequest(rawRequest: any, logger: Logger): Promise<any>
-  rawGraphQLRequestToEnvelope(rawGraphQLRequest: any, logger: Logger): Promise<GraphQLRequestEnvelope>
-  handleGraphQLResult(result?: any): Promise<any>
+  fromRaw(rawGraphQLRequest: any, logger: Logger): Promise<GraphQLRequestEnvelope>
+  handleResult(result?: any): Promise<any>
 }
 
 export interface ProviderAuthLibrary {
-  rawSignUpDataToUserEnvelope(rawMessage: any): UserEnvelope
+  fromRaw(rawMessage: any): UserEnvelope
 }
 
 export interface ProviderAPIHandling {

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -22,10 +22,10 @@ export interface ProviderLibrary {
 }
 
 export interface ProviderEventsLibrary {
-  fromRawArray(rawEvents: any): Array<EventEnvelope>
+  rawToEnvelopes(rawEvents: any): Array<EventEnvelope>
   /** Stores an event in the event store */
   store(config: BoosterConfig, logger: Logger, envelope: EventEnvelope): Promise<any>
-  readEntityEventsSince(
+  forEntitySince(
     config: BoosterConfig,
     logger: Logger,
     entityTypeName: string,
@@ -50,7 +50,7 @@ export interface ProviderReadModelsLibrary {
     filters: Record<string, Filter<any>>
   ): Promise<Array<TReadModel>>
   subscribe(config: BoosterConfig, logger: Logger, subscriptionEnvelope: SubscriptionEnvelope): Promise<void>
-  fromRawArray(config: BoosterConfig, logger: Logger, rawEvents: any): Promise<Array<ReadModelEnvelope>>
+  rawToEnvelopes(config: BoosterConfig, logger: Logger, rawEvents: any): Promise<Array<ReadModelEnvelope>>
   fetchSubscriptions(
     config: BoosterConfig,
     logger: Logger,
@@ -62,12 +62,12 @@ export interface ProviderReadModelsLibrary {
 
 export interface ProviderGraphQLLibrary {
   authorizeRequest(rawRequest: any, logger: Logger): Promise<any>
-  fromRaw(rawGraphQLRequest: any, logger: Logger): Promise<GraphQLRequestEnvelope>
+  rawToEnvelope(rawGraphQLRequest: any, logger: Logger): Promise<GraphQLRequestEnvelope>
   handleResult(result?: any): Promise<any>
 }
 
 export interface ProviderAuthLibrary {
-  fromRaw(rawMessage: any): UserEnvelope
+  rawToEnvelope(rawMessage: any): UserEnvelope
 }
 
 export interface ProviderAPIHandling {

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -32,7 +32,7 @@ export interface ProviderEventsLibrary {
     entityID: UUID,
     since?: string
   ): Promise<Array<EventEnvelope>>
-  readEntityLatestSnapshot(
+  latestEntitySnapshot(
     config: BoosterConfig,
     logger: Logger,
     entityTypeName: string,


### PR DESCRIPTION
## Description
Refactor the ProviderLibrary type as a scoped interface

## Changes
- Refactor ProviderLibrary as interface 
- Refactor all the ProviderLibrary calls.

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accodingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
