### PR TITLE
BOOST-754: change flag for homepage and unskip the short flag integration tests

### DIFF
--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -28,7 +28,7 @@ export default class Project extends Command {
       description: 'who is writing this?',
     }),
     homepage: flags.string({
-      char: 'h',
+      char: 'H',
       description: 'the website of this project',
     }),
     license: flags.string({

--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -167,13 +167,12 @@ describe('Project', () => {
 
   context('Valid project', () => {
     describe('using flags', () => {
-      // TODO remove skip when '-h' flag works fine, now it's throwing an error
-      it.skip('should create a new project using short flags to configure it, and the project compiles', async () => {
+      it('should create a new project using short flags to configure it, and the project compiles', async () => {
         const projectName = CART_DEMO_SHORT_FLAGS
         const flags = [
           `-a "${AUTHOR}"`,
           `-d "${DESCRIPTION}"`,
-          `-h "${HOMEPAGE}"`,
+          `-H "${HOMEPAGE}"`,
           `-l "${LICENSE}"`,
           `-p "${PROVIDER}"`,
           `-r "${REPO_URL}"`,


### PR DESCRIPTION
## Description
Update the flag for homepage when creating a new project with CLI.
Changed to `-H` since it's still related to the word. 
Unskipped the test related to short flags since it's working now.

If there is any other consensus on what letter to use, feel free to add it as a suggestion since the changes required for this to work are small enough

## Changes
- Update short flag to `-H`
- Unskip integration test

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [] Updated documentation accordingly

## Additional information
