### PR TITLE
Rename the "Outputs" names

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,6 @@
   "bugs": "https://github.com/boostercloud/booster/issues",
   "dependencies": {
     "@boostercloud/framework-core": "^0.3.3",
-    "@boostercloud/framework-provider-local-infrastructure": "^0.3.3",
     "@boostercloud/framework-types": "^0.3.3",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/application-stack.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/application-stack.ts
@@ -43,9 +43,9 @@ export class ApplicationStackBuilder {
       deployOptions: { stageName: this.config.environmentName },
     })
 
-    new CfnOutput(stack, 'baseRESTURL', {
+    new CfnOutput(stack, 'httpURL', {
       value: rootAPI.url,
-      description: 'The base URL for all the REST the endpoints of your application',
+      description: 'The base URL for all the auth endpoints and for sending GraphQL mutations and queries',
     })
 
     return rootAPI
@@ -65,7 +65,7 @@ export class ApplicationStackBuilder {
     })
     stage.addDependsOn(rootAPI)
 
-    new CfnOutput(stack, 'baseWebsocketURL', {
+    new CfnOutput(stack, 'websocketURL', {
       value: baseURLForAPI(this.config, stack, rootAPI.ref, 'wss'),
       description: 'The URL for the websocket communication. Used for subscriptions',
     })


### PR DESCRIPTION
## Description
Just rename those names so that they are more accurate and easy to understand

## Changes
Mainly `baseRESTURL` to `httpURL`

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
I'm still working in the documentation for this (which is including the the GraphQL API documentation)
