### PR TITLE
BOOST-728: fix end to end tests

### DIFF
--- a/packages/framework-integration-tests/integration/end-to-end/setup.ts
+++ b/packages/framework-integration-tests/integration/end-to-end/setup.ts
@@ -1,0 +1,43 @@
+import util = require('util')
+const exec = util.promisify(require('child_process').exec)
+import { deploy, nuke } from '../../src/deploy'
+import { config } from 'aws-sdk'
+
+// TODO: remove the AWS config with BOOST-729 to make end-to-end tests provider unaware
+
+before(async () => {
+  await setEnv()
+  await checkConfigAnd(deploy)
+})
+
+after(async () => {
+  await checkConfigAnd(nuke)
+})
+
+async function setEnv(): Promise<void> {
+  if (!process.env.BOOSTER_APP_SUFFIX) {
+    // If the user doesn't set an app name suffix, use the current git commit hash
+    // to build a unique suffix for the application name in AWS to avoid collisions
+    // between tests from different branches.
+    const { stdout } = await exec('git rev-parse HEAD')
+    process.env['BOOSTER_APP_SUFFIX'] = stdout.trim().substring(0, 6)
+    console.log('setting BOOSTER_APP_SUFFIX=' + process.env.BOOSTER_APP_SUFFIX)
+  }
+}
+
+async function checkConfigAnd(action: () => Promise<void>): Promise<void> {
+  console.log('Checking AWS configuration...')
+  if (!config.credentials?.accessKeyId || !config.credentials?.secretAccessKey) {
+    throw new Error(
+      "AWS credentials were not properly loaded by the AWS SDK and are required to run the integration tests. Check that you've set them in your `~/.aws/credentials` file or environment variables. Refer to AWS documentation for more details https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html"
+    )
+  }
+  if (!config.region) {
+    throw new Error(
+      "AWS region was not properly loaded by the AWS SDK and is required to run the integration tests. Check that you've set it in your `~/.aws/config` file or AWS_REGION environment variable. Refer to AWS documentation for more details https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html#setting-region-order-of-precedence"
+    )
+  } else {
+    console.log('AWS Region set to ' + config.region)
+  }
+  await action()
+}

--- a/packages/framework-integration-tests/integration/providers/aws/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/setup.ts
@@ -9,7 +9,9 @@ before(async () => {
 })
 
 after(async () => {
-  await checkConfigAnd(nuke)
+  if (!process.env['FULL_INTEGRATION_TEST']) {
+    await checkConfigAnd(nuke)
+  }
 })
 
 async function setEnv(): Promise<void> {

--- a/packages/framework-integration-tests/package.json
+++ b/packages/framework-integration-tests/package.json
@@ -42,11 +42,11 @@
     "fix-lint": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
     "compile": "tsc -b tsconfig.json",
     "clean": "rimraf ./dist tsconfig.tsbuildinfo",
-    "integration": "yarn integration/aws && yarn integration/local && yarn integration/cli && yarn integration/end-to-end",
-    "integration/aws": "mocha --forbid-only --config \"integration/providers/aws/.mocharc.yml\" \"integration/providers/aws/**/*.integration.ts\"",
+    "integration": "FULL_INTEGRATION_TEST=true yarn integration/aws && yarn integration/local && yarn integration/cli && yarn integration/end-to-end",
+    "integration/aws": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --config \"integration/providers/aws/.mocharc.yml\" \"integration/providers/aws/**/*.integration.ts\"",
     "integration/local": "mocha --forbid-only --config \"integration/local/.mocharc.yml\" \"integration/local/**/*.integration.ts\"",
     "integration/cli": "mocha --forbid-only --config \"integration/cli/.mocharc.yml\" \"integration/cli/**/*.integration.ts\"",
-    "integration/end-to-end": "mocha --forbid-only --config \"integration/end-to-end/.mocharc.yml\" \"integration/end-to-end/**/*.integration.ts\""
+    "integration/end-to-end": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --config \"integration/end-to-end/.mocharc.yml\" \"integration/end-to-end/**/*.integration.ts\""
   },
   "types": "dist/index.d.ts",
   "gitHead": "121816dbe55d57df5860b54a871c06dcda761101"


### PR DESCRIPTION
## Description
Adds AWS configuration to end-to-end tests and update scripts to include the environment variable needed for AWS `AWS_SDK_LOAD_CONFIG=true`.
Added the flag `FULL_INTEGRATION_TEST`, which makes the AWS setup config to not nuke the application stack, allowing the end-to-end tests to reuse it and nuke it when it finishes, reducing the amount of times we have to deploy/nuke the test application stack.

## Changes
- Update integration scripts in `package.json`
- Add AWS setup in end-to-end `setup.ts`

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
