### PR TITLE
[BOOST-639] Remove Azure from CLI as it's not ready 

### DIFF
--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -77,8 +77,6 @@ const getSelectedProviderPackage = (provider: Provider): string => {
   switch (provider) {
     case Provider.AWS:
       return '@boostercloud/framework-provider-aws'
-    case Provider.AZURE:
-      return '@boostercloud/framework-provider-azure'
     default:
       return ''
   }
@@ -92,7 +90,7 @@ const getProviderPackageName = async (prompter: Prompter, providerPackageName?: 
   const providerSelection: Provider = (await prompter.defaultOrChoose(
     providerPackageName,
     "What's the package name of your provider infrastructure library?",
-    [Provider.AWS, Provider.AZURE, Provider.OTHER]
+    [Provider.AWS, Provider.OTHER]
   )) as Provider
 
   if (providerSelection === Provider.OTHER) {

--- a/packages/cli/src/common/provider.ts
+++ b/packages/cli/src/common/provider.ts
@@ -1,5 +1,4 @@
 export const enum Provider {
   AWS = '@boostercloud/framework-provider-aws (AWS)',
-  AZURE = "@boostercloud/framework-provider-azure (Azure)",
   OTHER = 'Other',
 }

--- a/packages/framework-provider-azure/package.json
+++ b/packages/framework-provider-azure/package.json
@@ -33,7 +33,5 @@
   "bugs": {
     "url": "https://github.com/boostercloud/booster/issues"
   },
-  "devDependencies": {
-    "velocityjs": "^2.0.0"
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
## Description
- Remove Azure from providers in CLI as it's not ready
- Remove velocity dev dependency

## Changes
Follow up from https://github.com/theam/booster/pull/86#discussion_r426920179

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
