### PR TITLE
docs: add markdownlintrc file so we can configure the linting of the docs

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,4 +1,5 @@
 {
+    "_comment": "Other rules are described here https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#rules",
     "default": true,
     "line-length": {
         "line_length": 90,

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,8 @@
+{
+    "default": true,
+    "line-length": {
+        "line_length": 90,
+        "code_blocks": false
+    },
+    "no-trailing-punctuation": false
+}


### PR DESCRIPTION
## Description
We are using a linter that can be configured via config file, I added that config file so we can fine-tune our markdown linting.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [x] Added a link pointing to the documentation PR in this PR

## Additional information
I linked the rules description in the config file to have them handy