### PR TITLE
Fix: error when static site bucket not found

### DIFF
--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/s3utils.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/s3utils.ts
@@ -1,22 +1,37 @@
 import { Subscriber } from 'rxjs'
 import { Mode, SDK } from 'aws-cdk'
 import { ObjectIdentifier, ObjectIdentifierList } from 'aws-sdk/clients/s3'
+import * as AWS from 'aws-sdk'
 
 export async function emptyS3Bucket(observer: Subscriber<string>, bucketName: string, aws: SDK): Promise<void> {
   observer.next(bucketName + ': DELETE_IN_PROGRESS')
-  const s3 = await aws.s3(await aws.defaultAccount(), await aws.defaultRegion(), Mode.ForWriting)
-  const listedObjects = await s3.listObjectVersions({ Bucket: bucketName }).promise()
-  const contents = (listedObjects.Versions || []).concat(listedObjects.DeleteMarkers || [])
-  if (contents.length > 0) {
-    const records: ObjectIdentifierList = contents.map(
-      (record) =>
-        ({
-          Key: record.Key,
-          VersionId: record.VersionId,
-        } as ObjectIdentifier)
-    )
-    await s3.deleteObjects({ Bucket: bucketName, Delete: { Objects: records } }).promise()
-    if (listedObjects.IsTruncated) await emptyS3Bucket(observer, bucketName, aws)
+  const s3: AWS.S3 = await aws.s3(await aws.defaultAccount(), await aws.defaultRegion(), Mode.ForWriting)
+
+  if (await s3BucketExists(bucketName, s3)) {
+    const listedObjects = await s3.listObjectVersions({ Bucket: bucketName }).promise()
+    const contents = (listedObjects.Versions || []).concat(listedObjects.DeleteMarkers || [])
+    if (contents.length > 0) {
+      const records: ObjectIdentifierList = contents.map(
+        (record) =>
+          ({
+            Key: record.Key,
+            VersionId: record.VersionId,
+          } as ObjectIdentifier),
+      )
+      await s3.deleteObjects({ Bucket: bucketName, Delete: { Objects: records } }).promise()
+      if (listedObjects.IsTruncated) await emptyS3Bucket(observer, bucketName, aws)
+    }
+    observer.next(bucketName + ': DELETE_COMPLETE')
+  } else {
+    observer.next(bucketName + ': BUCKET_NOT_FOUND : SKIPPING_DELETION')
   }
-  observer.next(bucketName + ': DELETE_COMPLETE')
+}
+
+export async function s3BucketExists(bucketName: string, s3: AWS.S3): Promise<boolean> {
+  try {
+    await s3.headBucket({ Bucket: bucketName }).promise()
+    return true
+  } catch (e) {
+    return false
+  }
 }

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/s3utils.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/s3utils.test.ts
@@ -1,0 +1,64 @@
+import { random } from 'faker'
+import { s3BucketExists } from '../../src/infrastructure/s3utils'
+import { SinonStub, stub } from 'sinon'
+import { expect } from '../expect'
+
+describe('s3 utils', () => {
+  let s3: any
+
+  describe('s3BucketExists', () => {
+    let bucketName: string
+
+    let promiseStub: SinonStub
+    let headBucketStub: SinonStub
+
+    beforeEach(() => {
+      bucketName = random.alphaNumeric(10)
+
+      promiseStub = stub()
+      headBucketStub = stub()
+    })
+
+    context('bucket found', () => {
+      beforeEach(() => {
+        promiseStub.resolves()
+
+        headBucketStub.returns({
+          promise: promiseStub,
+        })
+
+        s3 = {
+          headBucket: headBucketStub,
+        }
+      })
+
+      it('should return true', async () => {
+        const result = await s3BucketExists(bucketName, s3)
+
+        expect(headBucketStub).to.have.been.calledOnce
+        expect(result).to.be.true
+      })
+    })
+
+    context('an error is thrown', () => {
+      beforeEach(() => {
+        promiseStub.rejects()
+
+        headBucketStub.returns({
+          promise: promiseStub,
+        })
+
+        s3 = {
+          headBucket: headBucketStub,
+        }
+      })
+
+      it('should return false', async () => {
+        const result = await s3BucketExists(bucketName, s3)
+
+        expect(headBucketStub).to.have.been.calledOnce
+        expect(result).to.be.false
+      })
+    })
+  })
+})

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/s3utils.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/s3utils.test.ts
@@ -35,7 +35,7 @@ describe('s3 utils', () => {
       it('should return true', async () => {
         const result = await s3BucketExists(bucketName, s3)
 
-        expect(headBucketStub).to.have.been.calledOnce
+        expect(headBucketStub).to.have.been.calledOnceWith({ Bucket: bucketName })
         expect(result).to.be.true
       })
     })
@@ -56,7 +56,7 @@ describe('s3 utils', () => {
       it('should return false', async () => {
         const result = await s3BucketExists(bucketName, s3)
 
-        expect(headBucketStub).to.have.been.calledOnce
+        expect(headBucketStub).to.have.been.calledOnceWith({ Bucket: bucketName })
         expect(result).to.be.false
       })
     })


### PR DESCRIPTION
## Description
Handles the error returned when there isn't any static site bucket to be deleted

## Changes
- Create new function in `s3utils.ts` to check whether there is a bucket available
- Adds new logic to avoid deleting an inexistent bucket 

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly

## Additional information
