### PR TITLE
fix: require sinon-chai added to all test classes that can't be run individually

### DIFF
--- a/packages/cli/.mocharc.yml
+++ b/packages/cli/.mocharc.yml
@@ -5,6 +5,6 @@ extension:
 package: './package.json'
 recursive: true
 reporter: 'spec'
-timeout: 5000
+timeout: 60000
 full-trace: true
 bail: true

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { expect } from 'chai'
+import { expect } from '../expect'
 import { fancy } from 'fancy-test'
 import { restore, fake } from 'sinon'
 import { Observable, Observer } from 'rxjs'

--- a/packages/cli/test/commands/nuke.test.ts
+++ b/packages/cli/test/commands/nuke.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { expect } from 'chai'
+import { expect } from '../expect'
 import { fancy } from 'fancy-test'
 import { restore, replace, fake } from 'sinon'
 import { Observable, Observer } from 'rxjs'

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -1,15 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from './expect'
 import { restore, fake, replace } from 'sinon'
 import { Logger, BoosterConfig } from '@boostercloud/framework-types'
 import { RoleAccess, UserEnvelope } from '@boostercloud/framework-types'
 import { BoosterAuth } from '../src/booster-auth'
 import { ProviderLibrary } from '@boostercloud/framework-types'
-
-chai.use(require('sinon-chai'))
 
 const logger: Logger = {
   debug() {},

--- a/packages/framework-core/test/booster-command-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-command-dispatcher.test.ts
@@ -2,15 +2,11 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { Booster } from '../src/booster'
 import { fake, replace, restore, match } from 'sinon'
-import * as chai from 'chai'
-import { expect } from 'chai'
+import { expect } from './expect'
 import { BoosterCommandDispatcher } from '../src/booster-command-dispatcher'
 import { Logger, Register } from '@boostercloud/framework-types'
 import { Command } from '../src/decorators'
 import { RegisterHandler } from '../src/booster-register-handler'
-
-chai.use(require('sinon-chai'))
-chai.use(require('chai-as-promised'))
 
 describe('the `BoosterCommandsDispatcher`', () => {
   afterEach(() => {

--- a/packages/framework-core/test/booster-event-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-event-dispatcher.test.ts
@@ -13,14 +13,11 @@ import {
   Register,
   EventInterface,
 } from '@boostercloud/framework-types'
-import * as chai from 'chai'
-import { expect } from 'chai'
+import { expect } from './expect'
 import { RawEventsParser } from '../src/services/raw-events-parser'
 import { ReadModelStore } from '../src/services/read-model-store'
 import { EventStore } from '../src/services/event-store'
 import { RegisterHandler } from '../src/booster-register-handler'
-
-chai.use(require('sinon-chai'))
 
 const someEvent: EventEnvelope = {
   version: 1,

--- a/packages/framework-core/test/booster-graphql-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-graphql-dispatcher.test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { fake, match, replace, restore, spy } from 'sinon'
-import * as chai from 'chai'
-import { expect } from 'chai'
+import { expect } from './expect'
 import { BoosterConfig, Logger, GraphQLRequestEnvelope } from '@boostercloud/framework-types'
 import { BoosterGraphQLDispatcher } from '../src/booster-graphql-dispatcher'
 import * as gqlParser from 'graphql/language/parser'
@@ -10,8 +9,6 @@ import * as gqlValidator from 'graphql/validation/validate'
 import * as gqlExecutor from 'graphql/execution/execute'
 import { GraphQLResolverContext } from '../src/services/graphql/common'
 import { NoopReadModelPubSub } from '../src/services/pub-sub/noop-read-model-pub-sub'
-
-chai.use(require('sinon-chai'))
 
 const logger: Logger = console
 

--- a/packages/framework-core/test/booster-logger.test.ts
+++ b/packages/framework-core/test/booster-logger.test.ts
@@ -2,13 +2,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from './expect'
 import { fake, replace, restore } from 'sinon'
 import { buildLogger } from '../src/booster-logger'
 import { Level } from '@boostercloud/framework-types'
-
-chai.use(require('sinon-chai'))
 
 describe('the `buildLogger method`', () => {
   afterEach(() => {

--- a/packages/framework-core/test/booster-read-model-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-read-model-dispatcher.test.ts
@@ -1,6 +1,5 @@
 import { describe } from 'mocha'
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from './expect'
 import {
   ProviderLibrary,
   BoosterConfig,
@@ -14,9 +13,6 @@ import {
 } from '@boostercloud/framework-types'
 import { restore } from 'sinon'
 import { BoosterReadModelDispatcher } from '../src/booster-read-model-dispatcher'
-
-chai.use(require('sinon-chai'))
-chai.use(require('chai-as-promised'))
 
 const logger: Logger = {
   debug() {},

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -1,14 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from './expect'
 import { Register, BoosterConfig, Level, UserEnvelope } from '@boostercloud/framework-types'
 import { replace, fake, restore } from 'sinon'
 import { RegisterHandler } from '../src/booster-register-handler'
 import { buildLogger } from '../src/booster-logger'
 import { spy } from 'sinon'
-
-chai.use(require('sinon-chai'))
 
 class SomeEntity {}
 

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -1,11 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { expect } from 'chai'
+import * as chai from 'chai'
 import { Register, BoosterConfig, Level, UserEnvelope } from '@boostercloud/framework-types'
 import { replace, fake, restore } from 'sinon'
 import { RegisterHandler } from '../src/booster-register-handler'
 import { buildLogger } from '../src/booster-logger'
 import { spy } from 'sinon'
+
+chai.use(require('sinon-chai'))
 
 class SomeEntity {}
 

--- a/packages/framework-core/test/booster.test.ts
+++ b/packages/framework-core/test/booster.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from './expect'
 import {
   Booster,
   boosterEventDispatcher,
@@ -13,8 +12,6 @@ import { replace, fake, restore } from 'sinon'
 import { Importer } from '../src/importer'
 import * as EntitySnapshotFetcher from '../src/entity-snapshot-fetcher'
 import { UUID } from '@boostercloud/framework-types'
-
-chai.use(require('sinon-chai'))
 
 describe('the `Booster` class', () => {
   afterEach(() => {

--- a/packages/framework-core/test/decorators/command.test.ts
+++ b/packages/framework-core/test/decorators/command.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { expect } from 'chai'
+import { expect } from '../expect'
 import { Register } from '@boostercloud/framework-types'
-import { Command } from '../../src/decorators/command'
-import { Booster } from '../../src/index'
+import { Command } from '../../src/decorators'
+import { Booster } from '../../src'
 
 describe('the `Command` decorator', () => {
   afterEach(() => {

--- a/packages/framework-core/test/decorators/entity.test.ts
+++ b/packages/framework-core/test/decorators/entity.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { expect } from 'chai'
+import { expect } from '../expect'
 import { Event, Entity, Reduces } from '../../src/decorators/'
 import { Booster } from '../../src'
 import { UUID } from '@boostercloud/framework-types'

--- a/packages/framework-core/test/decorators/event-handler.test.ts
+++ b/packages/framework-core/test/decorators/event-handler.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { expect } from 'chai'
-import { EventHandler } from '../../src/decorators/event-handler'
+import { expect } from '../expect'
+import { EventHandler } from '../../src/decorators'
 import { Booster } from '../../src'
-import { Event } from '../../src/decorators/event'
+import { Event } from '../../src/decorators'
 import { UUID, Register, BoosterConfig } from '@boostercloud/framework-types'
 
 describe('the `EventHandler` decorator', () => {

--- a/packages/framework-core/test/decorators/event.test.ts
+++ b/packages/framework-core/test/decorators/event.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { expect } from 'chai'
-import { Event } from '../../src/decorators/event'
+import { expect } from '../expect'
+import { Event } from '../../src/decorators'
 
 describe('the `Event` decorator', () => {
   it('does nothing, but can be used', () => {

--- a/packages/framework-core/test/decorators/migration.test.ts
+++ b/packages/framework-core/test/decorators/migration.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { expect } from 'chai'
-import { Migrates, ToVersion } from '../../src/decorators/migration'
-import { Booster } from '../../src/index'
+import { expect } from '../expect'
+import { Migrates, ToVersion } from '../../src/decorators'
+import { Booster } from '../../src'
 import { MigrationMetadata } from '@boostercloud/framework-types'
 
 // Entities to test the annotations

--- a/packages/framework-core/test/decorators/read-model.test.ts
+++ b/packages/framework-core/test/decorators/read-model.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { expect } from 'chai'
+import { expect } from '../expect'
 import { describe } from 'mocha'
 import { ReadModel, Booster, Entity, Projects } from '../../src/index'
 import { UUID } from '@boostercloud/framework-types'

--- a/packages/framework-core/test/entity-snapshot-fetcher.test.ts
+++ b/packages/framework-core/test/entity-snapshot-fetcher.test.ts
@@ -1,10 +1,13 @@
 import { describe } from 'mocha'
 import { fake, replace, restore } from 'sinon'
 import { expect } from 'chai'
+import * as chai from 'chai'
 import { BoosterConfig, Level, ProviderLibrary, UUID } from '@boostercloud/framework-types'
 import { buildLogger } from '../src/booster-logger'
 import { fetchEntitySnapshot } from '../src/entity-snapshot-fetcher'
 import { EventStore } from '../src/services/event-store'
+
+chai.use(require('sinon-chai'))
 
 describe('entitySnapshotFetcher', () => {
   afterEach(() => {

--- a/packages/framework-core/test/entity-snapshot-fetcher.test.ts
+++ b/packages/framework-core/test/entity-snapshot-fetcher.test.ts
@@ -1,13 +1,10 @@
 import { describe } from 'mocha'
 import { fake, replace, restore } from 'sinon'
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from './expect'
 import { BoosterConfig, Level, ProviderLibrary, UUID } from '@boostercloud/framework-types'
 import { buildLogger } from '../src/booster-logger'
 import { fetchEntitySnapshot } from '../src/entity-snapshot-fetcher'
 import { EventStore } from '../src/services/event-store'
-
-chai.use(require('sinon-chai'))
 
 describe('entitySnapshotFetcher', () => {
   afterEach(() => {

--- a/packages/framework-core/test/expect.ts
+++ b/packages/framework-core/test/expect.ts
@@ -1,0 +1,6 @@
+import * as chai from 'chai'
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+
+export const expect = chai.expect

--- a/packages/framework-core/test/importer.test.ts
+++ b/packages/framework-core/test/importer.test.ts
@@ -1,15 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import * as chai from 'chai'
 import { restore, replace, stub, spy } from 'sinon'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as process from 'process'
 import { Importer } from '../src/importer'
-import { expect } from 'chai'
-
-chai.use(require('sinon-chai'))
+import { expect } from './expect'
 
 describe('the `importer` service', () => {
   afterEach(() => {

--- a/packages/framework-core/test/index.test.ts
+++ b/packages/framework-core/test/index.test.ts
@@ -1,7 +1,10 @@
 import { describe } from 'mocha'
 import { expect } from 'chai'
+import * as chai from 'chai'
 import * as BoosterCore from '../src/index'
 import * as Booster from '../src/booster'
+
+chai.use(require('sinon-chai'))
 
 describe('framework-core package', () => {
   it('exports the `boosterEventDispatcher` function', () => {

--- a/packages/framework-core/test/index.test.ts
+++ b/packages/framework-core/test/index.test.ts
@@ -1,10 +1,7 @@
 import { describe } from 'mocha'
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from './expect'
 import * as BoosterCore from '../src/index'
 import * as Booster from '../src/booster'
-
-chai.use(require('sinon-chai'))
 
 describe('framework-core package', () => {
   it('exports the `boosterEventDispatcher` function', () => {

--- a/packages/framework-core/test/migrator.test.ts
+++ b/packages/framework-core/test/migrator.test.ts
@@ -1,12 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from './expect'
 import { BoosterConfig, CommandEnvelope, Logger, MigrationMetadata } from '@boostercloud/framework-types'
 import { Migrator } from '../src/migrator'
-
-chai.use(require('sinon-chai'))
 
 const logger: Logger = {
   debug() {},

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -11,12 +11,8 @@ import {
 } from '@boostercloud/framework-types'
 import { replace, fake, stub, restore } from 'sinon'
 import { EventStore } from '../../src/services/event-store'
-import { expect } from 'chai'
+import { expect } from '../expect'
 import { buildLogger } from '../../src/booster-logger'
-import * as chai from 'chai'
-
-chai.use(require('sinon-chai'))
-chai.use(require('chai-as-promised'))
 
 describe('EventStore', () => {
   afterEach(() => {

--- a/packages/framework-core/test/services/raw-events-parser.test.ts
+++ b/packages/framework-core/test/services/raw-events-parser.test.ts
@@ -2,7 +2,7 @@ import { describe } from 'mocha'
 import { fake, restore } from 'sinon'
 import { ProviderLibrary, BoosterConfig } from '@boostercloud/framework-types'
 import { RawEventsParser } from '../../src/services/raw-events-parser'
-import { expect } from 'chai'
+import { expect } from '../expect'
 
 describe('RawEventsParser', () => {
   afterEach(() => {

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -4,11 +4,7 @@ import { restore, fake, replace, spy } from 'sinon'
 import { ReadModelStore } from '../../src/services/read-model-store'
 import { buildLogger } from '../../src/booster-logger'
 import { Level, BoosterConfig, EventEnvelope, UUID, ProviderLibrary } from '@boostercloud/framework-types'
-import { expect } from 'chai'
-import * as chai from 'chai'
-
-chai.use(require('sinon-chai'))
-chai.use(require('chai-as-promised'))
+import { expect } from '../expect'
 
 describe('ReadModelStore', () => {
   afterEach(() => {

--- a/packages/framework-provider-aws-infrastructure/test/expect.ts
+++ b/packages/framework-provider-aws-infrastructure/test/expect.ts
@@ -1,0 +1,6 @@
+import * as chai from 'chai'
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+
+export const expect = chai.expect

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/deploy.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/deploy.test.ts
@@ -1,17 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from '../expect'
 import * as Infrastructure from '../../src/infrastructure/index'
 import { replace, restore, fake, match } from 'sinon'
 import { BoosterConfig, UUID } from '@boostercloud/framework-types'
 import * as CDK from 'aws-cdk'
 import { CdkToolkit } from 'aws-cdk/lib/cdk-toolkit'
 import { StreamViewType } from '@aws-cdk/aws-dynamodb'
-
-chai.use(require('sinon-chai'))
-chai.use(require('chai-as-promised'))
 
 const testEnvironment = {
   account: 'testAccount',

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/api-stack-velocity-templates.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/api-stack-velocity-templates.test.ts
@@ -1,6 +1,6 @@
 import * as Velocity from 'velocityjs'
 import { CognitoTemplates } from '../../../src/infrastructure/stacks/api-stack-velocity-templates'
-import { expect } from 'chai'
+import { expect } from '../../expect'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function buildAwsTemplateContext(withData: Record<string, any>): Record<string, any> {

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/application-stack.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/application-stack.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { expect } from 'chai'
+import { expect } from '../../expect'
 import { BoosterConfig, UUID } from '@boostercloud/framework-types'
 import { ApplicationStackBuilder } from '../../../src/infrastructure/stacks/application-stack'
 import { App } from '@aws-cdk/core'

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/read-models-stack.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/read-models-stack.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { expect } from 'chai'
+import { expect } from '../../expect'
 import { describe } from 'mocha'
 import { Stack } from '@aws-cdk/core'
 import { BoosterConfig, UUID } from '@boostercloud/framework-types'

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/read-models-stack.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/read-models-stack.test.ts
@@ -7,8 +7,6 @@ import { App } from '@aws-cdk/core'
 import { ReadModelsStack } from '../../../src/infrastructure/stacks/read-models-stack'
 import { Table } from '@aws-cdk/aws-dynamodb'
 
-// chai.use(require('sinon-chai'))
-
 describe('ReadModelsStack', () => {
   describe('the `build` method', () => {
     class SomeReadModel {

--- a/packages/framework-provider-aws/test/expect.ts
+++ b/packages/framework-provider-aws/test/expect.ts
@@ -1,0 +1,6 @@
+import * as chai from 'chai'
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+
+export const expect = chai.expect

--- a/packages/framework-provider-aws/test/library/api-gateway-io.test.ts
+++ b/packages/framework-provider-aws/test/library/api-gateway-io.test.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from '../expect'
 import {
   InvalidVersionError,
   InvalidParameterError,
@@ -7,8 +6,6 @@ import {
   NotFoundError,
 } from '@boostercloud/framework-types'
 import { requestFailed } from '../../src/library/api-gateway-io'
-
-chai.use(require('sinon-chai'))
 
 describe('the requestFailed method', () => {
   interface TestCase {

--- a/packages/framework-provider-aws/test/library/auth-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/auth-adapter.test.ts
@@ -1,14 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from '../expect'
 import { authorizeRequest, AuthorizerWithUserData, rawSignUpDataToUserEnvelope } from '../../src/library/auth-adapter'
 import { UserEnvelope } from '@boostercloud/framework-types'
 import { APIGatewayAuthorizerWithContextResult } from 'aws-lambda'
 import { CognitoIdentityServiceProvider } from 'aws-sdk'
 import { replace, restore } from 'sinon'
 import * as UserEnvelopes from '../../src/library/user-envelopes'
-
-chai.use(require('sinon-chai'))
 
 describe('the auth-adapter', () => {
   afterEach(() => {

--- a/packages/framework-provider-aws/test/library/events-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/events-adapter.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from '../expect'
 import * as Library from '../../src/library/events-adapter'
 import { restore, fake, match } from 'sinon'
 import { EventEnvelope, BoosterConfig, UUID, Logger } from '@boostercloud/framework-types'
@@ -9,10 +8,8 @@ import { KinesisStreamEvent } from 'aws-lambda'
 import { Kinesis } from 'aws-sdk'
 import { createStubInstance } from 'sinon'
 import { DynamoDB } from 'aws-sdk'
-import { eventStorePartitionKeyAttribute, eventStoreSortKeyAttribute } from '../../src/constants'
+import { eventStorePartitionKeyAttribute, eventStoreSortKeyAttribute } from '../../src'
 import { partitionKeyForEvent } from '../../src/library/partition-keys'
-
-chai.use(require('sinon-chai'))
 
 const fakeLogger: Logger = {
   info: fake(),

--- a/packages/framework-provider-aws/test/library/graphql-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/graphql-adapter.test.ts
@@ -1,11 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from '../expect'
 import { GraphQLRequestEnvelope, UserEnvelope } from '@boostercloud/framework-types'
 import { APIGatewayProxyWithLambdaAuthorizerEvent } from 'aws-lambda'
 import { AuthorizerWithUserData } from '../../src/library/auth-adapter'
 import { rawGraphQLRequestToEnvelope } from '../../src/library/graphql-adapter'
-chai.use(require('sinon-chai'))
 
 describe('the graphql-adapter', () => {
   describe('the `rawGraphQLRequestToEnvelope`', () => {

--- a/packages/framework-provider-aws/test/library/partition-keys.test.ts
+++ b/packages/framework-provider-aws/test/library/partition-keys.test.ts
@@ -1,10 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as chai from 'chai'
-import { expect } from 'chai'
+import { expect } from '../expect'
 import { partitionKeyForEvent } from '../../src/library/partition-keys'
 import { EventEnvelope } from '@boostercloud/framework-types'
-
-chai.use(require('sinon-chai'))
 
 describe('"partitionKeyForEvent" function', () => {
   it('returns a correctly formated partition key', () => {

--- a/packages/framework-provider-aws/test/library/read-model-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/read-model-adapter.test.ts
@@ -1,13 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as chai from 'chai'
-import { expect } from 'chai'
+import { expect } from '../expect'
 import { replace, fake } from 'sinon'
 import { fetchReadModel, storeReadModel } from '../../src/library/read-model-adapter'
 import { DynamoDB } from 'aws-sdk'
 import { BoosterConfig, Logger } from '@boostercloud/framework-types'
-
-chai.use(require('sinon-chai'))
-chai.use(require('chai-as-promised'))
 
 const logger: Logger = {
   info: fake(),

--- a/packages/framework-provider-aws/test/library/subscription-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/subscription-adapter.test.ts
@@ -1,12 +1,8 @@
-import * as chai from 'chai'
-import { expect } from 'chai'
+import { expect } from '../expect'
 import { fake } from 'sinon'
 import { DynamoDBStreamEvent } from 'aws-lambda'
 import { rawReadModelEventsToEnvelopes } from '../../src/library/subscription-adapter'
 import { BoosterConfig, Logger, ReadModelEnvelope } from '@boostercloud/framework-types'
-
-chai.use(require('sinon-chai'))
-chai.use(require('chai-as-promised'))
 
 const logger: Logger = {
   info: fake(),

--- a/packages/framework-provider-aws/test/library/user-envelopes.ts
+++ b/packages/framework-provider-aws/test/library/user-envelopes.ts
@@ -1,15 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from '../expect'
 import { UserEnvelope } from '@boostercloud/framework-types'
 import { AttributeListType, AttributeMappingType } from 'aws-sdk/clients/cognitoidentityserviceprovider'
 import { fetchUserFromRequest, UserEnvelopeBuilder } from '../../src/library/user-envelopes'
 import { APIGatewayProxyEvent } from 'aws-lambda'
 import CognitoIdentityServiceProvider = require('aws-sdk/clients/cognitoidentityserviceprovider')
 import { restore, replace, fake } from 'sinon'
-
-chai.use(require('sinon-chai'))
-chai.use(require('chai-as-promised'))
 
 describe('the UserEnvelopeBuilder.fromAttributeMap', () => {
   it('works with a user with no roles', () => {

--- a/packages/framework-provider-local-infrastructure/test/controllers/auth.test.ts
+++ b/packages/framework-provider-local-infrastructure/test/controllers/auth.test.ts
@@ -1,15 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AuthController } from '../../src/controllers/auth'
 import { UserRegistry } from '@boostercloud/framework-provider-local'
-import * as chai from 'chai'
-import * as sinonChai from 'sinon-chai'
 import { mockRes, mockReq } from 'sinon-express-mock'
 import * as faker from 'faker'
 import { stub, restore } from 'sinon'
-import { expect } from 'chai'
+import { expect } from '../expect'
 import { UserApp } from '@boostercloud/framework-types'
-
-chai.use(sinonChai)
 
 describe('the auth controller', () => {
   beforeEach(() => {

--- a/packages/framework-provider-local-infrastructure/test/expect.ts
+++ b/packages/framework-provider-local-infrastructure/test/expect.ts
@@ -1,0 +1,6 @@
+import * as chai from 'chai'
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+
+export const expect = chai.expect

--- a/packages/framework-provider-local/test/expect.ts
+++ b/packages/framework-provider-local/test/expect.ts
@@ -1,0 +1,6 @@
+import * as chai from 'chai'
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+
+export const expect = chai.expect

--- a/packages/framework-provider-local/test/services/event-registry.test.ts
+++ b/packages/framework-provider-local/test/services/event-registry.test.ts
@@ -6,7 +6,7 @@ import { stub, restore } from 'sinon'
 import * as chai from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 import * as sinonChai from 'sinon-chai'
-import { EventRegistry } from '../../src/services/event-registry'
+import { EventRegistry } from '../../src/services'
 chai.use(chaiAsPromised)
 chai.use(sinonChai)
 

--- a/packages/framework-provider-local/test/services/event-registry.test.ts
+++ b/packages/framework-provider-local/test/services/event-registry.test.ts
@@ -1,14 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { BoosterConfig, ProviderLibrary, EventEnvelope } from '@boostercloud/framework-types'
-import { expect } from 'chai'
+import { expect } from '../expect'
 import * as faker from 'faker'
 import { stub, restore } from 'sinon'
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
-import * as sinonChai from 'sinon-chai'
 import { EventRegistry } from '../../src/services'
-chai.use(chaiAsPromised)
-chai.use(sinonChai)
 
 describe('the event registry', () => {
   beforeEach(() => {

--- a/packages/framework-provider-local/test/services/user-registry.test.ts
+++ b/packages/framework-provider-local/test/services/user-registry.test.ts
@@ -6,7 +6,7 @@ import { stub, restore } from 'sinon'
 import * as chai from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 import * as sinonChai from 'sinon-chai'
-import { UserRegistry } from '../../src/services/user-registry'
+import { UserRegistry } from '../../src/services'
 chai.use(chaiAsPromised)
 chai.use(sinonChai)
 

--- a/packages/framework-provider-local/test/services/user-registry.test.ts
+++ b/packages/framework-provider-local/test/services/user-registry.test.ts
@@ -1,14 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { BoosterConfig, ProviderLibrary, NotAuthorizedError } from '@boostercloud/framework-types'
-import { expect } from 'chai'
+import { expect } from '../expect'
 import * as faker from 'faker'
 import { stub, restore } from 'sinon'
-import * as chai from 'chai'
-import * as chaiAsPromised from 'chai-as-promised'
-import * as sinonChai from 'sinon-chai'
 import { UserRegistry } from '../../src/services'
-chai.use(chaiAsPromised)
-chai.use(sinonChai)
 
 describe('the user registry', () => {
   beforeEach(() => {

--- a/packages/framework-types/test/config.test.ts
+++ b/packages/framework-types/test/config.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as fc from 'fast-check'
 import { BoosterConfig } from '../src'
-import { expect } from 'fancy-test'
+import { expect } from './expect'
 import { MigrationMetadata } from '../src/concepts'
 import { ProviderLibrary } from '../src'
 

--- a/packages/framework-types/test/config.test.ts
+++ b/packages/framework-types/test/config.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as fc from 'fast-check'
-import { BoosterConfig } from '../src/config'
+import { BoosterConfig } from '../src'
 import { expect } from 'fancy-test'
 import { MigrationMetadata } from '../src/concepts'
 import { ProviderLibrary } from '../src'

--- a/packages/framework-types/test/expect.ts
+++ b/packages/framework-types/test/expect.ts
@@ -1,0 +1,6 @@
+import * as chai from 'chai'
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+
+export const expect = chai.expect


### PR DESCRIPTION
## Description
<Description of the pull request>
This pull request intends to fix a small bug that prevents some test classes to be run individually in intellij. This is a problem as debugging and coverage test configurations can't be used either which makes fixing bugs harder

## Changes
<Changes made>
Added `chai.use(require('sinon-chai'))` to the test classes that are missing it.

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
