### PR TITLE
Update dependabot schedule interval to 1 week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
   target-branch: "master"
   versioning-strategy: lockfile-only


### PR DESCRIPTION
## Description
We are receiving a handful lot of PRs every day due to the frequency we have set for Dependabot to check. I suggest that we set that check to be run once a week.

## Changes
- Dependabot config updated

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly at [the docs repo](https://github.com/boostercloud/docs)
- [ ] Added a link pointing to the documentation PR in this PR

## Additional information
