### PR TITLE
BOOST-693 Replace Kinesis by DynamoDB Streams

### DIFF
--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -35,7 +35,8 @@ export class BoosterEventDispatcher {
   ): (event: EventEnvelope, config: BoosterConfig) => Promise<void> {
     return async (eventEnvelope, config) => {
       logger.debug('[BoosterEventDispatcher#eventProcessor]: Started processing workflow for event:', eventEnvelope)
-      await eventStore.append(eventEnvelope)
+      // FIXME: Remove me
+      // await eventStore.append(eventEnvelope)
 
       // TODO: Separate into two independent processes the snapshotting/read-model generation process from the event handling process
       await Promise.all([

--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -35,9 +35,6 @@ export class BoosterEventDispatcher {
   ): (event: EventEnvelope, config: BoosterConfig) => Promise<void> {
     return async (eventEnvelope, config) => {
       logger.debug('[BoosterEventDispatcher#eventProcessor]: Started processing workflow for event:', eventEnvelope)
-      // FIXME: Remove me
-      // await eventStore.append(eventEnvelope)
-
       // TODO: Separate into two independent processes the snapshotting/read-model generation process from the event handling process
       await Promise.all([
         BoosterEventDispatcher.snapshotAndUpdateReadModels(eventEnvelope, eventStore, readModelStore, logger),

--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -34,12 +34,19 @@ export class BoosterEventDispatcher {
     logger: Logger
   ): (event: EventEnvelope, config: BoosterConfig) => Promise<void> {
     return async (eventEnvelope, config) => {
-      logger.debug('[BoosterEventDispatcher#eventProcessor]: Started processing workflow for event:', eventEnvelope)
-      // TODO: Separate into two independent processes the snapshotting/read-model generation process from the event handling process
-      await Promise.all([
-        BoosterEventDispatcher.snapshotAndUpdateReadModels(eventEnvelope, eventStore, readModelStore, logger),
-        BoosterEventDispatcher.handleEvent(eventEnvelope, config, logger),
-      ])
+      switch (eventEnvelope.kind) {
+        case 'event':
+          logger.debug('[BoosterEventDispatcher#eventProcessor]: Started processing workflow for event:', eventEnvelope)
+          // TODO: Separate into two independent processes the snapshotting/read-model generation process from the event handling process
+          await Promise.all([
+            BoosterEventDispatcher.snapshotAndUpdateReadModels(eventEnvelope, eventStore, readModelStore, logger),
+            BoosterEventDispatcher.handleEvent(eventEnvelope, config, logger),
+          ])
+          break
+        case 'snapshot':
+          // TODO: The event stream includes snapshots, but we currently just ignore them. In the future we could want to introduce snapshot hooks to backup them or other uses.
+          break
+      }
     }
   }
 

--- a/packages/framework-core/src/booster-read-model-dispatcher.ts
+++ b/packages/framework-core/src/booster-read-model-dispatcher.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   BoosterConfig,
   Logger,

--- a/packages/framework-core/src/booster-register-handler.ts
+++ b/packages/framework-core/src/booster-register-handler.ts
@@ -10,7 +10,7 @@ import {
 
 export class RegisterHandler {
   public static async handle(config: BoosterConfig, logger: Logger, register: Register): Promise<void> {
-    return config.provider.events.publish(
+    return config.provider.events.store(
       register.eventList.map(RegisterHandler.wrapEvent.bind(null, register, config)),
       config,
       logger

--- a/packages/framework-core/src/booster-register-handler.ts
+++ b/packages/framework-core/src/booster-register-handler.ts
@@ -10,7 +10,7 @@ import {
 
 export class RegisterHandler {
   public static async handle(config: BoosterConfig, logger: Logger, register: Register): Promise<void> {
-    return config.provider.events.publish(
+    return config.provider.events.storeAndPublish(
       register.eventList.map(RegisterHandler.wrapEvent.bind(null, register, config)),
       config,
       logger

--- a/packages/framework-core/src/booster-register-handler.ts
+++ b/packages/framework-core/src/booster-register-handler.ts
@@ -10,7 +10,7 @@ import {
 
 export class RegisterHandler {
   public static async handle(config: BoosterConfig, logger: Logger, register: Register): Promise<void> {
-    return config.provider.events.storeAndPublish(
+    return config.provider.events.publish(
       register.eventList.map(RegisterHandler.wrapEvent.bind(null, register, config)),
       config,
       logger

--- a/packages/framework-core/src/booster-subscribers-notifier.ts
+++ b/packages/framework-core/src/booster-subscribers-notifier.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   BoosterConfig,
   Logger,

--- a/packages/framework-core/src/services/event-store.ts
+++ b/packages/framework-core/src/services/event-store.ts
@@ -55,7 +55,7 @@ export class EventStore {
       `[EventStore#storeSnapshot] Max number of events after latest stored snapshot reached (${numberOfEventsBetweenSnapshots}). Storing snapshot in the event store:`,
       snapshot
     )
-    return await this.provider.evenst.storeAndPublish([snapshot], this.config, this.logger)
+    return await this.provider.events.storeAndPublish([snapshot], this.config, this.logger)
   }
 
   private loadLatestSnapshot(entityName: string, entityID: UUID): Promise<EventEnvelope | null> {

--- a/packages/framework-core/src/services/event-store.ts
+++ b/packages/framework-core/src/services/event-store.ts
@@ -55,7 +55,7 @@ export class EventStore {
       `[EventStore#storeSnapshot] Max number of events after latest stored snapshot reached (${numberOfEventsBetweenSnapshots}). Storing snapshot in the event store:`,
       snapshot
     )
-    return await this.provider.events.publish([snapshot], this.config, this.logger)
+    return await this.provider.events.store([snapshot], this.config, this.logger)
   }
 
   private loadLatestSnapshot(entityName: string, entityID: UUID): Promise<EventEnvelope | null> {

--- a/packages/framework-core/src/services/event-store.ts
+++ b/packages/framework-core/src/services/event-store.ts
@@ -22,16 +22,6 @@ export class EventStore {
     this.logger = logger
   }
 
-  public async append(eventEnvelope: EventEnvelope): Promise<void> {
-    this.logger.debug('[EventStore#append] Appending event envelope in the events store:', eventEnvelope)
-    try {
-      await this.provider.events.store(this.config, this.logger, eventEnvelope)
-    } catch (e) {
-      this.logger.error('[EventStore#append] Unhandled error while appending an event to the event store:', e)
-      throw e
-    }
-  }
-
   public async fetchEntitySnapshot(entityName: string, entityID: UUID): Promise<EventEnvelope | null> {
     this.logger.debug(`[EventStore#fetchEntitySnapshot] Fetching snapshot for entity ${entityName} with ID ${entityID}`)
     const latestSnapshotEnvelope = await this.loadLatestSnapshot(entityName, entityID)
@@ -65,7 +55,7 @@ export class EventStore {
       `[EventStore#storeSnapshot] Max number of events after latest stored snapshot reached (${numberOfEventsBetweenSnapshots}). Storing snapshot in the event store:`,
       snapshot
     )
-    return await this.provider.events.store(this.config, this.logger, snapshot)
+    return await this.provider.evenst.storeAndPublish([snapshot], this.config, this.logger)
   }
 
   private loadLatestSnapshot(entityName: string, entityID: UUID): Promise<EventEnvelope | null> {

--- a/packages/framework-core/src/services/event-store.ts
+++ b/packages/framework-core/src/services/event-store.ts
@@ -55,7 +55,7 @@ export class EventStore {
       `[EventStore#storeSnapshot] Max number of events after latest stored snapshot reached (${numberOfEventsBetweenSnapshots}). Storing snapshot in the event store:`,
       snapshot
     )
-    return await this.provider.events.storeAndPublish([snapshot], this.config, this.logger)
+    return await this.provider.events.publish([snapshot], this.config, this.logger)
   }
 
   private loadLatestSnapshot(entityName: string, entityID: UUID): Promise<EventEnvelope | null> {

--- a/packages/framework-core/test/booster-event-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-event-dispatcher.test.ts
@@ -82,21 +82,6 @@ describe('BoosterEventDispatcher', () => {
     })
 
     describe('the `eventProcessor` method', () => {
-      it('appends an event to the event store', async () => {
-        const stubEventStore = createStubInstance(EventStore)
-        const stubReadModelStore = createStubInstance(ReadModelStore)
-
-        const boosterEventDispatcher = BoosterEventDispatcher as any
-        replace(boosterEventDispatcher, 'snapshotAndUpdateReadModels', fake())
-        replace(boosterEventDispatcher, 'handleEvent', fake())
-
-        const callback = boosterEventDispatcher.eventProcessor(stubEventStore, stubReadModelStore, logger)
-
-        await callback(someEvent, config)
-
-        expect(stubEventStore.append).to.have.been.calledOnceWith(someEvent)
-      })
-
       it('waits for snapshotting and read model update process to complete', async () => {
         const stubEventStore = createStubInstance(EventStore)
         const stubReadModelStore = createStubInstance(ReadModelStore)

--- a/packages/framework-core/test/booster-read-model-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-read-model-dispatcher.test.ts
@@ -54,6 +54,7 @@ describe('BoosterReadModelDispatcher', () => {
       const envelope = {
         typeName: 'anyReadModel',
         requestID: '123',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any // To avoid the compilation failure of "missing version field"
 
       await expect(readModelDispatcher.fetch(envelope)).to.eventually.be.rejectedWith(InvalidParameterError)

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -27,7 +27,7 @@ describe('the `RegisterHandler` class', () => {
     const config = new BoosterConfig('test')
     config.provider = {
       events: {
-        publish: fake(),
+        store: fake(),
       },
     } as any
     config.reducers['SomeEvent'] = { class: SomeEntity, methodName: 'whatever' }
@@ -45,14 +45,14 @@ describe('the `RegisterHandler` class', () => {
     expect(registerHandler.wrapEvent).to.have.been.calledTwice
     expect(registerHandler.wrapEvent).to.have.been.calledWith(register, config, event1)
     expect(registerHandler.wrapEvent).to.have.been.calledWith(register, config, event2)
-    expect(config.provider.events.publish).to.have.been.calledOnce
+    expect(config.provider.events.store).to.have.been.calledOnce
   })
 
-  it('publishes wrapped events', async () => {
+  it('stores wrapped events', async () => {
     const config = new BoosterConfig('test')
     config.provider = {
       events: {
-        publish: fake(),
+        store: fake(),
       },
     } as any
     config.reducers['SomeEvent'] = {
@@ -69,8 +69,8 @@ describe('the `RegisterHandler` class', () => {
 
     await RegisterHandler.handle(config, logger, register)
 
-    expect(config.provider.events.publish).to.have.been.calledOnce
-    expect(config.provider.events.publish).to.have.been.calledWithMatch(
+    expect(config.provider.events.store).to.have.been.calledOnce
+    expect(config.provider.events.store).to.have.been.calledWithMatch(
       [
         {
           createdAt: 'just the right time',

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -27,7 +27,7 @@ describe('the `RegisterHandler` class', () => {
     const config = new BoosterConfig('test')
     config.provider = {
       events: {
-        publish: fake(),
+        storeAndPublish: fake(),
       },
     } as any
     config.reducers['SomeEvent'] = { class: SomeEntity, methodName: 'whatever' }
@@ -45,14 +45,14 @@ describe('the `RegisterHandler` class', () => {
     expect(registerHandler.wrapEvent).to.have.been.calledTwice
     expect(registerHandler.wrapEvent).to.have.been.calledWith(register, config, event1)
     expect(registerHandler.wrapEvent).to.have.been.calledWith(register, config, event2)
-    expect(config.provider.events.publish).to.have.been.calledOnce
+    expect(config.provider.events.storeAndPublish).to.have.been.calledOnce
   })
 
   it('publishes wrapped events', async () => {
     const config = new BoosterConfig('test')
     config.provider = {
       events: {
-        publish: fake(),
+        storeAndPublish: fake(),
       },
     } as any
     config.reducers['SomeEvent'] = {
@@ -69,8 +69,8 @@ describe('the `RegisterHandler` class', () => {
 
     await RegisterHandler.handle(config, logger, register)
 
-    expect(config.provider.events.publish).to.have.been.calledOnce
-    expect(config.provider.events.publish).to.have.been.calledWithMatch(
+    expect(config.provider.events.storeAndPublish).to.have.been.calledOnce
+    expect(config.provider.events.storeAndPublish).to.have.been.calledWithMatch(
       [
         {
           createdAt: 'just the right time',

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -27,7 +27,7 @@ describe('the `RegisterHandler` class', () => {
     const config = new BoosterConfig('test')
     config.provider = {
       events: {
-        storeAndPublish: fake(),
+        publish: fake(),
       },
     } as any
     config.reducers['SomeEvent'] = { class: SomeEntity, methodName: 'whatever' }
@@ -45,14 +45,14 @@ describe('the `RegisterHandler` class', () => {
     expect(registerHandler.wrapEvent).to.have.been.calledTwice
     expect(registerHandler.wrapEvent).to.have.been.calledWith(register, config, event1)
     expect(registerHandler.wrapEvent).to.have.been.calledWith(register, config, event2)
-    expect(config.provider.events.storeAndPublish).to.have.been.calledOnce
+    expect(config.provider.events.publish).to.have.been.calledOnce
   })
 
   it('publishes wrapped events', async () => {
     const config = new BoosterConfig('test')
     config.provider = {
       events: {
-        storeAndPublish: fake(),
+        publish: fake(),
       },
     } as any
     config.reducers['SomeEvent'] = {
@@ -69,8 +69,8 @@ describe('the `RegisterHandler` class', () => {
 
     await RegisterHandler.handle(config, logger, register)
 
-    expect(config.provider.events.storeAndPublish).to.have.been.calledOnce
-    expect(config.provider.events.storeAndPublish).to.have.been.calledWithMatch(
+    expect(config.provider.events.publish).to.have.been.calledOnce
+    expect(config.provider.events.publish).to.have.been.calledWithMatch(
       [
         {
           createdAt: 'just the right time',

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -437,7 +437,7 @@ describe('EventStore', () => {
 
         await eventStore.storeSnapshot(someSnapshot)
 
-        expect(config.provider.events.storeAndPublish).to.have.been.calledOnceWith(config, logger, someSnapshot)
+        expect(config.provider.events.storeAndPublish).to.have.been.calledOnceWith([someSnapshot], config, logger)
       })
     })
 

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -31,7 +31,7 @@ describe('EventStore', () => {
   const config = new BoosterConfig('test')
   config.provider = ({
     events: {
-      store: () => {},
+      storeAndPublish: () => {},
       latestEntitySnapshot: () => {},
       forEntitySince: () => {},
     },
@@ -89,18 +89,6 @@ describe('EventStore', () => {
   }
 
   describe('public methods', () => {
-    describe('append', () => {
-      it('appends an event to the event store', async () => {
-        replace(config.provider.events, 'store', fake())
-        const eventStore = new EventStore(config, logger)
-        const someEnvelope = eventEnvelopeFor(someEvent)
-
-        await eventStore.append(someEnvelope)
-
-        expect(config.provider.events.store).to.have.been.calledOnceWith(config, logger, someEnvelope)
-      })
-    })
-
     describe('fetchEntitySnapshot', () => {
       it('properly binds `this` to the entityReducer', async () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -440,7 +428,7 @@ describe('EventStore', () => {
 
     describe('storeSnapshot', () => {
       it('stores a snapshot in the event store', async () => {
-        replace(config.provider.events, 'store', fake())
+        replace(config.provider.events, 'storeAndPublish', fake())
 
         const someSnapshot = snapshotEnvelopeFor({
           id: '42',
@@ -449,7 +437,7 @@ describe('EventStore', () => {
 
         await eventStore.storeSnapshot(someSnapshot)
 
-        expect(config.provider.events.store).to.have.been.calledOnceWith(config, logger, someSnapshot)
+        expect(config.provider.events.storeAndPublish).to.have.been.calledOnceWith(config, logger, someSnapshot)
       })
     })
 

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -31,7 +31,7 @@ describe('EventStore', () => {
   const config = new BoosterConfig('test')
   config.provider = ({
     events: {
-      storeAndPublish: () => {},
+      publish: () => {},
       latestEntitySnapshot: () => {},
       forEntitySince: () => {},
     },
@@ -428,7 +428,7 @@ describe('EventStore', () => {
 
     describe('storeSnapshot', () => {
       it('stores a snapshot in the event store', async () => {
-        replace(config.provider.events, 'storeAndPublish', fake())
+        replace(config.provider.events, 'publish', fake())
 
         const someSnapshot = snapshotEnvelopeFor({
           id: '42',
@@ -437,7 +437,7 @@ describe('EventStore', () => {
 
         await eventStore.storeSnapshot(someSnapshot)
 
-        expect(config.provider.events.storeAndPublish).to.have.been.calledOnceWith([someSnapshot], config, logger)
+        expect(config.provider.events.publish).to.have.been.calledOnceWith([someSnapshot], config, logger)
       })
     })
 

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -31,7 +31,7 @@ describe('EventStore', () => {
   const config = new BoosterConfig('test')
   config.provider = ({
     events: {
-      publish: () => {},
+      store: () => {},
       latestEntitySnapshot: () => {},
       forEntitySince: () => {},
     },
@@ -428,7 +428,7 @@ describe('EventStore', () => {
 
     describe('storeSnapshot', () => {
       it('stores a snapshot in the event store', async () => {
-        replace(config.provider.events, 'publish', fake())
+        replace(config.provider.events, 'store', fake())
 
         const someSnapshot = snapshotEnvelopeFor({
           id: '42',
@@ -437,7 +437,7 @@ describe('EventStore', () => {
 
         await eventStore.storeSnapshot(someSnapshot)
 
-        expect(config.provider.events.publish).to.have.been.calledOnceWith([someSnapshot], config, logger)
+        expect(config.provider.events.store).to.have.been.calledOnceWith([someSnapshot], config, logger)
       })
     })
 

--- a/packages/framework-integration-tests/integration/aws/commands-api.integration.ts
+++ b/packages/framework-integration-tests/integration/aws/commands-api.integration.ts
@@ -107,7 +107,7 @@ describe('the commands API', async () => {
       expect(response?.data?.ChangeCartItem).to.be.true
     })
 
-    await sleep(5000)
+    await sleep(10000)
 
     const expectedSnapshotItemsCount = snapshotsCount + 1
     expect(await countSnapshotItems()).to.be.equal(expectedSnapshotItemsCount)

--- a/packages/framework-provider-aws-infrastructure/package.json
+++ b/packages/framework-provider-aws-infrastructure/package.json
@@ -25,7 +25,6 @@
     "@aws-cdk/aws-cognito": "1.26.0",
     "@aws-cdk/aws-dynamodb": "1.26.0",
     "@aws-cdk/aws-iam": "1.26.0",
-    "@aws-cdk/aws-kinesis": "1.26.0",
     "@aws-cdk/aws-lambda": "1.26.0",
     "@aws-cdk/aws-lambda-event-sources": "1.26.0",
     "@boostercloud/framework-provider-aws": "^0.3.3",

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/index.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/index.ts
@@ -23,10 +23,14 @@ async function getEnvironment(aws: SDK): Promise<Environment> {
   const region = await aws.defaultRegion()
 
   if (!account) {
-    throw new Error('Unable to load default AWS account. Check that you have properly set your AWS credentials in `~/.aws/credentials` file or the corresponding environment variables. Refer to AWS documentation for more details https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html')
+    throw new Error(
+      'Unable to load default AWS account. Check that you have properly set your AWS credentials in `~/.aws/credentials` file or the corresponding environment variables. Refer to AWS documentation for more details https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html'
+    )
   }
   if (!region) {
-    throw new Error('Unable to determine default region. Check that you have set it in your `~/.aws/config` file or AWS_REGION environment variable. Refer to AWS documentation for more details https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html#setting-region-order-of-precedence')
+    throw new Error(
+      'Unable to determine default region. Check that you have set it in your `~/.aws/config` file or AWS_REGION environment variable. Refer to AWS documentation for more details https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html#setting-region-order-of-precedence'
+    )
   }
 
   return {

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/params.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/params.ts
@@ -2,10 +2,10 @@
 import { Duration, Stack } from '@aws-cdk/core'
 import { FunctionProps, Runtime, StartingPosition } from '@aws-cdk/aws-lambda'
 import { BoosterConfig } from '@boostercloud/framework-types'
-import { KinesisEventSourceProps } from '@aws-cdk/aws-lambda-event-sources/lib/kinesis'
 import { RestApi } from '@aws-cdk/aws-apigateway'
 import { CfnApi } from '@aws-cdk/aws-apigatewayv2'
 import { environmentVarNames } from '@boostercloud/framework-provider-aws'
+import { DynamoEventSourceProps } from '@aws-cdk/aws-lambda-event-sources'
 
 export interface APIs {
   restAPI: RestApi
@@ -39,7 +39,7 @@ export function baseURLForAPI(
   return `${protocol}://${apiID}.execute-api.${stack.region}.${stack.urlSuffix}/${config.environmentName}/`
 }
 
-export function stream(): Pick<KinesisEventSourceProps, 'startingPosition' | 'batchSize'> {
+export function stream(): Pick<DynamoEventSourceProps, 'startingPosition' | 'batchSize'> {
   return {
     startingPosition: StartingPosition.TRIM_HORIZON,
     batchSize: 100,

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/application-stack.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/application-stack.ts
@@ -86,14 +86,14 @@ function setupPermissions(
 ): void {
   graphQLLambda.addToRolePolicy(
     new PolicyStatement({
-      resources: [],
-      actions: ['dynamodb:Query*', 'dynamodb:Put*'],
+      resources: [eventsStore.tableArn],
+      actions: ['dynamodb:Query*', 'dynamodb:Put*', 'dynamodb:BatchWriteItem'],
     })
   )
   graphQLLambda.addToRolePolicy(
     new PolicyStatement({
       resources: [subscriptionsTable.tableArn],
-      actions: ['dynamodb:Put*'],
+      actions: ['dynamodb:Put*', 'dynamodb:BatchWriteItem'],
     })
   )
 
@@ -122,7 +122,7 @@ function setupPermissions(
   eventsLambda.addToRolePolicy(
     new PolicyStatement({
       resources: [eventsStore.tableArn],
-      actions: ['dynamodb:Query*', 'dynamodb:Put*'],
+      actions: ['dynamodb:Query*', 'dynamodb:Put*', 'dynamodb:BatchWriteItem'],
     })
   )
 
@@ -130,7 +130,7 @@ function setupPermissions(
   if (tableArns.length > 0) {
     eventsLambda.addToRolePolicy(
       new PolicyStatement({
-        actions: ['dynamodb:Get*', 'dynamodb:Put*'],
+        actions: ['dynamodb:Get*', 'dynamodb:Put*', 'dynamodb:BatchWriteItem'],
         resources: tableArns,
       })
     )

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/application-stack.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/application-stack.ts
@@ -1,6 +1,4 @@
-import { App, CfnOutput, Fn, Stack, StackProps } from '@aws-cdk/core'
-import { Table } from '@aws-cdk/aws-dynamodb'
-import { Function } from '@aws-cdk/aws-lambda'
+import { App, CfnOutput, Stack, StackProps } from '@aws-cdk/core'
 import { BoosterConfig } from '@boostercloud/framework-types'
 import { AuthStack } from './auth-stack'
 import { EventsStack } from './events-stack'
@@ -72,73 +70,5 @@ export class ApplicationStackBuilder {
     })
 
     return rootAPI
-  }
-}
-
-function setupPermissions(
-  readModelTables: Array<Table>,
-  graphQLLambda: Function,
-  subscriptionDispatcherLambda: Function,
-  subscriptionsTable: Table,
-  websocketAPI: CfnApi,
-  eventsStore: Table,
-  eventsLambda: Function
-): void {
-  graphQLLambda.addToRolePolicy(
-    new PolicyStatement({
-      resources: [eventsStore.tableArn],
-      actions: ['dynamodb:Query*', 'dynamodb:Put*', 'dynamodb:BatchWriteItem'],
-    })
-  )
-  graphQLLambda.addToRolePolicy(
-    new PolicyStatement({
-      resources: [subscriptionsTable.tableArn],
-      actions: ['dynamodb:Put*', 'dynamodb:BatchWriteItem'],
-    })
-  )
-
-  subscriptionDispatcherLambda.addToRolePolicy(
-    new PolicyStatement({
-      resources: [subscriptionsTable.tableArn],
-      actions: ['dynamodb:Query*'],
-    })
-  )
-  subscriptionDispatcherLambda.addToRolePolicy(
-    new PolicyStatement({
-      resources: [
-        Fn.join(':', [
-          'arn',
-          Fn.ref('AWS::Partition'),
-          'execute-api',
-          Fn.ref('AWS::Region'),
-          Fn.ref('AWS::AccountId'),
-          `${websocketAPI.ref}/*`,
-        ]),
-      ],
-      actions: ['execute-api:ManageConnections'],
-    })
-  )
-
-  eventsLambda.addToRolePolicy(
-    new PolicyStatement({
-      resources: [eventsStore.tableArn],
-      actions: ['dynamodb:Query*', 'dynamodb:Put*', 'dynamodb:BatchWriteItem'],
-    })
-  )
-
-  const tableArns = readModelTables.map((table): string => table.tableArn)
-  if (tableArns.length > 0) {
-    eventsLambda.addToRolePolicy(
-      new PolicyStatement({
-        actions: ['dynamodb:Get*', 'dynamodb:Put*', 'dynamodb:BatchWriteItem'],
-        resources: tableArns,
-      })
-    )
-    graphQLLambda.addToRolePolicy(
-      new PolicyStatement({
-        actions: ['dynamodb:Query*', 'dynamodb:Scan*'],
-        resources: tableArns,
-      })
-    )
   }
 }

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/events-stack.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/events-stack.ts
@@ -17,9 +17,8 @@ export class EventsStack {
   public constructor(
     private readonly config: BoosterConfig,
     private readonly stack: Stack,
-    private readonly apis: APIs,
-  ) {
-  }
+    private readonly apis: APIs
+  ) {}
 
   public build(): EventsStackMembers {
     const eventsStore = this.buildEventsStore()

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
@@ -37,7 +37,9 @@ export const setupPermissions = (
     )
   )
 
-  eventsLambda.addToRolePolicy(createPolicyStatement([eventsStore.tableArn], ['dynamodb:Query*', 'dynamodb:Put*']))
+  eventsLambda.addToRolePolicy(
+    createPolicyStatement([eventsStore.tableArn], ['dynamodb:BatchWriteItem', 'dynamodb:Query*', 'dynamodb:Put*'])
+  )
 
   const tableArns = readModelTables.map((table): string => table.tableArn)
   if (tableArns.length > 0) {

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
@@ -1,7 +1,6 @@
 import { Table } from '@aws-cdk/aws-dynamodb'
 import { Function } from '@aws-cdk/aws-lambda'
 import { CfnApi } from '@aws-cdk/aws-apigatewayv2'
-import { Stream } from '@aws-cdk/aws-kinesis'
 import { Fn } from '@aws-cdk/core'
 import { createPolicyStatement } from './policies'
 
@@ -11,12 +10,11 @@ export const setupPermissions = (
   subscriptionDispatcherLambda: Function,
   subscriptionsTable: Table,
   websocketAPI: CfnApi,
-  eventsStream: Stream,
   eventsStore: Table,
   eventsLambda: Function
 ): void => {
   graphQLLambda.addToRolePolicy(
-    createPolicyStatement([eventsStream.streamArn], ['kinesis:Put*', 'dynamodb:Query*', 'dynamodb:Put*'])
+    createPolicyStatement([eventsStore.tableArn], ['dynamodb:BatchWriteItem', 'dynamodb:Query*', 'dynamodb:Put*'])
   )
   graphQLLambda.addToRolePolicy(createPolicyStatement([subscriptionsTable.tableArn], ['dynamodb:Put*']))
 

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/application-stack.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/application-stack.test.ts
@@ -38,7 +38,6 @@ describe('the application stack builder', () => {
 
     const restAPIName = appStackName + '-rest-api'
     const websocketAPIName = appStackName + '-websocket-api'
-    const eventsStreamName = 'events-stream'
     const eventsStore = 'events-store'
     const eventsLambda = 'events-main'
     const authorizerLambda = 'graphql-authorizer'
@@ -65,7 +64,6 @@ describe('the application stack builder', () => {
     expect(appStack.tryFindChild(graphQLLambda)).not.to.be.undefined
     expect(appStack.tryFindChild(subscriptionsNotifierLambda)).not.to.be.undefined
     // Events-related
-    expect(appStack.tryFindChild(eventsStreamName)).not.to.be.undefined
     expect(appStack.tryFindChild(eventsStore)).not.to.be.undefined
     // ReadModels
     readModels.forEach(({ name }) => expect(appStack.tryFindChild(name)).not.to.be.undefined)

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
@@ -14,7 +14,6 @@ describe('permissions', () => {
   })
 
   describe('setupPermissions', () => {
-    let mockEventStreamArn: string
     let mockSubscriptionsTableArn: string
     let mockReadModelTableArn: string
     let mockEventsStoreTableArn: string
@@ -41,7 +40,6 @@ describe('permissions', () => {
     let fnRefStub: SinonStub
 
     beforeEach(() => {
-      mockEventStreamArn = random.alphaNumeric(10)
       mockSubscriptionsTableArn = random.alphaNumeric(10)
       mockReadModelTableArn = random.alphaNumeric(10)
       mockEventsStoreTableArn = random.alphaNumeric(10)
@@ -100,11 +98,11 @@ describe('permissions', () => {
       })
 
       describe('policy statements', () => {
-        it('should add events stream permissions', () => {
+        it('should add events store permissions', () => {
           assert.calledWithExactly(
             createPolicyStatementStub,
-            [mockEventStreamArn],
-            ['kinesis:Put*', 'dynamodb:Query*', 'dynamodb:Put*']
+            [mockEventsStoreTableArn],
+            ['dynamodb:BatchWriteItem', 'dynamodb:Query*', 'dynamodb:Put*']
           )
         })
 
@@ -166,11 +164,11 @@ describe('permissions', () => {
       })
 
       describe('policy statements', () => {
-        it('should create events store table permissions', () => {
+        it('should add events store permissions', () => {
           assert.calledWithExactly(
             createPolicyStatementStub,
             [mockEventsStoreTableArn],
-            ['dynamodb:Query*', 'dynamodb:Put*']
+            ['dynamodb:BatchWriteItem', 'dynamodb:Query*', 'dynamodb:Put*']
           )
         })
 

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
@@ -2,7 +2,6 @@ import { Function } from '@aws-cdk/aws-lambda'
 import { setupPermissions } from '../../../src/infrastructure/stacks/permissions'
 import { Table } from '@aws-cdk/aws-dynamodb'
 import { CfnApi } from '@aws-cdk/aws-apigatewayv2'
-import { Stream } from '@aws-cdk/aws-kinesis'
 import { SinonStub, assert, stub, restore } from 'sinon'
 import { random } from 'faker'
 import * as policies from '../../../src/infrastructure/stacks/policies'
@@ -32,7 +31,6 @@ describe('permissions', () => {
     let mockReadModelTable: Table
     let mockReadModelTables: Array<Table>
     let mockWebsocketAPI: CfnApi
-    let mockEventStream: Stream
 
     let createPolicyStatementStub: SinonStub
     let graphQLAddToRolePolicyStub: SinonStub
@@ -60,10 +58,6 @@ describe('permissions', () => {
       mockGraphQLLambda = {} as Function
       mockSubscriptionDispatcherLambda = {} as Function
       mockEventsLambda = {} as Function
-
-      mockEventStream = {
-        streamArn: mockEventStreamArn,
-      } as Stream
 
       mockSubscriptionsTable = {
         tableArn: mockSubscriptionsTableArn,
@@ -93,7 +87,6 @@ describe('permissions', () => {
         mockSubscriptionDispatcherLambda,
         mockSubscriptionsTable,
         mockWebsocketAPI,
-        mockEventStream,
         mockEventsStoreTable,
         mockEventsLambda
       )

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   rawEventsToEnvelopes,
-  publishEvents,
+  storeEvents,
   readEntityLatestSnapshot,
   readEntityEventsSince,
 } from './library/events-adapter'
@@ -28,7 +28,7 @@ export const Provider: ProviderLibrary = {
     rawToEnvelopes: rawEventsToEnvelopes,
     forEntitySince: readEntityEventsSince.bind(null, dynamoDB),
     latestEntitySnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
-    publish: publishEvents.bind(null, dynamoDB),
+    store: storeEvents.bind(null, dynamoDB),
   },
   // ProviderReadModelsLibrary
   readModels: {

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -9,7 +9,7 @@ import {
 import { fetchReadModel, storeReadModel } from './library/read-model-adapter'
 import { rawGraphQLRequestToEnvelope } from './library/graphql-adapter'
 import { rawSignUpDataToUserEnvelope, authorizeRequest } from './library/auth-adapter'
-import { Kinesis, DynamoDB, CognitoIdentityServiceProvider } from 'aws-sdk'
+import { DynamoDB, CognitoIdentityServiceProvider } from 'aws-sdk'
 import { ProviderInfrastructure, ProviderLibrary } from '@boostercloud/framework-types'
 import { requestFailed, requestSucceeded } from './library/api-gateway-io'
 import { searchReadModel } from './library/searcher-adapter'
@@ -20,7 +20,6 @@ import {
   subscribeToReadModel,
 } from './library/subscription-adapter'
 
-const eventsStream: Kinesis = new Kinesis()
 const dynamoDB: DynamoDB.DocumentClient = new DynamoDB.DocumentClient()
 const userPool = new CognitoIdentityServiceProvider()
 

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -26,10 +26,9 @@ export const Provider: ProviderLibrary = {
   // ProviderEventsLibrary
   events: {
     rawToEnvelopes: rawEventsToEnvelopes,
-    store: storeEvent.bind(null, dynamoDB),
     forEntitySince: readEntityEventsSince.bind(null, dynamoDB),
     latestEntitySnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
-    storeAndPublish: publishEvents.bind(null, eventsStream),
+    storeAndPublish: storeAndPublishEvents.bind(null, dynamoDB),
   },
   // ProviderReadModelsLibrary
   readModels: {

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   rawEventsToEnvelopes,
-  storeEvent,
+  storeAndPublishEvents,
   readEntityLatestSnapshot,
   readEntityEventsSince,
-  publishEvents,
 } from './library/events-adapter'
 import { fetchReadModel, storeReadModel } from './library/read-model-adapter'
 import { rawGraphQLRequestToEnvelope } from './library/graphql-adapter'
@@ -30,7 +29,7 @@ export const Provider: ProviderLibrary = {
     store: storeEvent.bind(null, dynamoDB),
     forEntitySince: readEntityEventsSince.bind(null, dynamoDB),
     latestEntitySnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
-    publish: publishEvents.bind(null, eventsStream),
+    storeAndPublish: publishEvents.bind(null, eventsStream),
   },
   // ProviderReadModelsLibrary
   readModels: {

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   rawEventsToEnvelopes,
-  storeAndPublishEvents,
+  publishEvents,
   readEntityLatestSnapshot,
   readEntityEventsSince,
 } from './library/events-adapter'
@@ -28,7 +28,7 @@ export const Provider: ProviderLibrary = {
     rawToEnvelopes: rawEventsToEnvelopes,
     forEntitySince: readEntityEventsSince.bind(null, dynamoDB),
     latestEntitySnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
-    storeAndPublish: storeAndPublishEvents.bind(null, dynamoDB),
+    publish: publishEvents.bind(null, dynamoDB),
   },
   // ProviderReadModelsLibrary
   readModels: {

--- a/packages/framework-provider-aws/src/library/events-adapter.ts
+++ b/packages/framework-provider-aws/src/library/events-adapter.ts
@@ -82,13 +82,13 @@ export async function readEntityLatestSnapshot(
   }
 }
 
-export async function storeAndPublishEvents(
+export async function publishEvents(
   dynamoDB: DynamoDB.DocumentClient,
   eventEnvelopes: Array<EventEnvelope>,
   config: BoosterConfig,
   logger: Logger
 ): Promise<void> {
-  logger.debug('[EventsAdapter#storeAndPublishEvents] Storing EventEnvelopes with eventEnvelopes:', eventEnvelopes)
+  logger.debug('[EventsAdapter#publishEvents] Storing EventEnvelopes with eventEnvelopes:', eventEnvelopes)
   const params: DynamoDB.DocumentClient.BatchWriteItemInput = {
     RequestItems: {
       [config.resourceNames.eventsStore]: eventEnvelopes.map((eventEnvelope) => ({
@@ -107,5 +107,5 @@ export async function storeAndPublishEvents(
     },
   }
   await dynamoDB.batchWrite(params).promise()
-  logger.debug('[EventsAdapter#storeAndPublishEvents] EventEnvelope stored')
+  logger.debug('[EventsAdapter#publishEvents] EventEnvelope stored')
 }

--- a/packages/framework-provider-aws/src/library/events-adapter.ts
+++ b/packages/framework-provider-aws/src/library/events-adapter.ts
@@ -82,13 +82,13 @@ export async function readEntityLatestSnapshot(
   }
 }
 
-export async function publishEvents(
+export async function storeEvents(
   dynamoDB: DynamoDB.DocumentClient,
   eventEnvelopes: Array<EventEnvelope>,
   config: BoosterConfig,
   logger: Logger
 ): Promise<void> {
-  logger.debug('[EventsAdapter#publishEvents] Storing EventEnvelopes with eventEnvelopes:', eventEnvelopes)
+  logger.debug('[EventsAdapter#storeEvents] Storing EventEnvelopes with eventEnvelopes:', eventEnvelopes)
   const params: DynamoDB.DocumentClient.BatchWriteItemInput = {
     RequestItems: {
       [config.resourceNames.eventsStore]: eventEnvelopes.map((eventEnvelope) => ({
@@ -107,5 +107,5 @@ export async function publishEvents(
     },
   }
   await dynamoDB.batchWrite(params).promise()
-  logger.debug('[EventsAdapter#publishEvents] EventEnvelope stored')
+  logger.debug('[EventsAdapter#storeEvents] EventEnvelope stored')
 }

--- a/packages/framework-provider-aws/src/library/events-adapter.ts
+++ b/packages/framework-provider-aws/src/library/events-adapter.ts
@@ -1,9 +1,9 @@
-import { KinesisStreamEvent, KinesisStreamRecord } from 'aws-lambda'
+import { DynamoDBStreamEvent, DynamoDBRecord } from 'aws-lambda'
 import { BoosterConfig, EventEnvelope, Logger, UUID } from '@boostercloud/framework-types'
-import { DynamoDB, Kinesis } from 'aws-sdk'
+import { DynamoDB } from 'aws-sdk'
 import { eventStorePartitionKeyAttribute, eventStoreSortKeyAttribute } from '../constants'
 import { partitionKeyForEvent } from './partition-keys'
-import { PutRecordsRequestEntry } from 'aws-sdk/clients/kinesis'
+import { Converter } from 'aws-sdk/clients/dynamodb'
 
 // eslint-disable-next-line @typescript-eslint/no-magic-numbers
 const originOfTime = new Date(0).toISOString()
@@ -107,25 +107,8 @@ export async function readEntityLatestSnapshot(
   }
 }
 
-export async function publishEvents(
-  eventsStream: Kinesis,
-  eventEnvelopes: Array<EventEnvelope>,
-  config: BoosterConfig,
-  logger: Logger
-): Promise<void> {
-  logger.info('Publishing the following events:', eventEnvelopes)
-  const publishResult = await eventsStream
-    .putRecords({
-      StreamName: config.resourceNames.eventsStream,
-      Records: eventEnvelopes.map(toPutRecordsEntity),
-    })
-    .promise()
-  logger.debug('Events published with result', publishResult.$response)
-}
-
-function toPutRecordsEntity(eventEnvelope: EventEnvelope): PutRecordsRequestEntry {
-  return {
-    PartitionKey: partitionKeyForEvent(eventEnvelope.entityTypeName, eventEnvelope.entityID),
-    Data: Buffer.from(JSON.stringify(eventEnvelope)),
-  }
-}
+/**
+ * This function is a no-op on AWS, as DynamoDB emits an event
+ * that triggers the lambdas when the events are stored.
+ */
+export async function publishEvents(): Promise<void> {}

--- a/packages/framework-provider-aws/test/library/events-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/events-adapter.test.ts
@@ -81,7 +81,7 @@ describe('the events-adapter', () => {
     })
   })
 
-  describe('the `publishEvents` method', () => {
+  describe('the `storeEvents` method', () => {
     it('publishes the eventEnvelopes passed via parameter', async () => {
       const config = new BoosterConfig('test')
       config.appName = 'test-app'
@@ -122,7 +122,7 @@ describe('the events-adapter', () => {
         }
       )
 
-      await Library.publishEvents(fakeDynamo, eventEnvelopes, config, fakeLogger)
+      await Library.storeEvents(fakeDynamo, eventEnvelopes, config, fakeLogger)
 
       expect(fakeBatchWrite).to.be.calledWith(
         match({

--- a/packages/framework-provider-aws/test/library/events-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/events-adapter.test.ts
@@ -122,7 +122,7 @@ describe('the events-adapter', () => {
         }
       )
 
-      await Library.storeAndPublishEvents(fakeDynamo, eventEnvelopes, config, fakeLogger)
+      await Library.publishEvents(fakeDynamo, eventEnvelopes, config, fakeLogger)
 
       expect(fakeBatchWrite).to.be.calledWith(
         match({

--- a/packages/framework-provider-aws/test/library/events-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/events-adapter.test.ts
@@ -86,7 +86,7 @@ describe('the events-adapter', () => {
       const config = new BoosterConfig('test')
       config.appName = 'test-app'
       const requestID = 'request-id'
-      const streamName = config.resourceNames.eventsStream
+      const streamName = config.resourceNames.eventsStore
       const events = [
         {
           entityID(): UUID {
@@ -126,7 +126,7 @@ describe('the events-adapter', () => {
 
       expect(fakeBatchWrite).to.be.calledWith(
         match({
-          RequestItems: { [streamName]: match.has('length', 2) },
+          RequestItems: match.has(streamName, match.has('length', 2)),
         })
       )
     })

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -16,8 +16,6 @@ export const Provider: ProviderLibrary = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     rawToEnvelopes: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    store: undefined as any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     forEntitySince: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     latestEntitySnapshot: undefined as any,

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -22,7 +22,7 @@ export const Provider: ProviderLibrary = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     latestEntitySnapshot: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    publish: publishEvents.bind(null, eventRegistry),
+    storeAndPublish: publishEvents.bind(null, eventRegistry),
   },
   // ProviderReadModelsLibrary
   readModels: {

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -1,6 +1,6 @@
 import { ProviderLibrary, ProviderInfrastructure } from '@boostercloud/framework-types'
 import { rawSignUpDataToUserEnvelope } from './library/auth-adapter'
-import { publishEvents } from './library/events-adapter'
+import { storeEvents } from './library/events-adapter'
 import { requestSucceeded, requestFailed } from './library/api-adapter'
 import { EventRegistry } from './services'
 
@@ -20,7 +20,7 @@ export const Provider: ProviderLibrary = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     latestEntitySnapshot: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    publish: publishEvents.bind(null, eventRegistry),
+    store: storeEvents.bind(null, eventRegistry),
   },
   // ProviderReadModelsLibrary
   readModels: {

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -20,7 +20,7 @@ export const Provider: ProviderLibrary = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     latestEntitySnapshot: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    storeAndPublish: publishEvents.bind(null, eventRegistry),
+    publish: publishEvents.bind(null, eventRegistry),
   },
   // ProviderReadModelsLibrary
   readModels: {

--- a/packages/framework-provider-local/src/library/events-adapter.ts
+++ b/packages/framework-provider-local/src/library/events-adapter.ts
@@ -1,7 +1,7 @@
 import { Logger, BoosterConfig, EventEnvelope } from '@boostercloud/framework-types'
 import { EventRegistry } from '..'
 
-export async function publishEvents(
+export async function storeEvents(
   eventsStream: EventRegistry,
   eventEnvelopes: Array<EventEnvelope>,
   _config: BoosterConfig,

--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -47,7 +47,6 @@ export class BoosterConfig {
     const applicationStackName = this.appName + '-application-stack'
     return {
       applicationStack: applicationStackName,
-      eventsStream: applicationStackName + '-events-stream',
       eventsStore: applicationStackName + '-events-store',
       subscriptionsStore: applicationStackName + '-subscriptions-store',
       forReadModel(readModelName: string): string {
@@ -135,7 +134,6 @@ export class BoosterConfig {
 
 interface ResourceNames {
   applicationStack: string
-  eventsStream: string
   eventsStore: string
   subscriptionsStore: string
   forReadModel(entityName: string): string

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -23,8 +23,6 @@ export interface ProviderLibrary {
 
 export interface ProviderEventsLibrary {
   rawToEnvelopes(rawEvents: any): Array<EventEnvelope>
-  /** Stores an event in the event store */
-  store(config: BoosterConfig, logger: Logger, envelope: EventEnvelope): Promise<any>
   forEntitySince(
     config: BoosterConfig,
     logger: Logger,
@@ -39,7 +37,7 @@ export interface ProviderEventsLibrary {
     entityID: UUID
   ): Promise<EventEnvelope | null>
   /** Streams an event to the corresponding event handler */
-  publish(eventEnvelopes: Array<EventEnvelope>, config: BoosterConfig, logger: Logger): Promise<void>
+  storeAndPublish(eventEnvelopes: Array<EventEnvelope>, config: BoosterConfig, logger: Logger): Promise<void>
 }
 export interface ProviderReadModelsLibrary {
   fetch(config: BoosterConfig, logger: Logger, readModelName: string, readModelID: UUID): Promise<ReadModelInterface>

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -37,7 +37,7 @@ export interface ProviderEventsLibrary {
     entityID: UUID
   ): Promise<EventEnvelope | null>
   /** Streams an event to the corresponding event handler */
-  storeAndPublish(eventEnvelopes: Array<EventEnvelope>, config: BoosterConfig, logger: Logger): Promise<void>
+  publish(eventEnvelopes: Array<EventEnvelope>, config: BoosterConfig, logger: Logger): Promise<void>
 }
 export interface ProviderReadModelsLibrary {
   fetch(config: BoosterConfig, logger: Logger, readModelName: string, readModelID: UUID): Promise<ReadModelInterface>

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -37,7 +37,7 @@ export interface ProviderEventsLibrary {
     entityID: UUID
   ): Promise<EventEnvelope | null>
   /** Streams an event to the corresponding event handler */
-  publish(eventEnvelopes: Array<EventEnvelope>, config: BoosterConfig, logger: Logger): Promise<void>
+  store(eventEnvelopes: Array<EventEnvelope>, config: BoosterConfig, logger: Logger): Promise<void>
 }
 export interface ProviderReadModelsLibrary {
   fetch(config: BoosterConfig, logger: Logger, readModelName: string, readModelID: UUID): Promise<ReadModelInterface>

--- a/packages/framework-types/src/searcher.ts
+++ b/packages/framework-types/src/searcher.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Class } from './typelevel'
 
 export type SearcherFunction<TObject> = (className: string, filters: Record<string, Filter<any>>) => Promise<Array<any>>

--- a/packages/framework-types/test/config.test.ts
+++ b/packages/framework-types/test/config.test.ts
@@ -23,16 +23,6 @@ describe('the config type', () => {
       )
     })
 
-    it('gets the events stream name from the app name', () => {
-      fc.assert(
-        fc.property(fc.string(1, 10), (appName) => {
-          const cfg = new BoosterConfig('test')
-          cfg.appName = appName
-          expect(cfg.resourceNames.eventsStream).to.equal(`${appName}-application-stack-events-stream`)
-        })
-      )
-    })
-
     it('gets the events store name from the app name', () => {
       fc.assert(
         fc.property(fc.string(1, 10), (appName) => {


### PR DESCRIPTION
## Description

We were using Kinesis to guarantee the order of the events in the event store, but Kinesis price schema is not really "serverless" because it is billed by shards/month. This has two main drawbacks:

* It introduces a minimal fixed monthly price that made some early adopters reject trying the framework; Bad for beginners.
* It could easily become quite expensive or limit the application throughput for big applications; Bad for pro users too.

In this PR we replace Kinesis by DynamoDB Streams, which offer a nearly identical API with similar guarantees, and has a pure pay-per-use schema that also scales automatically.

_**Note:** This PR is a refurbished version of PR #85, which was already reviewed and approved. For this version review, focus on [the latest commit](https://github.com/theam/booster/pull/94/commits/d2022add1c213b98575712b62596b44b7af37fa0), which just renamed the event library method `storeAndPublish` as `publish` (because of [these reasons](https://github.com/theam/booster/pull/85#discussion_r430378492) and fixes tests._

## Changes
<Changes made>

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Project passes integration tests
- [x] Updated documentation accordingly (Done in another branch)
