### PR TITLE
Add a section for installing the Booster CLI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,3 +102,24 @@ folder, and a file called `credentials` with this template:
 aws_access_key_id = <YOUR ACCESS KEY ID>
 aws_secret_access_key = <YOUR SECRET ACCESS KEY>
 ```
+#### Installing the Booster CLI
+
+Booster comes with a command-line tool that helps you generating boilerplate code,
+testing and deploying the application, and deleting all the resources in the cloud. All
+the stable versions are published to [`npm`](https://www.npmjs.com/package/@boostercloud/cli),
+these versions are the recommended ones, as they are well documented, and the changes are
+stated in the release notes.
+
+To install the Booster CLI run
+
+```shell
+npm install --global @boostercloud/cli
+```
+
+Verify the Booster CLI installation with the `boost version` command. You should get back
+something like
+
+```shell
+$ boost version
+@boostercloud/cli/0.3.3 darwin-x64 node-v13.12.0
+```


### PR DESCRIPTION
## Description
In the rewriting of the docs we will be opening several PRs, one per section, so we end up with the documentation in a single markdown file.

## Changes
Add a section for Installing the Booster CLI so a user can later follow the 10 minutes tutorial

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

