### PR TITLE
Updated Dependabot config to apply security updates exclusively

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     interval: daily
     time: '13:00'
   open-pull-requests-limit: 10
+  allowed_updates:
+    - match:
+      update_type: "security"
+  target_branch: "master"


### PR DESCRIPTION
Dependabot was bumping major versions with breaking changes, and tests were failing. We should only upgrade major dependency versions on purpose.

I also restricted the PRs to master to avoid duplicate PRs in mirrored repositories