### PR TITLE
Project generators integration tests

### DIFF
--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -40,18 +40,18 @@ describe('Project', () => {
   )
 
   const sendToStdin = (childProcess: ChildProcess, promptAnswers: Array<string>, delay: number) => {
-    let currentRepetitions = 0;
+    let currentRepetitions = 0
     const totalRepetitions = promptAnswers.length
     let answers: Array<string> = promptAnswers.slice()
 
-    let intervalID = setInterval(() => {
+    const intervalID = setInterval(() => {
       childProcess.stdin?.write(answers[0])
       answers = answers.slice(1)
 
       if (++currentRepetitions === totalRepetitions) {
-        clearInterval(intervalID);
+        clearInterval(intervalID)
       }
-    }, delay);
+    }, delay)
   }
 
   const execNewProject = (projectName: string, promptAnswers: Array<string> = [], flags: Array<string> = []) => {
@@ -64,6 +64,20 @@ describe('Project', () => {
 
       if (promptAnswers.length > 0) {
         sendToStdin(childProcess, promptAnswers, 1000)
+      }
+    })
+  }
+
+  const packageJsonAssertions = (expectedJson: string, jsonContent: string, objectsToCompareJustKeys: Array<string>, checkKeysAndValues: boolean = true) => {
+    const expectedJsonObj = JSON.parse(expectedJson)
+    const jsonContentObj = JSON.parse(jsonContent)
+
+    Object.entries(expectedJsonObj).forEach(([key, value]) => {
+      if (objectsToCompareJustKeys.includes(key)) {
+        expect(jsonContentObj.hasOwnProperty(key)).true
+        return packageJsonAssertions(JSON.stringify(expectedJsonObj[key]), JSON.stringify(jsonContentObj[key]), objectsToCompareJustKeys, false)
+      } else {
+        checkKeysAndValues ? expect(jsonContentObj[key]).to.deep.equals(expectedJsonObj[key]) : expect(jsonContentObj.hasOwnProperty(key)).true
       }
     })
   }
@@ -115,7 +129,8 @@ describe('Project', () => {
 
     const expectedCartDemoPackageJson = await readFileContent('integration/fixtures/cart-demo/package.json')
     const cartDemoPackageJsonContent = await readFileContent(CART_DEMO_PACKAGE_JSON)
-    expect(cartDemoPackageJsonContent).to.equal(expectedCartDemoPackageJson.replace(PROJECT_NAME_FIXTURE_PLACEHOLDER, projectName))
+    packageJsonAssertions(expectedCartDemoPackageJson.replace(PROJECT_NAME_FIXTURE_PLACEHOLDER, projectName),
+      cartDemoPackageJsonContent, ['dependencies', 'devDependencies'])
 
     const expectedCartDemoTsConfigEslint = await readFileContent('integration/fixtures/cart-demo/tsconfig.eslint.json')
     const cartDemoTsConfigEslintContent = await readFileContent(CART_DEMO_TS_CONFIG_ESLINT)
@@ -162,7 +177,7 @@ describe('Project', () => {
 
       it('should create a new project using a custom provider, and the project compiles', async () => {
         const projectName = CART_DEMO_CUSTOM_PROVIDER
-        const promptAnswers = [`${DESCRIPTION}\r\n'`, `${VERSION}\r\n`, `${AUTHOR}\r\n`, `${HOMEPAGE}\r\n`, `${LICENSE}\r\n`, `${REPO_URL}\r\n`, DOWN_KEY, `${PROVIDER}\r\n`]
+        const promptAnswers = [`${DESCRIPTION}\r\n'`, `${VERSION}\r\n`, `${AUTHOR}\r\n`, `${HOMEPAGE}\r\n`, `${LICENSE}\r\n`, `${REPO_URL}\r\n`, `${DOWN_KEY}\r\n`, `${PROVIDER}\r\n`]
         const stdout = await execNewProject(projectName, promptAnswers)
 
         await assertions(stdout, projectName)

--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -30,7 +30,7 @@ export const CLI_PROJECT_INTEGRATION_TEST_FOLDERS: Array<string> = [
   CART_DEMO_COMMAND_PROMPT,
   CART_DEMO_INVALID_PROVIDER,
   CART_DEMO_CUSTOM_PROVIDER,
-  CART_DEMO_FLAGS_AND_COMMAND_PROMPT
+  CART_DEMO_FLAGS_AND_COMMAND_PROMPT,
 ]
 
 describe('Project', () => {
@@ -56,11 +56,13 @@ describe('Project', () => {
 
   const execNewProject = (projectName: string, promptAnswers: Array<string> = [], flags: Array<string> = []) => {
     return new Promise<string>((resolve): void => {
-      const childProcess = require('child_process').exec(`${cliPath} new:project ${projectName} ${flags.join(' ')}`,
+      const childProcess = require('child_process').exec(
+        `${cliPath} new:project ${projectName} ${flags.join(' ')}`,
         (error: ExecException | null, stdout: string, stderr: string) => {
           childProcess.stdin.end()
           resolve(stdout)
-        })
+        }
+      )
 
       if (promptAnswers.length > 0) {
         sendToStdin(childProcess, promptAnswers, 1000)
@@ -68,16 +70,28 @@ describe('Project', () => {
     })
   }
 
-  const packageJsonAssertions = (expectedJson: string, jsonContent: string, objectsToCompareJustKeys: Array<string>, checkKeysAndValues: boolean = true) => {
+  const packageJsonAssertions = (
+    expectedJson: string,
+    jsonContent: string,
+    objectsToCompareJustKeys: Array<string>,
+    checkKeysAndValues = true
+  ) => {
     const expectedJsonObj = JSON.parse(expectedJson)
     const jsonContentObj = JSON.parse(jsonContent)
 
     Object.entries(expectedJsonObj).forEach(([key, value]) => {
       if (objectsToCompareJustKeys.includes(key)) {
-        expect(jsonContentObj.hasOwnProperty(key)).true
-        return packageJsonAssertions(JSON.stringify(expectedJsonObj[key]), JSON.stringify(jsonContentObj[key]), objectsToCompareJustKeys, false)
+        expect(Object.prototype.hasOwnProperty.call(jsonContentObj, key)).true
+        return packageJsonAssertions(
+          JSON.stringify(expectedJsonObj[key]),
+          JSON.stringify(jsonContentObj[key]),
+          objectsToCompareJustKeys,
+          false
+        )
       } else {
-        checkKeysAndValues ? expect(jsonContentObj[key]).to.deep.equals(expectedJsonObj[key]) : expect(jsonContentObj.hasOwnProperty(key)).true
+        checkKeysAndValues
+          ? expect(jsonContentObj[key]).to.deep.equals(expectedJsonObj[key])
+          : expect(Object.prototype.hasOwnProperty.call(jsonContentObj, key)).true
       }
     })
   }
@@ -105,7 +119,9 @@ describe('Project', () => {
 
     const expectedCartDemoConfig = await readFileContent('integration/fixtures/cart-demo/src/config/config.ts')
     const cartDemoConfigContent = await readFileContent(CART_DEMO_CONFIG)
-    expect(cartDemoConfigContent).to.equal(expectedCartDemoConfig.replace(PROJECT_NAME_FIXTURE_PLACEHOLDER, projectName))
+    expect(cartDemoConfigContent).to.equal(
+      expectedCartDemoConfig.replace(PROJECT_NAME_FIXTURE_PLACEHOLDER, projectName)
+    )
 
     const expectedCartDemoIndex = await readFileContent('integration/fixtures/cart-demo/src/index.ts')
     const cartDemoIndexContent = await readFileContent(CART_DEMO_INDEX)
@@ -129,8 +145,11 @@ describe('Project', () => {
 
     const expectedCartDemoPackageJson = await readFileContent('integration/fixtures/cart-demo/package.json')
     const cartDemoPackageJsonContent = await readFileContent(CART_DEMO_PACKAGE_JSON)
-    packageJsonAssertions(expectedCartDemoPackageJson.replace(PROJECT_NAME_FIXTURE_PLACEHOLDER, projectName),
-      cartDemoPackageJsonContent, ['dependencies', 'devDependencies'])
+    packageJsonAssertions(
+      expectedCartDemoPackageJson.replace(PROJECT_NAME_FIXTURE_PLACEHOLDER, projectName),
+      cartDemoPackageJsonContent,
+      ['dependencies', 'devDependencies']
+    )
 
     const expectedCartDemoTsConfigEslint = await readFileContent('integration/fixtures/cart-demo/tsconfig.eslint.json')
     const cartDemoTsConfigEslintContent = await readFileContent(CART_DEMO_TS_CONFIG_ESLINT)
@@ -151,7 +170,15 @@ describe('Project', () => {
       // TODO remove skip when '-h' flag works fine, now it's throwing an error
       it.skip('should create a new project using short flags to configure it, and the project compiles', async () => {
         const projectName = CART_DEMO_SHORT_FLAGS
-        const flags = [`-a "${AUTHOR}"`, `-d "${DESCRIPTION}"`, `-h "${HOMEPAGE}"`, `-l "${LICENSE}"`, `-p "${PROVIDER}"`, `-r "${REPO_URL}"`, `-v "${VERSION}"`]
+        const flags = [
+          `-a "${AUTHOR}"`,
+          `-d "${DESCRIPTION}"`,
+          `-h "${HOMEPAGE}"`,
+          `-l "${LICENSE}"`,
+          `-p "${PROVIDER}"`,
+          `-r "${REPO_URL}"`,
+          `-v "${VERSION}"`,
+        ]
         const stdout = await execNewProject(projectName, [], flags)
 
         await assertions(stdout, projectName)
@@ -159,7 +186,15 @@ describe('Project', () => {
 
       it('should create a new project using long flags to configure it, and the project compiles', async () => {
         const projectName = CART_DEMO_LONG_FLAGS
-        const flags = [`--author "${AUTHOR}"`, `--description "${DESCRIPTION}"`, `--homepage "${HOMEPAGE}"`, `--license "${LICENSE}"`, `--providerPackageName "${PROVIDER}"`, `--repository "${REPO_URL}"`, `--version "${VERSION}"`]
+        const flags = [
+          `--author "${AUTHOR}"`,
+          `--description "${DESCRIPTION}"`,
+          `--homepage "${HOMEPAGE}"`,
+          `--license "${LICENSE}"`,
+          `--providerPackageName "${PROVIDER}"`,
+          `--repository "${REPO_URL}"`,
+          `--version "${VERSION}"`,
+        ]
         const stdout = await execNewProject(projectName, [], flags)
 
         await assertions(stdout, projectName)
@@ -169,7 +204,15 @@ describe('Project', () => {
     describe('using command prompt', () => {
       it('should create a new project, and the project compiles', async () => {
         const projectName = CART_DEMO_COMMAND_PROMPT
-        const promptAnswers = [`${DESCRIPTION}\r\n'`, `${VERSION}\r\n`, `${AUTHOR}\r\n`, `${HOMEPAGE}\r\n`, `${LICENSE}\r\n`, `${REPO_URL}\r\n`, '\r\n']
+        const promptAnswers = [
+          `${DESCRIPTION}\r\n'`,
+          `${VERSION}\r\n`,
+          `${AUTHOR}\r\n`,
+          `${HOMEPAGE}\r\n`,
+          `${LICENSE}\r\n`,
+          `${REPO_URL}\r\n`,
+          '\r\n',
+        ]
         const stdout = await execNewProject(projectName, promptAnswers)
 
         await assertions(stdout, projectName)
@@ -177,7 +220,16 @@ describe('Project', () => {
 
       it('should create a new project using a custom provider, and the project compiles', async () => {
         const projectName = CART_DEMO_CUSTOM_PROVIDER
-        const promptAnswers = [`${DESCRIPTION}\r\n'`, `${VERSION}\r\n`, `${AUTHOR}\r\n`, `${HOMEPAGE}\r\n`, `${LICENSE}\r\n`, `${REPO_URL}\r\n`, `${DOWN_KEY}\r\n`, `${PROVIDER}\r\n`]
+        const promptAnswers = [
+          `${DESCRIPTION}\r\n'`,
+          `${VERSION}\r\n`,
+          `${AUTHOR}\r\n`,
+          `${HOMEPAGE}\r\n`,
+          `${LICENSE}\r\n`,
+          `${REPO_URL}\r\n`,
+          `${DOWN_KEY}\r\n`,
+          `${PROVIDER}\r\n`,
+        ]
         const stdout = await execNewProject(projectName, promptAnswers)
 
         await assertions(stdout, projectName)
@@ -187,7 +239,13 @@ describe('Project', () => {
     describe('using flags and command prompt', () => {
       it('should create a new project, and the project compiles', async () => {
         const projectName = CART_DEMO_FLAGS_AND_COMMAND_PROMPT
-        const promptAnswers = [`${DESCRIPTION}\r\n'`, `${VERSION}\r\n`, `${AUTHOR}\r\n`, `${HOMEPAGE}\r\n`, `${LICENSE}\r\n`]
+        const promptAnswers = [
+          `${DESCRIPTION}\r\n'`,
+          `${VERSION}\r\n`,
+          `${AUTHOR}\r\n`,
+          `${HOMEPAGE}\r\n`,
+          `${LICENSE}\r\n`,
+        ]
         const flags = [`--providerPackageName "${PROVIDER}"`, `--repository "${REPO_URL}"`]
         const stdout = await execNewProject(projectName, promptAnswers, flags)
 
@@ -210,7 +268,15 @@ describe('Project', () => {
         const expectedOutputRegex = new RegExp(
           /(.+) boost (.+)?new(.+)? (.+)\n- Creating project root\n(.+) Creating project root\n- Generating config files\n(.+) Generating config files\n- Installing dependencies\n(.+) Error: Could not install dependencies\n(.+)/
         )
-        const flags = [`--author "${AUTHOR}"`, `--description "${DESCRIPTION}"`, `--homepage "${HOMEPAGE}"`, `--license "${LICENSE}"`, '--providerPackageName "invalid-provider"', `--repository "${REPO_URL}"`, `--version "${VERSION}"`]
+        const flags = [
+          `--author "${AUTHOR}"`,
+          `--description "${DESCRIPTION}"`,
+          `--homepage "${HOMEPAGE}"`,
+          `--license "${LICENSE}"`,
+          '--providerPackageName "invalid-provider"',
+          `--repository "${REPO_URL}"`,
+          `--version "${VERSION}"`,
+        ]
         const stdout = await execNewProject(CART_DEMO_INVALID_PROVIDER, [], flags)
 
         expect(stdout).to.match(expectedOutputRegex)

--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -1,0 +1,205 @@
+import path = require('path')
+import util = require('util')
+import { expect } from 'chai'
+import { readFileContent } from '../helper/fileHelper'
+import * as fs from 'fs'
+import { ChildProcess, ExecException } from 'child_process'
+
+const exec = util.promisify(require('child_process').exec)
+
+const PROJECT_NAME_FIXTURE_PLACEHOLDER = 'project_name_fixture_placeholder'
+const TEST_TIMEOUT = 60000
+const DOWN_KEY = '\u001b[B'
+const DESCRIPTION = 'cart-demo'
+const VERSION = '1.0.0'
+const AUTHOR = 'The Agile Monkeys'
+const HOMEPAGE = 'https://www.booster.cloud/'
+const LICENSE = 'MIT'
+const REPO_URL = 'https://github.com/boostercloud/booster/'
+const PROVIDER = '@boostercloud/framework-provider-aws'
+const CART_DEMO_SHORT_FLAGS = 'cart-demo-short-flags'
+const CART_DEMO_LONG_FLAGS = 'cart-demo-long-flags'
+const CART_DEMO_COMMAND_PROMPT = 'cart-demo-command-prompt'
+const CART_DEMO_INVALID_PROVIDER = 'cart-demo-invalid-provider'
+const CART_DEMO_CUSTOM_PROVIDER = 'cart-demo-custom-provider'
+const CART_DEMO_FLAGS_AND_COMMAND_PROMPT = 'cart-demo-flags-and-command-prompt'
+
+export const CLI_PROJECT_INTEGRATION_TEST_FOLDERS: Array<string> = [
+  CART_DEMO_SHORT_FLAGS,
+  CART_DEMO_LONG_FLAGS,
+  CART_DEMO_COMMAND_PROMPT,
+  CART_DEMO_INVALID_PROVIDER,
+  CART_DEMO_CUSTOM_PROVIDER,
+  CART_DEMO_FLAGS_AND_COMMAND_PROMPT
+]
+
+describe('Project', () => {
+  const cliPath = path.join('..', 'cli', 'bin', 'run')
+  const expectedOutputRegex = new RegExp(
+    /(.+) boost (.+)?new(.+)? (.+)\n- Creating project root\n(.+) Creating project root\n- Generating config files\n(.+) Generating config files\n- Installing dependencies\n(.+) Installing dependencies\n(.+) Project generated!\n/
+  )
+
+  const sendToStdin = (childProcess: ChildProcess, promptAnswers: Array<string>, delay: number) => {
+    let currentRepetitions = 0;
+    const totalRepetitions = promptAnswers.length
+    let answers: Array<string> = promptAnswers.slice()
+
+    let intervalID = setInterval(() => {
+      childProcess.stdin?.write(answers[0])
+      answers = answers.slice(1)
+
+      if (++currentRepetitions === totalRepetitions) {
+        clearInterval(intervalID);
+      }
+    }, delay);
+  }
+
+  const execNewProject = (projectName: string, promptAnswers: Array<string> = [], flags: Array<string> = []) => {
+    return new Promise<string>((resolve): void => {
+      const childProcess = require('child_process').exec(`${cliPath} new:project ${projectName} ${flags.join(' ')}`,
+        (error: ExecException | null, stdout: string, stderr: string) => {
+          childProcess.stdin.end()
+          resolve(stdout)
+        })
+
+      if (promptAnswers.length > 0) {
+        sendToStdin(childProcess, promptAnswers, 1000)
+      }
+    })
+  }
+
+  const assertions = async (stdout: string, projectName: string) => {
+    const CART_DEMO_CONFIG = `${projectName}/src/config/config.ts`
+    const CART_DEMO_INDEX = `${projectName}/src/index.ts`
+    const CART_DEMO_ESLINT_IGNORE = `${projectName}/.eslintignore`
+    const CART_DEMO_ESLINT_RC = `${projectName}/.eslintrc.js`
+    const CART_DEMO_GIT_IGNORE = `${projectName}/.gitignore`
+    const CART_DEMO_PRETTIER_RC = `${projectName}/.prettierrc.yaml`
+    const CART_DEMO_PACKAGE_JSON = `${projectName}/package.json`
+    const CART_DEMO_TS_CONFIG_ESLINT = `${projectName}/tsconfig.eslint.json`
+    const CART_DEMO_TS_CONFIG = `${projectName}/tsconfig.json`
+
+    expect(stdout).to.match(expectedOutputRegex)
+
+    expect(fs.existsSync(`${projectName}/node_modules`)).true
+    expect(fs.existsSync(`${projectName}/package-lock.json`)).true
+    expect(fs.readdirSync(`${projectName}/src/commands`).length).equals(0)
+    expect(fs.readdirSync(`${projectName}/src/common`).length).equals(0)
+    expect(fs.readdirSync(`${projectName}/src/config`).length).equals(1)
+    expect(fs.readdirSync(`${projectName}/src/entities`).length).equals(0)
+    expect(fs.readdirSync(`${projectName}/src/events`).length).equals(0)
+
+    const expectedCartDemoConfig = await readFileContent('integration/fixtures/cart-demo/src/config/config.ts')
+    const cartDemoConfigContent = await readFileContent(CART_DEMO_CONFIG)
+    expect(cartDemoConfigContent).to.equal(expectedCartDemoConfig.replace(PROJECT_NAME_FIXTURE_PLACEHOLDER, projectName))
+
+    const expectedCartDemoIndex = await readFileContent('integration/fixtures/cart-demo/src/index.ts')
+    const cartDemoIndexContent = await readFileContent(CART_DEMO_INDEX)
+    expect(cartDemoIndexContent).to.equal(expectedCartDemoIndex)
+
+    const expectedCartDemoEslintIgnore = await readFileContent('integration/fixtures/cart-demo/.eslintignore')
+    const cartDemoEslintIgnoreContent = await readFileContent(CART_DEMO_ESLINT_IGNORE)
+    expect(cartDemoEslintIgnoreContent).to.equal(expectedCartDemoEslintIgnore)
+
+    const expectedCartDemoEslintRc = await readFileContent('integration/fixtures/cart-demo/.eslintrc.js')
+    const cartDemoEslintRcContent = await readFileContent(CART_DEMO_ESLINT_RC)
+    expect(cartDemoEslintRcContent).to.equal(expectedCartDemoEslintRc)
+
+    const expectedCartDemoGitIgnore = await readFileContent('integration/fixtures/cart-demo/.gitignore')
+    const cartDemoGitIgnoreContent = await readFileContent(CART_DEMO_GIT_IGNORE)
+    expect(cartDemoGitIgnoreContent).to.equal(expectedCartDemoGitIgnore)
+
+    const expectedCartDemoPretierRc = await readFileContent('integration/fixtures/cart-demo/.prettierrc.yaml')
+    const cartDemoPretierRcContent = await readFileContent(CART_DEMO_PRETTIER_RC)
+    expect(cartDemoPretierRcContent).to.equal(expectedCartDemoPretierRc)
+
+    const expectedCartDemoPackageJson = await readFileContent('integration/fixtures/cart-demo/package.json')
+    const cartDemoPackageJsonContent = await readFileContent(CART_DEMO_PACKAGE_JSON)
+    expect(cartDemoPackageJsonContent).to.equal(expectedCartDemoPackageJson.replace(PROJECT_NAME_FIXTURE_PLACEHOLDER, projectName))
+
+    const expectedCartDemoTsConfigEslint = await readFileContent('integration/fixtures/cart-demo/tsconfig.eslint.json')
+    const cartDemoTsConfigEslintContent = await readFileContent(CART_DEMO_TS_CONFIG_ESLINT)
+    expect(cartDemoTsConfigEslintContent).to.equal(expectedCartDemoTsConfigEslint)
+
+    const expectedCartDemoTsConfig = await readFileContent('integration/fixtures/cart-demo/tsconfig.json')
+    const cartDemoTsConfigContent = await readFileContent(CART_DEMO_TS_CONFIG)
+    expect(cartDemoTsConfigContent).to.equal(expectedCartDemoTsConfig)
+
+    process.chdir(projectName)
+    await exec('npm run compile')
+    await exec('npm run lint:check')
+    process.chdir('..')
+  }
+
+  context('Valid project', () => {
+    describe('using flags', () => {
+      // TODO remove skip when '-h' flag works fine, now it's throwing an error
+      it.skip('should create a new project using short flags to configure it, and the project compiles', async () => {
+        const projectName = CART_DEMO_SHORT_FLAGS
+        const flags = [`-a "${AUTHOR}"`, `-d "${DESCRIPTION}"`, `-h "${HOMEPAGE}"`, `-l "${LICENSE}"`, `-p "${PROVIDER}"`, `-r "${REPO_URL}"`, `-v "${VERSION}"`]
+        const stdout = await execNewProject(projectName, [], flags)
+
+        await assertions(stdout, projectName)
+      }).timeout(TEST_TIMEOUT)
+
+      it('should create a new project using long flags to configure it, and the project compiles', async () => {
+        const projectName = CART_DEMO_LONG_FLAGS
+        const flags = [`--author "${AUTHOR}"`, `--description "${DESCRIPTION}"`, `--homepage "${HOMEPAGE}"`, `--license "${LICENSE}"`, `--providerPackageName "${PROVIDER}"`, `--repository "${REPO_URL}"`, `--version "${VERSION}"`]
+        const stdout = await execNewProject(projectName, [], flags)
+
+        await assertions(stdout, projectName)
+      }).timeout(TEST_TIMEOUT)
+    })
+
+    describe('using command prompt', () => {
+      it('should create a new project, and the project compiles', async () => {
+        const projectName = CART_DEMO_COMMAND_PROMPT
+        const promptAnswers = [`${DESCRIPTION}\r\n'`, `${VERSION}\r\n`, `${AUTHOR}\r\n`, `${HOMEPAGE}\r\n`, `${LICENSE}\r\n`, `${REPO_URL}\r\n`, '\r\n']
+        const stdout = await execNewProject(projectName, promptAnswers)
+
+        await assertions(stdout, projectName)
+      }).timeout(TEST_TIMEOUT)
+
+      it('should create a new project using a custom provider, and the project compiles', async () => {
+        const projectName = CART_DEMO_CUSTOM_PROVIDER
+        const promptAnswers = [`${DESCRIPTION}\r\n'`, `${VERSION}\r\n`, `${AUTHOR}\r\n`, `${HOMEPAGE}\r\n`, `${LICENSE}\r\n`, `${REPO_URL}\r\n`, DOWN_KEY, `${PROVIDER}\r\n`]
+        const stdout = await execNewProject(projectName, promptAnswers)
+
+        await assertions(stdout, projectName)
+      }).timeout(TEST_TIMEOUT)
+    })
+
+    describe('using flags and command prompt', () => {
+      it('should create a new project, and the project compiles', async () => {
+        const projectName = CART_DEMO_FLAGS_AND_COMMAND_PROMPT
+        const promptAnswers = [`${DESCRIPTION}\r\n'`, `${VERSION}\r\n`, `${AUTHOR}\r\n`, `${HOMEPAGE}\r\n`, `${LICENSE}\r\n`]
+        const flags = [`--providerPackageName "${PROVIDER}"`, `--repository "${REPO_URL}"`]
+        const stdout = await execNewProject(projectName, promptAnswers, flags)
+
+        await assertions(stdout, projectName)
+      }).timeout(TEST_TIMEOUT)
+    })
+  })
+
+  context('Invalid project', () => {
+    describe('missing project name', () => {
+      it('should fail', async () => {
+        const { stderr } = await exec(`${cliPath} new:project`)
+
+        expect(stderr).to.equal("You haven't provided a project name, but it is required, run with --help for usage\n")
+      })
+    })
+
+    describe('using an invalid provider', () => {
+      it('should fail', async () => {
+        const expectedOutputRegex = new RegExp(
+          /(.+) boost (.+)?new(.+)? (.+)\n- Creating project root\n(.+) Creating project root\n- Generating config files\n(.+) Generating config files\n- Installing dependencies\n(.+) Error: Could not install dependencies\n(.+)/
+        )
+        const flags = [`--author "${AUTHOR}"`, `--description "${DESCRIPTION}"`, `--homepage "${HOMEPAGE}"`, `--license "${LICENSE}"`, '--providerPackageName "invalid-provider"', `--repository "${REPO_URL}"`, `--version "${VERSION}"`]
+        const stdout = await execNewProject(CART_DEMO_INVALID_PROVIDER, [], flags)
+
+        expect(stdout).to.match(expectedOutputRegex)
+      }).timeout(TEST_TIMEOUT)
+    })
+  })
+})

--- a/packages/framework-integration-tests/integration/cli/setup.ts
+++ b/packages/framework-integration-tests/integration/cli/setup.ts
@@ -1,11 +1,12 @@
 import * as path from 'path'
 import util = require('util')
-import { removeFiles } from '../helper/fileHelper'
+import { removeFiles, removeFolders } from '../helper/fileHelper'
 import { CLI_ENTITY_INTEGRATION_TEST_FILES } from './cli.entity.integration'
 import { CLI_COMMAND_INTEGRATION_TEST_FILES } from './cli.command.integration'
 import { CLI_TYPE_INTEGRATION_TEST_FILES } from './cli.type.integration'
 import { CLI_EVENTS_INTEGRATION_TEST_FILES } from './cli.event.integration'
 import { CLI_READ_MODEL_INTEGRATION_TEST_FILES } from './cli.readmodel.integration'
+import { CLI_PROJECT_INTEGRATION_TEST_FOLDERS } from './cli.project.integration'
 
 const exec = util.promisify(require('child_process').exec)
 
@@ -15,6 +16,10 @@ const testFiles: Array<string> = [
   ...CLI_TYPE_INTEGRATION_TEST_FILES,
  ...CLI_EVENTS_INTEGRATION_TEST_FILES,
   ...CLI_READ_MODEL_INTEGRATION_TEST_FILES,
+]
+
+const testFolders: Array<string> = [
+  ...CLI_PROJECT_INTEGRATION_TEST_FOLDERS
 ]
 
 before(async () => {
@@ -29,6 +34,7 @@ before(async () => {
 
   try {
     await Promise.all(removeFiles(testFiles))
+    await Promise.all(removeFolders(testFolders))
   } catch (e) {
     // error whilst deleting files
   }
@@ -42,5 +48,6 @@ after(async () => {
     console.log(e)
   } finally {
     await Promise.all(removeFiles(testFiles))
+    await Promise.all(removeFolders(testFolders))
   }
 })

--- a/packages/framework-integration-tests/integration/cli/setup.ts
+++ b/packages/framework-integration-tests/integration/cli/setup.ts
@@ -33,8 +33,10 @@ before(async () => {
   process.chdir('..')
 
   try {
-    await Promise.all(removeFiles(testFiles))
-    await Promise.all(removeFolders(testFolders))
+    await Promise.all([
+      ...removeFiles(testFiles),
+      ...removeFolders(testFolders),
+    ])
   } catch (e) {
     // error whilst deleting files
   }

--- a/packages/framework-integration-tests/integration/cli/setup.ts
+++ b/packages/framework-integration-tests/integration/cli/setup.ts
@@ -14,13 +14,20 @@ const testFiles: Array<string> = [
   ...CLI_ENTITY_INTEGRATION_TEST_FILES,
   ...CLI_COMMAND_INTEGRATION_TEST_FILES,
   ...CLI_TYPE_INTEGRATION_TEST_FILES,
- ...CLI_EVENTS_INTEGRATION_TEST_FILES,
+  ...CLI_EVENTS_INTEGRATION_TEST_FILES,
   ...CLI_READ_MODEL_INTEGRATION_TEST_FILES,
 ]
 
 const testFolders: Array<string> = [
   ...CLI_PROJECT_INTEGRATION_TEST_FOLDERS
 ]
+
+const removeGeneratedResources = () => {
+  return Promise.all([
+    ...removeFiles(testFiles),
+    ...removeFolders(testFolders),
+  ])
+}
 
 before(async () => {
   const integrationTestsPackageRoot = path.dirname(__dirname)
@@ -33,10 +40,7 @@ before(async () => {
   process.chdir('..')
 
   try {
-    await Promise.all([
-      ...removeFiles(testFiles),
-      ...removeFolders(testFolders),
-    ])
+    await removeGeneratedResources()
   } catch (e) {
     // error whilst deleting files
   }
@@ -49,7 +53,6 @@ after(async () => {
     // error whilst deleting files
     console.log(e)
   } finally {
-    await Promise.all(removeFiles(testFiles))
-    await Promise.all(removeFolders(testFolders))
+    await removeGeneratedResources()
   }
 })

--- a/packages/framework-integration-tests/integration/cli/setup.ts
+++ b/packages/framework-integration-tests/integration/cli/setup.ts
@@ -18,15 +18,10 @@ const testFiles: Array<string> = [
   ...CLI_READ_MODEL_INTEGRATION_TEST_FILES,
 ]
 
-const testFolders: Array<string> = [
-  ...CLI_PROJECT_INTEGRATION_TEST_FOLDERS
-]
+const testFolders: Array<string> = [...CLI_PROJECT_INTEGRATION_TEST_FOLDERS]
 
 const removeGeneratedResources = () => {
-  return Promise.all([
-    ...removeFiles(testFiles),
-    ...removeFolders(testFolders),
-  ])
+  return Promise.all([...removeFiles(testFiles), ...removeFolders(testFolders)])
 }
 
 before(async () => {

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/.eslintignore
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/.eslintignore
@@ -1,0 +1,3 @@
+dist
+lib
+node_modules

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/.eslintrc.js
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/.eslintrc.js
@@ -1,0 +1,50 @@
+module.exports = {
+  env: {
+    node: true,
+    es6: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+    'prettier/@typescript-eslint',
+    'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+  ],
+  globals: {
+    Atomics: 'readonly',
+    SharedArrayBuffer: 'readonly',
+  },
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    project: 'tsconfig.eslint.json',
+  },
+  rules: {
+    indent: ['error', 2, { SwitchCase: 1 }],
+    'linebreak-style': ['error', 'unix'],
+    quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }],
+    semi: ['error', 'never'],
+    '@typescript-eslint/generic-type-naming': ['error', '^T[A-Z][a-zA-Z]+$'],
+    'no-extra-parens': 'off',
+    '@typescript-eslint/no-extra-parens': ['error'],
+    'no-magic-numbers': 'off',
+    '@typescript-eslint/no-parameter-properties': 0,
+    '@typescript-eslint/no-floating-promises': ['error'],
+    '@typescript-eslint/array-type': [0, 'generic'],
+    '@typescript-eslint/no-use-before-define': 0,
+    '@typescript-eslint/no-var-requires': 0,
+    '@typescript-eslint/ban-ts-ignore': 0,
+    '@typescript-eslint/no-empty-function': 0,
+    '@typescript-eslint/explicit-function-return-type': [
+      'warn',
+      {
+        allowExpressions: true,
+        allowTypedFunctionExpressions: true,
+        allowHigherOrderFunctions: true,
+      },
+    ],
+  },
+}

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/.gitignore
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/.gitignore
@@ -1,0 +1,12 @@
+*-debug.log
+*-error.log
+.nyc_output
+dist/
+lib/
+package-lock.json
+tmp/
+node_modules
+*.tsbuildinfo
+.idea
+coverage
+.booster

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/.prettierrc.yaml
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/.prettierrc.yaml
@@ -1,0 +1,9 @@
+tabWidth: 2
+useTabs: false
+semi: false
+singleQuote: true
+quoteProps: 'as-needed'
+trailingComma: 'es5'
+bracketSpacing: true
+arrowParens: always
+printWidth: 120

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/package.json
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/package.json
@@ -4,25 +4,25 @@
   "version": "1.0.0",
   "author": "The Agile Monkeys",
   "dependencies": {
-    "@boostercloud/framework-core": "^0.4.1",
-    "@boostercloud/framework-types": "^0.4.1",
-    "@boostercloud/framework-provider-aws": "*"
+    "@boostercloud/framework-core": "whatever",
+    "@boostercloud/framework-types": "whatever",
+    "@boostercloud/framework-provider-aws": "whatever"
   },
   "devDependencies": {
-    "@boostercloud/cli": "^0.4.1",
-    "rimraf": "^3.0.1",
-    "@typescript-eslint/eslint-plugin": "^2.18.0",
-    "@typescript-eslint/parser": "^2.18.0",
-    "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
-    "eslint-plugin-prettier": "^3.1.2",
-    "mocha": "^7.0.1",
-    "nyc": "^15.0.0",
-    "prettier": "^1.19.1",
-    "typescript": "^3.7.5",
-    "ts-node": "^8.6.2",
-    "@types/node": "^13.5.1",
-    "@boostercloud/framework-provider-aws-infrastructure": "*"
+    "@boostercloud/cli": "whatever",
+    "rimraf": "whatever",
+    "@typescript-eslint/eslint-plugin": "whatever",
+    "@typescript-eslint/parser": "whatever",
+    "eslint": "whatever",
+    "eslint-config-prettier": "whatever",
+    "eslint-plugin-prettier": "whatever",
+    "mocha": "whatever",
+    "nyc": "whatever",
+    "prettier": "whatever",
+    "typescript": "whatever",
+    "ts-node": "whatever",
+    "@types/node": "whatever",
+    "@boostercloud/framework-provider-aws-infrastructure": "whatever"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/package.json
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "project_name_fixture_placeholder",
+  "description": "cart-demo",
+  "version": "1.0.0",
+  "author": "The Agile Monkeys",
+  "dependencies": {
+    "@boostercloud/framework-core": "^0.4.1",
+    "@boostercloud/framework-types": "^0.4.1",
+    "@boostercloud/framework-provider-aws": "*"
+  },
+  "devDependencies": {
+    "@boostercloud/cli": "^0.4.1",
+    "rimraf": "^3.0.1",
+    "@typescript-eslint/eslint-plugin": "^2.18.0",
+    "@typescript-eslint/parser": "^2.18.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "mocha": "^7.0.1",
+    "nyc": "^15.0.0",
+    "prettier": "^1.19.1",
+    "typescript": "^3.7.5",
+    "ts-node": "^8.6.2",
+    "@types/node": "^13.5.1",
+    "@boostercloud/framework-provider-aws-infrastructure": "*"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "homepage": "https://www.booster.cloud/",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "repository": "https://github.com/boostercloud/booster/",
+  "scripts": {
+    "lint:check": "eslint --ext '.js,.ts' **/*.ts",
+    "lint:fix": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
+    "compile": "tsc -b tsconfig.json",
+    "deploy": "boost deploy",
+    "clean": "rimraf ./dist tsconfig.tsbuildinfo",
+    "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
+  },
+  "types": "lib/index.d.ts"
+}

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/src/config/config.ts
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/src/config/config.ts
@@ -1,0 +1,8 @@
+import { Booster } from '@boostercloud/framework-core'
+import { BoosterConfig } from '@boostercloud/framework-types'
+import { Provider } from '@boostercloud/framework-provider-aws'
+
+Booster.configure('production', (config: BoosterConfig): void => {
+  config.appName = 'project_name_fixture_placeholder'
+  config.provider = Provider
+})

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/src/index.ts
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/src/index.ts
@@ -1,0 +1,11 @@
+import { Booster } from '@boostercloud/framework-core'
+export {
+  Booster,
+  boosterEventDispatcher,
+  boosterPreSignUpChecker,
+  boosterServeGraphQL,
+  boosterRequestAuthorizer,
+  boosterNotifySubscribers,
+} from '@boostercloud/framework-core'
+
+Booster.start()

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/tsconfig.eslint.json
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/tsconfig.json
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "importHelpers": true,
+    "module": "commonjs",
+    "strict": true,
+    "target": "es2017",
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/framework-integration-tests/integration/helper/fileHelper.ts
+++ b/packages/framework-integration-tests/integration/helper/fileHelper.ts
@@ -12,3 +12,12 @@ export const removeFiles = (filePaths: Array<string>): Array<Promise<void>> => {
     })
   })
 }
+
+export const removeFolders = (paths: Array<string>): Array<Promise<void>> => {
+  return paths.map((path: string) => {
+    return new Promise((resolve) => {
+      fs.rmdirSync(path, {recursive: true})
+      resolve()
+    })
+  })
+}


### PR DESCRIPTION
## Description
Add tests for project generators and checking that the generating files can be compiled.

## Changes
* CLI integration tests are added

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
I've been struggling with providing stdin inputs for the CLI prompts. Since these are integration tests, I didn't want to mock the prompt operation (provided by the library called [inquirer](https://www.npmjs.com/package/inquirer)), so I finally came up with an approach that is able to write in the writable stdin. I had to use an interval to send the answers, though. I've not found any other approach that worked fine so far. I found several articles to mock the prompt operation ([this is a good one by the way](https://glebbahmutov.com/blog/unit-testing-cli-programs/)), but I was not able to find a better approach for our use case. Feel free to discuss it!

I'll open an issue on GitHub to troubleshoot this issue `// TODO remove skip when '-h' flag works fine, now it's throwing an error`.