### PR TITLE
Docs: Update part-1-build-and-deploy.md

### DIFF
--- a/docs/examples/cart-service/part-1-build-and-deploy.md
+++ b/docs/examples/cart-service/part-1-build-and-deploy.md
@@ -134,15 +134,16 @@ export class Cart {
 
   // Helper function that creates a copy of the current cart items and adds the new one
   public static newItems(items: Array<CartItem>, sku: string, quantity: number): Array<CartItem> {
-    return items.map(item => {
-      if (item.sku == sku) {
-        return {
-          ...item,
-          quantity: item.quantity + quantity
-        }
-      }
-      return {...item}
-    })
+    let current_item = items.find(i => i.sku === sku)
+    if (!current_item) {
+     return [...items, {
+       sku,
+       quantity
+     }];
+    } else {
+      current_item.quantity += quantity
+      return [...items]
+    }
   }
 }
 ```

--- a/docs/examples/cart-service/part-1-build-and-deploy.md
+++ b/docs/examples/cart-service/part-1-build-and-deploy.md
@@ -135,14 +135,14 @@ export class Cart {
   // Helper function that creates a copy of the current cart items and adds the new one
   public static newItems(items: Array<CartItem>, sku: string, quantity: number): Array<CartItem> {
     let current_item = items.find(i => i.sku === sku)
-    if (!current_item) {
-     return [...items, {
-       sku,
-       quantity
-     }];
-    } else {
+    if (current_item) {
       current_item.quantity += quantity
       return [...items]
+    } else {
+      return [...items, {
+        sku,
+        quantity
+      }]
     }
   }
 }


### PR DESCRIPTION
## Description
A fix for an example.

## Changes
I would say that the `newItems` method never includes new SKUs to the list of items. I just came up with this version and now I see new items in my readModel. 

```
{
  "data": {
    "CartReadModel": {
      "id": "demo",
      "items": [
        {
          "sku": "ABC_02",
          "quantity": 2
        },
        {
          "sku": "ABC_01",
          "quantity": 10
        },
        {
          "sku": "ABC_03",
          "quantity": 8
        }
      ]
    }
  }
}
```

Let me know if it makes sense.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
