### PR TITLE
Fix: Await for command handlers to finish

### DIFF
--- a/packages/framework-core/src/booster-command-dispatcher.ts
+++ b/packages/framework-core/src/booster-command-dispatcher.ts
@@ -36,7 +36,7 @@ export class BoosterCommandDispatcher {
     // the command inputted by the user.
     const register = new Register(commandEnvelope.requestID, commandEnvelope.currentUser)
     this.logger.debug('Calling "handle" method on command: ', command)
-    command.handle(register)
+    await command.handle(register)
     this.logger.debug('Command dispatched with register: ', register)
     await RegisterHandler.handle(this.config, this.logger, register)
   }

--- a/packages/framework-core/src/booster-register-handler.ts
+++ b/packages/framework-core/src/booster-register-handler.ts
@@ -10,6 +10,9 @@ import {
 
 export class RegisterHandler {
   public static async handle(config: BoosterConfig, logger: Logger, register: Register): Promise<void> {
+    if (register.eventList.length == 0) {
+      return
+    }
     return config.provider.events.store(
       register.eventList.map(RegisterHandler.wrapEvent.bind(null, register, config)),
       config,

--- a/packages/framework-core/test/booster-command-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-command-dispatcher.test.ts
@@ -73,7 +73,9 @@ describe('the `BoosterCommandsDispatcher`', () => {
         replace(RegisterHandler, 'handle', fake())
 
         let boosterConfig: any
-        Booster.configure('test', (config) => boosterConfig = config)
+        Booster.configure('test', (config) => {
+          boosterConfig = config
+        })
 
         await new BoosterCommandDispatcher(boosterConfig, logger).dispatchCommand({
           requestID: '1234',

--- a/packages/framework-core/test/booster-command-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-command-dispatcher.test.ts
@@ -32,7 +32,7 @@ describe('the `BoosterCommandsDispatcher`', () => {
         class PostComment {
           public constructor(readonly comment: string) {}
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          public handle(_register: Register): void {
+          public handle(_register: Register): Promise<void> {
             throw new Error('Not implemented')
           }
         }
@@ -55,6 +55,33 @@ describe('the `BoosterCommandsDispatcher`', () => {
             expect(RegisterHandler.handle).to.have.been.calledOnceWith(config, logger, match.instanceOf(Register))
           }
         )
+      })
+
+      it('waits for the handler method of a registered command to finish any async operation', async () => {
+        let asyncOperationFinished = false
+        @Command({ authorize: 'all' })
+        class PostComment {
+          public constructor(readonly comment: string) {}
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          public async handle(_register: Register): Promise<void> {
+            await new Promise((resolve) => setTimeout(resolve, 100))
+            asyncOperationFinished = true
+          }
+        }
+
+        const command = new PostComment('This test is good!')
+        replace(RegisterHandler, 'handle', fake())
+
+        let boosterConfig: any
+        Booster.configure('test', (config) => boosterConfig = config)
+
+        await new BoosterCommandDispatcher(boosterConfig, logger).dispatchCommand({
+          requestID: '1234',
+          version: 1,
+          typeName: 'PostComment',
+          value: command,
+        })
+        expect(asyncOperationFinished).to.be.true
       })
 
       it('fails if the command "version" is not sent', () => {

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -48,6 +48,21 @@ describe('the `RegisterHandler` class', () => {
     expect(config.provider.events.store).to.have.been.calledOnce
   })
 
+  it('does nothing when there are no events', async () => {
+    const config = new BoosterConfig('test')
+    config.provider = {
+      events: {
+        store: fake(),
+      },
+    } as any
+    config.reducers['SomeEvent'] = { class: SomeEntity, methodName: 'whatever' }
+
+    const register = new Register('1234')
+    await RegisterHandler.handle(config, logger, register)
+
+    expect(config.provider.events.store).to.not.have.been.called
+  })
+
   it('stores wrapped events', async () => {
     const config = new BoosterConfig('test')
     config.provider = {

--- a/packages/framework-core/test/decorators/command.test.ts
+++ b/packages/framework-core/test/decorators/command.test.ts
@@ -21,7 +21,7 @@ describe('the `Command` decorator', () => {
     class PostComment {
       public constructor(readonly comment: string) {}
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      public handle(_register: Register): void {
+      public handle(_register: Register): Promise<void> {
         throw new Error('Not implemented')
       }
     }

--- a/packages/framework-integration-tests/src/commands/change-cart-item.ts
+++ b/packages/framework-integration-tests/src/commands/change-cart-item.ts
@@ -8,7 +8,7 @@ import { ChangedCartItem } from '../events/changed-cart-item'
 export class ChangeCartItem {
   public constructor(readonly cartId: UUID, readonly productId: UUID, readonly quantity: number) {}
 
-  public handle(register: Register): void {
+  public async handle(register: Register): Promise<void> {
     register.events(new ChangedCartItem(this.cartId, this.productId, this.quantity))
   }
 }

--- a/packages/framework-integration-tests/src/commands/confirm-payment.ts
+++ b/packages/framework-integration-tests/src/commands/confirm-payment.ts
@@ -12,7 +12,7 @@ import { CartPaid } from '../events/cart-paid'
 export class ConfirmPayment {
   public constructor(readonly cartId: UUID, readonly confirmationToken: string) {}
 
-  public handle(register: Register): void {
+  public async handle(register: Register): Promise<void> {
     register.events(new CartPaid(this.cartId, this.confirmationToken))
   }
 }

--- a/packages/framework-integration-tests/src/commands/create-product.ts
+++ b/packages/framework-integration-tests/src/commands/create-product.ts
@@ -16,7 +16,7 @@ export class CreateProduct {
     readonly currency: string
   ) {}
 
-  public handle(register: Register): void {
+  public async handle(register: Register): Promise<void> {
     register.events(
       new ProductCreated(UUID.generate(), this.sku, this.displayName, this.description, {
         cents: this.priceInCents,

--- a/packages/framework-integration-tests/src/commands/delete-product.ts
+++ b/packages/framework-integration-tests/src/commands/delete-product.ts
@@ -9,7 +9,7 @@ import { Admin } from '../roles'
 export class DeleteProduct {
   public constructor(readonly productId: UUID) {}
 
-  public handle(register: Register): void {
+  public async handle(register: Register): Promise<void> {
     register.events(new ProductDeleted(this.productId))
   }
 }

--- a/packages/framework-integration-tests/src/commands/update-product.ts
+++ b/packages/framework-integration-tests/src/commands/update-product.ts
@@ -22,7 +22,7 @@ export class UpdateProduct {
     readonly reason: ProductUpdateReason = ProductUpdateReason.CatalogChange
   ) {}
 
-  public handle(register: Register): void {
+  public async handle(register: Register): Promise<void> {
     register.events(
       new ProductUpdated(
         this.id,

--- a/packages/framework-integration-tests/src/commands/update-shipping-address.ts
+++ b/packages/framework-integration-tests/src/commands/update-shipping-address.ts
@@ -9,7 +9,7 @@ import { UpdatedShippingAddress } from '../events/updated-shipping-address'
 export class UpdateShippingAddress {
   public constructor(readonly cartId: UUID, readonly address: Address) {}
 
-  public handle(register: Register): void {
+  public async handle(register: Register): Promise<void> {
     register.events(new UpdatedShippingAddress(this.cartId, this.address))
   }
 }

--- a/packages/framework-types/src/concepts/command.ts
+++ b/packages/framework-types/src/concepts/command.ts
@@ -7,7 +7,7 @@ import { RoleAccess } from './role'
  * All Command classes of your application must extend this class.
  */
 export interface CommandInterface {
-  handle(register: Register): void
+  handle(register: Register): Promise<void>
 }
 
 export interface CommandMetadata {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,9 +1655,9 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
 
 "@types/aws-lambda@^8.10.31", "@types/aws-lambda@^8.10.48":
-  version "8.10.51"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.51.tgz#7ad774507a3cf1d2e949ca305380c23b5af635a0"
-  integrity sha512-XK7RerpXj4r+IO0r7qIeNqUSU6L4qhPMwNhISxozJJiUX/jdXj9WYzTShRVisEcUQHXgJ4TTBqTArM8f9Mjb8g==
+  version "8.10.52"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.52.tgz#b019cc7e1819eaf86a9166383951d5ec4aa2d32e"
+  integrity sha512-Gm8hzCpdDj4/wlS8HA6nPPM5nHTF3Wjv/d6n7J2fdcJF4GtAIMbG7Wm8xKXY02K/Yqo8fzGw7PfbbkP9IeVlCg==
 
 "@types/body-parser@*":
   version "1.19.0"


### PR DESCRIPTION
## Description
This PR fixes a bug that happened always when the command handler does an asynchronous operation (uses `await` for example). Booster called the command handler without `await`, so the provider lambda finished before giving a chance to the command handler to finish.

## Changes
* The return type of command handlers is now `Promise<void>` as it should have been
* Added the corresponding await
* Do not handle events after the command handler finished if there were no events registered
* Added new tests for these new cases.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR
