### PR TITLE
[BOOST-710] added kubernetes provider skeleton

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -163,6 +163,42 @@
       "internalConsoleOptions": "neverOpen",
       "protocol": "inspector",
       "cwd": "${workspaceFolder}/packages/framework-integration-tests"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "framework-provider-kubernetes tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-r",
+        "ts-node/register",
+        "--timeout",
+        "999999",
+        "--colors",
+        "--forbid-only",
+        "${workspaceFolder}/packages/framework-provider-kubernetes/test/**/*.test.ts"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "protocol": "inspector"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "framework-provider-kubernetes-infrastructure tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-r",
+        "ts-node/register",
+        "--timeout",
+        "999999",
+        "--colors",
+        "--forbid-only",
+        "${workspaceFolder}/packages/framework-provider-kubernetes-infrastructure/test/**/*.test.ts"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "protocol": "inspector"
     }
   ]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -6,6 +6,8 @@
     "packages/framework-provider-azure",
     "packages/framework-provider-local",
     "packages/framework-provider-local-infrastructure",
+    "packages/framework-provider-kubernetes",
+    "packages/framework-provider-kubernetes-infrastructure",
     "packages/framework-core",
     "packages/cli",
     "packages/framework-integration-tests"

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
     "packages/cli",
     "packages/framework-integration-tests"
   ],
-  "license": "Apache-2.0",
-  "dependencies": {
-    "yarn": "^1.22.4"
-  }
+  "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -39,9 +39,14 @@
     "packages/framework-provider-azure",
     "packages/framework-provider-local",
     "packages/framework-provider-local-infrastructure",
+    "packages/framework-provider-kubernetes",
+    "packages/framework-provider-kubernetes-infrastructure",
     "packages/framework-core",
     "packages/cli",
     "packages/framework-integration-tests"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "yarn": "^1.22.4"
+  }
 }

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -77,8 +77,6 @@ const getSelectedProviderPackage = (provider: Provider): string => {
   switch (provider) {
     case Provider.AWS:
       return '@boostercloud/framework-provider-aws'
-    case Provider.KUBERNETES:
-      return '@boostercloud/framework-provider-kubernetes'
     default:
       return ''
   }
@@ -92,7 +90,7 @@ const getProviderPackageName = async (prompter: Prompter, providerPackageName?: 
   const providerSelection: Provider = (await prompter.defaultOrChoose(
     providerPackageName,
     "What's the package name of your provider infrastructure library?",
-    [Provider.AWS, Provider.KUBERNETES, Provider.OTHER]
+    [Provider.AWS, Provider.OTHER]
   )) as Provider
 
   if (providerSelection === Provider.OTHER) {

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -77,6 +77,8 @@ const getSelectedProviderPackage = (provider: Provider): string => {
   switch (provider) {
     case Provider.AWS:
       return '@boostercloud/framework-provider-aws'
+    case Provider.KUBERNETES:
+      return '@boostercloud/framework-provider-kubernetes'
     default:
       return ''
   }
@@ -90,7 +92,7 @@ const getProviderPackageName = async (prompter: Prompter, providerPackageName?: 
   const providerSelection: Provider = (await prompter.defaultOrChoose(
     providerPackageName,
     "What's the package name of your provider infrastructure library?",
-    [Provider.AWS, Provider.OTHER]
+    [Provider.AWS, Provider.KUBERNETES, Provider.OTHER]
   )) as Provider
 
   if (providerSelection === Provider.OTHER) {

--- a/packages/cli/src/common/provider.ts
+++ b/packages/cli/src/common/provider.ts
@@ -1,4 +1,5 @@
 export const enum Provider {
   AWS = '@boostercloud/framework-provider-aws (AWS)',
+  KUBERNETES = "@boostercloud/framework-provider-kubernetes (Kubernetes)",
   OTHER = 'Other',
 }

--- a/packages/cli/src/common/provider.ts
+++ b/packages/cli/src/common/provider.ts
@@ -1,5 +1,4 @@
 export const enum Provider {
   AWS = '@boostercloud/framework-provider-aws (AWS)',
-  KUBERNETES = "@boostercloud/framework-provider-kubernetes (Kubernetes)",
   OTHER = 'Other',
 }

--- a/packages/framework-provider-kubernetes-infrastructure/.eslintignore
+++ b/packages/framework-provider-kubernetes-infrastructure/.eslintignore
@@ -1,0 +1,3 @@
+dist
+lib
+node_modules

--- a/packages/framework-provider-kubernetes-infrastructure/.mocharc.yml
+++ b/packages/framework-provider-kubernetes-infrastructure/.mocharc.yml
@@ -1,0 +1,10 @@
+diff: true
+require: 'ts-node/register'
+extension:
+  - ts
+package: './package.json'
+recursive: true
+reporter: 'spec'
+timeout: 5000
+full-trace: true
+bail: true

--- a/packages/framework-provider-kubernetes-infrastructure/package.json
+++ b/packages/framework-provider-kubernetes-infrastructure/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@boostercloud/framework-provider-kubernetes-infrastructure",
+  "version": "0.4.0",
+  "description": "Handle Booster's integration with Kubernetes",
+  "keywords": [
+    "framework-provider-kubernetes-infrastructure"
+  ],
+  "author": "Booster Cloud",
+  "homepage": "https://booster.cloud",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/boostercloud/booster.git"
+  },
+  "dependencies": {
+    "@boostercloud/framework-types": "^0.4.0",
+    "@boostercloud/framework-provider-kubernetes": "^0.4.0"
+  },
+  "scripts": {
+    "lint": "eslint --ext '.js,.ts' **/*.ts",
+    "fix-lint": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
+    "compile": "tsc -b tsconfig.json",
+    "clean": "rimraf ./dist tsconfig.tsbuildinfo",
+    "prepack": "tsc -b tsconfig.json",
+    "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
+  },
+  "bugs": {
+    "url": "https://github.com/boostercloud/booster/issues"
+  },
+  "devDependencies": {
+    "@types/faker": "^4.1.11",
+    "faker": "^4.1.0"
+  }
+}

--- a/packages/framework-provider-kubernetes-infrastructure/src/index.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/index.ts
@@ -1,0 +1,10 @@
+import { Observable, EMPTY } from 'rxjs'
+import { BoosterConfig } from '@boostercloud/framework-types'
+
+export function deploy(configuration: BoosterConfig): Observable<string> {
+  return EMPTY
+}
+
+export function nuke(configuration: BoosterConfig): Observable<string> {
+  return EMPTY
+}

--- a/packages/framework-provider-kubernetes-infrastructure/src/index.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/index.ts
@@ -1,4 +1,4 @@
-/*eslint no-unused-vars: [2, { "args": "none" }]*/
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Observable, EMPTY } from 'rxjs'
 import { BoosterConfig } from '@boostercloud/framework-types'
 

--- a/packages/framework-provider-kubernetes-infrastructure/src/index.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/index.ts
@@ -1,3 +1,4 @@
+/*eslint no-unused-vars: [2, { "args": "none" }]*/
 import { Observable, EMPTY } from 'rxjs'
 import { BoosterConfig } from '@boostercloud/framework-types'
 

--- a/packages/framework-provider-kubernetes-infrastructure/tsconfig.eslint.json
+++ b/packages/framework-provider-kubernetes-infrastructure/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}

--- a/packages/framework-provider-kubernetes-infrastructure/tsconfig.json
+++ b/packages/framework-provider-kubernetes-infrastructure/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/framework-provider-kubernetes/.eslintignore
+++ b/packages/framework-provider-kubernetes/.eslintignore
@@ -1,0 +1,3 @@
+dist
+lib
+node_modules

--- a/packages/framework-provider-kubernetes/.mocharc.yml
+++ b/packages/framework-provider-kubernetes/.mocharc.yml
@@ -1,0 +1,10 @@
+diff: true
+require: 'ts-node/register'
+extension:
+  - ts
+package: './package.json'
+recursive: true
+reporter: 'spec'
+timeout: 5000
+full-trace: true
+bail: true

--- a/packages/framework-provider-kubernetes/package.json
+++ b/packages/framework-provider-kubernetes/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@boostercloud/framework-provider-kubernetes",
+  "version": "0.4.0",
+  "description": "Handle Booster's integration with Kubernetes",
+  "keywords": [
+    "framework-provider-kubernetes"
+  ],
+  "author": "Booster Cloud",
+  "homepage": "https://booster.cloud",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/boostercloud/booster.git"
+  },
+  "dependencies": {
+    "@boostercloud/framework-types": "^0.4.0"
+  },
+  "scripts": {
+    "lint": "eslint --ext '.js,.ts' **/*.ts",
+    "fix-lint": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
+    "compile": "tsc -b tsconfig.json",
+    "clean": "rimraf ./dist tsconfig.tsbuildinfo",
+    "prepack": "tsc -b tsconfig.json",
+    "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
+  },
+  "bugs": {
+    "url": "https://github.com/boostercloud/booster/issues"
+  }
+}

--- a/packages/framework-provider-kubernetes/src/index.ts
+++ b/packages/framework-provider-kubernetes/src/index.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ProviderInfrastructure, ProviderLibrary } from '@boostercloud/framework-types'
+
+export const Provider: ProviderLibrary = {
+  // ProviderEventsLibrary
+  events: {
+    rawToEnvelopes: undefined as any,
+    store: undefined as any,
+    forEntitySince: undefined as any,
+    latestEntitySnapshot: undefined as any,
+  },
+  // ProviderReadModelsLibrary
+  readModels: {
+    fetch: undefined as any,
+    search: undefined as any,
+    subscribe: undefined as any,
+    rawToEnvelopes: undefined as any,
+    fetchSubscriptions: undefined as any,
+    notifySubscription: undefined as any,
+    store: undefined as any,
+  },
+  // ProviderGraphQLLibrary
+  graphQL: {
+    authorizeRequest: undefined as any,
+    rawToEnvelope: undefined as any,
+    handleResult: undefined as any,
+  },
+  // ProviderAuthLibrary
+  auth: {
+    rawToEnvelope: undefined as any,
+  },
+  // ProviderAPIHandling
+  api: {
+    requestSucceeded: undefined as any,
+    requestFailed: undefined as any,
+  },
+  // ProviderInfrastructureGetter
+  infrastructure: () =>
+    require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure,
+}

--- a/packages/framework-provider-kubernetes/tsconfig.eslint.json
+++ b/packages/framework-provider-kubernetes/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}

--- a/packages/framework-provider-kubernetes/tsconfig.json
+++ b/packages/framework-provider-kubernetes/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8264,11 +8264,6 @@ yargs@^15.0.2, yargs@^15.1.0:
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
 
-yarn@^1.22.4:
-  version "1.22.4"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.4.tgz#01c1197ca5b27f21edc8bc472cd4c8ce0e5a470e"
-  integrity sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA==
-
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8264,6 +8264,11 @@ yargs@^15.0.2, yargs@^15.1.0:
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
 
+yarn@^1.22.4:
+  version "1.22.4"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.4.tgz#01c1197ca5b27f21edc8bc472cd4c8ce0e5a470e"
+  integrity sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA==
+
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"


### PR DESCRIPTION
## Description
In this PR we are adding the foundations for the Kubernetes provider. The new provider is also added to the CLI because this feature is going to be implemented in a feature branch separated from master (check the base branch in this PR)

## Changes
 - Added the new packages `framework-provider-kubernetes` and `framework-provider-kubernetes-infrastructure`
 - Added all the minimum configuration stuff inside of each package
 - Added the new provider to the create-project command in the CLI.

## Checks
- [X] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
