### PR TITLE
[INTEGRATION TEST] increase sleep times to allow infrastructure to warm up

### DIFF
--- a/packages/framework-integration-tests/integration/aws/auth.integration.ts
+++ b/packages/framework-integration-tests/integration/aws/auth.integration.ts
@@ -92,8 +92,8 @@ describe('With the auth API', () => {
     it('can query a public read model', async () => {
       const client = await graphQLClient()
 
-      // Let's wait 10 seconds to allow previous command results to be projected as a read model
-      await sleep(10000)
+      // Let's wait 15 seconds to allow previous command results to be projected as a read model
+      await sleep(15000)
 
       const queryResult = await client.query({
         variables: {

--- a/packages/framework-integration-tests/integration/aws/commands-api.integration.ts
+++ b/packages/framework-integration-tests/integration/aws/commands-api.integration.ts
@@ -30,7 +30,7 @@ describe('the commands API', async () => {
     expect(response?.data?.ChangeCartItem).to.be.true
 
     // Let some time to create the event and update the read model
-    await sleep(5000)
+    await sleep(10000)
   })
 
   it('should create an event in the event store', async () => {


### PR DESCRIPTION
## Description
For integration tests, the stack is created and then deleted. The first requests may take longer due to the warm-up time.

## Changes
- Increase waits in the first test of the authentication and commands-api integration tests suite

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
