### PR TITLE
[BOOST-575] adds type generation integration tests

### DIFF
--- a/packages/framework-integration-tests/integration/cli/cli.command.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.command.integration.ts
@@ -27,28 +27,28 @@ describe('Command', () => {
       const { stdout } = await exec(`${cliPath} new:command ChangeCart`)
       expect(stdout).to.match(expectedOutputRegex)
 
-      const expectedEntityContent = await readFileContent('integration/fixtures/commands/ChangeCart.ts')
-      const entityContent = await readFileContent(FILE_CHANGE_CART_COMMAND)
-      expect(entityContent).to.equal(expectedEntityContent)
+      const expectedCommandContent = await readFileContent('integration/fixtures/commands/ChangeCart.ts')
+      const commandContent = await readFileContent(FILE_CHANGE_CART_COMMAND)
+      expect(commandContent).to.equal(expectedCommandContent)
 
       // Set command auth
-      const updatedEntityContent = entityContent.replace(COMMAND_AUTH_PLACEHOLDER, "'all'")
+      const updatedCommandContent = commandContent.replace(COMMAND_AUTH_PLACEHOLDER, "'all'")
 
-      writeFileContent(FILE_CHANGE_CART_COMMAND, updatedEntityContent)
+      writeFileContent(FILE_CHANGE_CART_COMMAND, updatedCommandContent)
     })
 
     describe('with fields', () => {
       it('should create a new command with fields', async () => {
         await exec(`${cliPath} new:command ChangeCartWithFields --fields cartId:UUID sku:string quantity:number`)
 
-        const expectedEntityContent = await readFileContent('integration/fixtures/commands/ChangeCartWithFields.ts')
-        const entityContent = await readFileContent(FILE_CHANGE_CART_WITH_FIELDS_COMMAND)
-        expect(entityContent).to.equal(expectedEntityContent)
+        const expectedCommandContent = await readFileContent('integration/fixtures/commands/ChangeCartWithFields.ts')
+        const commandContent = await readFileContent(FILE_CHANGE_CART_WITH_FIELDS_COMMAND)
+        expect(commandContent).to.equal(expectedCommandContent)
 
         // Set command auth
-        const updatedEntityContent = entityContent.replace(COMMAND_AUTH_PLACEHOLDER, "'all'")
+        const updatedCommandContent = commandContent.replace(COMMAND_AUTH_PLACEHOLDER, "'all'")
 
-        writeFileContent(FILE_CHANGE_CART_WITH_FIELDS_COMMAND, updatedEntityContent)
+        writeFileContent(FILE_CHANGE_CART_WITH_FIELDS_COMMAND, updatedCommandContent)
       })
     })
   })

--- a/packages/framework-integration-tests/integration/cli/cli.type.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.type.integration.ts
@@ -1,0 +1,50 @@
+import path = require('path')
+import util = require('util')
+import { expect } from 'chai'
+import { readFileContent } from '../helper/fileHelper'
+
+const exec = util.promisify(require('child_process').exec)
+
+const FILE_CART_ITEM_TYPE = 'src/common/CartItem.ts'
+const FILE_CART_ITEM_WITH_FIELDS_TYPE = 'src/common/CartItemWithFields.ts'
+
+export const CLI_TYPE_INTEGRATION_TEST_FILES: Array<string> = [FILE_CART_ITEM_TYPE, FILE_CART_ITEM_WITH_FIELDS_TYPE]
+
+describe('Type', () => {
+  const cliPath = path.join('..', 'cli', 'bin', 'run')
+
+  context('Valid type', () => {
+    it('should create a new type', async () => {
+      const expectedOutputRegex = new RegExp(
+        /(.+) boost (.+)?new:type(.+)? (.+)\n- Verifying project\n(.+) Verifying project\n- Creating new type\n(.+) Creating new type\n(.+) Type generated!\n/
+      )
+
+      const { stdout } = await exec(`${cliPath} new:type CartItem`)
+      expect(stdout).to.match(expectedOutputRegex)
+
+      const expectedTypeContent = await readFileContent('integration/fixtures/common/CartItem.ts')
+      const typeContent = await readFileContent(FILE_CART_ITEM_TYPE)
+      expect(typeContent).to.equal(expectedTypeContent)
+    })
+
+    describe('with fields', () => {
+      it('should create a new type with fields', async () => {
+        await exec(`${cliPath} new:type CartItemWithFields --fields sku:string quantity:number`)
+
+        const expectedTypeContent = await readFileContent('integration/fixtures/common/CartItemWithFields.ts')
+        const typeContent = await readFileContent(FILE_CART_ITEM_WITH_FIELDS_TYPE)
+        expect(typeContent).to.equal(expectedTypeContent)
+      })
+    })
+  })
+
+  context('Invalid type', () => {
+    describe('missing type name', () => {
+      it('should fail', async () => {
+        const { stderr } = await exec(`${cliPath} new:type`)
+
+        expect(stderr).to.equal("You haven't provided a type name, but it is required, run with --help for usage\n")
+      })
+    })
+  })
+})

--- a/packages/framework-integration-tests/integration/cli/setup.ts
+++ b/packages/framework-integration-tests/integration/cli/setup.ts
@@ -3,10 +3,15 @@ import util = require('util')
 import { removeFiles } from '../helper/fileHelper'
 import { CLI_ENTITY_INTEGRATION_TEST_FILES } from './cli.entity.integration'
 import { CLI_COMMAND_INTEGRATION_TEST_FILES } from './cli.command.integration'
+import { CLI_TYPE_INTEGRATION_TEST_FILES } from './cli.type.integration'
 
 const exec = util.promisify(require('child_process').exec)
 
-const testFiles: Array<string> = [...CLI_ENTITY_INTEGRATION_TEST_FILES, ...CLI_COMMAND_INTEGRATION_TEST_FILES]
+const testFiles: Array<string> = [
+  ...CLI_ENTITY_INTEGRATION_TEST_FILES,
+  ...CLI_COMMAND_INTEGRATION_TEST_FILES,
+  ...CLI_TYPE_INTEGRATION_TEST_FILES,
+]
 
 before(async () => {
   const integrationTestsPackageRoot = path.dirname(__dirname)

--- a/packages/framework-integration-tests/integration/fixtures/common/CartItem.ts
+++ b/packages/framework-integration-tests/integration/fixtures/common/CartItem.ts
@@ -1,0 +1,2 @@
+export interface CartItem {
+}

--- a/packages/framework-integration-tests/integration/fixtures/common/CartItemWithFields.ts
+++ b/packages/framework-integration-tests/integration/fixtures/common/CartItemWithFields.ts
@@ -1,0 +1,4 @@
+export interface CartItemWithFields {
+  sku: string
+  quantity: number
+}


### PR DESCRIPTION
## Description
Create integration tests to check that the files generated are what it is expected.

## Changes
- Creates integration tests for types generation.
- Rename some variables in the commands generation tests.

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR


