### PR TITLE
[BOOST-571] adds command generation integration tests

### DIFF
--- a/packages/framework-integration-tests/.eslintignore
+++ b/packages/framework-integration-tests/.eslintignore
@@ -1,4 +1,4 @@
 dist
 lib
 node_modules
-test/fixtures
+integration/fixtures

--- a/packages/framework-integration-tests/integration/cli/cli.command.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.command.integration.ts
@@ -1,0 +1,65 @@
+import path = require('path')
+import util = require('util')
+import { expect } from 'chai'
+import { readFileContent, writeFileContent } from '../helper/fileHelper'
+
+const exec = util.promisify(require('child_process').exec)
+
+const COMMAND_AUTH_PLACEHOLDER = "// Specify authorized roles here. Use 'all' to authorize anyone"
+
+const FILE_CHANGE_CART_COMMAND = 'src/commands/ChangeCart.ts'
+const FILE_CHANGE_CART_WITH_FIELDS_COMMAND = 'src/commands/ChangeCartWithFields.ts'
+
+export const CLI_COMMAND_INTEGRATION_TEST_FILES: Array<string> = [
+  FILE_CHANGE_CART_COMMAND,
+  FILE_CHANGE_CART_WITH_FIELDS_COMMAND,
+]
+
+describe('Command', () => {
+  const cliPath = path.join('..', 'cli', 'bin', 'run')
+
+  context('Valid command', () => {
+    it('should create a new command', async () => {
+      const expectedOutputRegex = new RegExp(
+        /(.+) boost (.+)?new:command(.+)? (.+)\n- Verifying project\n(.+) Verifying project\n- Creating new command\n(.+) Creating new command\n(.+) Command generated!\n/
+      )
+
+      const { stdout } = await exec(`${cliPath} new:command ChangeCart`)
+      expect(stdout).to.match(expectedOutputRegex)
+
+      const expectedEntityContent = await readFileContent('integration/fixtures/commands/ChangeCart.ts')
+      const entityContent = await readFileContent(FILE_CHANGE_CART_COMMAND)
+      expect(entityContent).to.equal(expectedEntityContent)
+
+      // Set command auth
+      const updatedEntityContent = entityContent.replace(COMMAND_AUTH_PLACEHOLDER, "'all'")
+
+      writeFileContent(FILE_CHANGE_CART_COMMAND, updatedEntityContent)
+    })
+
+    describe('with fields', () => {
+      it('should create a new command with fields', async () => {
+        await exec(`${cliPath} new:command ChangeCartWithFields --fields cartId:UUID sku:string quantity:number`)
+
+        const expectedEntityContent = await readFileContent('integration/fixtures/commands/ChangeCartWithFields.ts')
+        const entityContent = await readFileContent(FILE_CHANGE_CART_WITH_FIELDS_COMMAND)
+        expect(entityContent).to.equal(expectedEntityContent)
+
+        // Set command auth
+        const updatedEntityContent = entityContent.replace(COMMAND_AUTH_PLACEHOLDER, "'all'")
+
+        writeFileContent(FILE_CHANGE_CART_WITH_FIELDS_COMMAND, updatedEntityContent)
+      })
+    })
+  })
+
+  context('Invalid command', () => {
+    describe('missing command name', () => {
+      it('should fail', async () => {
+        const { stderr } = await exec(`${cliPath} new:command`)
+
+        expect(stderr).to.equal("You haven't provided a command name, but it is required, run with --help for usage\n")
+      })
+    })
+  })
+})

--- a/packages/framework-integration-tests/integration/cli/cli.entity.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.entity.integration.ts
@@ -51,6 +51,35 @@ describe('Entity', () => {
         expect(entityContent).to.equal(expectedEntityContent)
       })
     })
+
+    describe('with reducer', () => {
+      it('should create new entity with reducer', async () => {
+        // Create event
+        await exec(`${cliPath} new:event PostCreated --fields postId:UUID title:string body:string`)
+        const expectedEventContent = readFileContent('integration/fixtures/events/PostCreated.ts')
+        const eventContent = readFileContent(FILE_POST_CREATED_EVENT)
+        expect(eventContent).to.equal(expectedEventContent)
+
+        // Set event entity ID
+        const updatedEventContent = eventContent.replace(EVENT_ENTITY_ID_PLACEHOLDER, 'this.postId')
+
+        writeFileContent('src/events/PostCreated.ts', updatedEventContent)
+
+        // Create entity
+        await exec(`${cliPath} new:entity PostWithReducer --fields title:string body:string --reduces PostCreated`)
+        const expectedEntityContent = readFileContent('integration/fixtures/entities/PostWithReducer.ts')
+        const entityContent = readFileContent(FILE_POST_WITH_REDUCER_ENTITY)
+        expect(entityContent).to.equal(expectedEntityContent)
+
+        // Set reducer response
+        const updatedEntityContent = entityContent.replace(
+          ENTITY_REDUCER_PLACEHOLDER,
+          'new PostWithReducer(event.postId, event.title, event.body)'
+        )
+
+        writeFileContent(FILE_POST_WITH_REDUCER_ENTITY, updatedEntityContent)
+      })
+    })
   })
 
   context('invalid entity', () => {
@@ -60,35 +89,6 @@ describe('Entity', () => {
 
         expect(stderr).to.equal("You haven't provided an entity name, but it is required, run with --help for usage\n")
       })
-    })
-  })
-
-  describe('entity with reducer', () => {
-    it('should create new entity with reducer', async () => {
-      // Create event
-      await exec(`${cliPath} new:event PostCreated --fields postId:UUID title:string body:string`)
-      const expectedEventContent = readFileContent('integration/fixtures/events/PostCreated.ts')
-      const eventContent = readFileContent(FILE_POST_CREATED_EVENT)
-      expect(eventContent).to.equal(expectedEventContent)
-
-      // Set event entity ID
-      const updatedEventContent = eventContent.replace(EVENT_ENTITY_ID_PLACEHOLDER, 'this.postId')
-
-      writeFileContent('src/events/PostCreated.ts', updatedEventContent)
-
-      // Create entity
-      await exec(`${cliPath} new:entity PostWithReducer --fields title:string body:string --reduces PostCreated`)
-      const expectedEntityContent = readFileContent('integration/fixtures/entities/PostWithReducer.ts')
-      const entityContent = readFileContent(FILE_POST_WITH_REDUCER_ENTITY)
-      expect(entityContent).to.equal(expectedEntityContent)
-
-      // Set reducer response
-      const updatedEntityContent = entityContent.replace(
-        ENTITY_REDUCER_PLACEHOLDER,
-        'new PostWithReducer(event.postId, event.title, event.body)'
-      )
-
-      writeFileContent(FILE_POST_WITH_REDUCER_ENTITY, updatedEntityContent)
     })
   })
 })

--- a/packages/framework-integration-tests/integration/cli/setup.ts
+++ b/packages/framework-integration-tests/integration/cli/setup.ts
@@ -2,10 +2,11 @@ import * as path from 'path'
 import util = require('util')
 import { removeFiles } from '../helper/fileHelper'
 import { CLI_ENTITY_INTEGRATION_TEST_FILES } from './cli.entity.integration'
+import { CLI_COMMAND_INTEGRATION_TEST_FILES } from './cli.command.integration'
 
 const exec = util.promisify(require('child_process').exec)
 
-const testFiles: Array<string> = [...CLI_ENTITY_INTEGRATION_TEST_FILES]
+const testFiles: Array<string> = [...CLI_ENTITY_INTEGRATION_TEST_FILES, ...CLI_COMMAND_INTEGRATION_TEST_FILES]
 
 before(async () => {
   const integrationTestsPackageRoot = path.dirname(__dirname)

--- a/packages/framework-integration-tests/integration/fixtures/commands/ChangeCart.ts
+++ b/packages/framework-integration-tests/integration/fixtures/commands/ChangeCart.ts
@@ -1,0 +1,14 @@
+import { Command } from '@boostercloud/framework-core'
+import { Register } from '@boostercloud/framework-types'
+
+@Command({
+  authorize: // Specify authorized roles here. Use 'all' to authorize anyone 
+})
+export class ChangeCart {
+  public constructor(
+  ) {}
+
+  public handle(register: Register): void {
+    register.events( /* YOUR EVENT HERE */)
+  }
+}

--- a/packages/framework-integration-tests/integration/fixtures/commands/ChangeCartWithFields.ts
+++ b/packages/framework-integration-tests/integration/fixtures/commands/ChangeCartWithFields.ts
@@ -1,0 +1,17 @@
+import { Command } from '@boostercloud/framework-core'
+import { Register, UUID } from '@boostercloud/framework-types'
+
+@Command({
+  authorize: // Specify authorized roles here. Use 'all' to authorize anyone 
+})
+export class ChangeCartWithFields {
+  public constructor(
+    readonly cartId: UUID,
+    readonly sku: string,
+    readonly quantity: number,
+  ) {}
+
+  public handle(register: Register): void {
+    register.events( /* YOUR EVENT HERE */)
+  }
+}


### PR DESCRIPTION
## Description
Create integration tests to check that the files generated are what it is expected. Also, verify that the code compiles.

## Changes
- Create integration tests for commands generation
- Check command generation error
- Little refactor to entity cli integration tests

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
