### PR TITLE
Wait after integration tests deployment and before tests begin

### DIFF
--- a/packages/framework-integration-tests/integration/providers/aws/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/setup.ts
@@ -2,10 +2,14 @@ import util = require('util')
 const exec = util.promisify(require('child_process').exec)
 import { deploy, nuke } from '../../../src/deploy'
 import { config } from 'aws-sdk'
+import { sleep } from '../helpers'
 
 before(async () => {
   await setEnv()
   await checkConfigAnd(deploy)
+  console.log('Waiting 30 seconds after deployment to let the stack finish its initialization...')
+  await sleep(30000)
+  console.log('...sleep finished. Let the tests begin 🔥!')
 })
 
 after(async () => {

--- a/packages/framework-integration-tests/integration/providers/aws/subscriptions.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/subscriptions.integration.ts
@@ -37,28 +37,33 @@ describe('subscriptions', () => {
 
   describe('the "terminate" operation', () => {
     it('should delete al subscription of the connectionID when socket is disconnected', async () => {
-      const originalSubscriptionsCount = await countSubscriptionsItems()
-      const mockCartId = random.uuid()
-
-      // Let's create one subscription for one client
       const clientA = await graphQLClientWithSubscriptions()
-      cartSubscription(clientA, mockCartId).subscribe(() => {})
-
-      // Let's create two subscriptions for another client
       const clientB = await graphQLClientWithSubscriptions()
-      cartSubscription(clientB, mockCartId).subscribe(() => {})
-      cartSubscription(clientB, mockCartId).subscribe(() => {})
+      try {
+        const originalSubscriptionsCount = await countSubscriptionsItems()
+        const mockCartId = random.uuid()
 
-      // Wait for for the subscriptions to arrive
-      await waitForIt(countSubscriptionsItems, (newCount) => newCount == originalSubscriptionsCount + 3)
+        // Let's create one subscription for one client
+        cartSubscription(clientA, mockCartId).subscribe(() => {})
 
-      // Now we close the socket of client B and check its 2 subscriptions were deleted
-      clientB.disconnect()
-      await waitForIt(countSubscriptionsItems, (newCount) => newCount == originalSubscriptionsCount + 1)
+        // Let's create two subscriptions for another client
+        cartSubscription(clientB, mockCartId).subscribe(() => {})
+        cartSubscription(clientB, mockCartId).subscribe(() => {})
 
-      // Finally, close the socket of client A and check that we are back to the original count of subscriptions
-      clientA.disconnect()
-      await waitForIt(countSubscriptionsItems, (newCount) => newCount == originalSubscriptionsCount)
+        // Wait for for the subscriptions to arrive
+        await waitForIt(countSubscriptionsItems, (newCount) => newCount == originalSubscriptionsCount + 3)
+
+        // Now we close the socket of client B and check its 2 subscriptions were deleted
+        clientB.disconnect()
+        await waitForIt(countSubscriptionsItems, (newCount) => newCount == originalSubscriptionsCount + 1)
+
+        // Finally, close the socket of client A and check that we are back to the original count of subscriptions
+        clientA.disconnect()
+        await waitForIt(countSubscriptionsItems, (newCount) => newCount == originalSubscriptionsCount)
+      } catch (e) {
+        clientA.disconnect()
+        clientB.disconnect()
+      }
     })
   })
 })

--- a/packages/framework-integration-tests/integration/providers/aws/subscriptions.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/subscriptions.integration.ts
@@ -17,12 +17,11 @@ describe('subscriptions', () => {
     })
 
     it('should delete a subscription when the client calls "unsubscribe"', async () => {
-      const mockCartId = random.uuid()
       const originalSubscriptionsCount = await countSubscriptionsItems()
 
       // Let's create two subscriptions to the same read model
-      cartSubscription(client, mockCartId).subscribe(() => {})
-      const subscriptionObservable = cartSubscription(client, mockCartId).subscribe(() => {})
+      cartSubscription(client, random.uuid()).subscribe(() => {})
+      const subscriptionObservable = cartSubscription(client, random.uuid()).subscribe(() => {})
 
       // Wait for for the subscriptions to arrive
       await waitForIt(countSubscriptionsItems, (newCount) => newCount == originalSubscriptionsCount + 2)

--- a/packages/framework-integration-tests/integration/providers/aws/subscriptions.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/subscriptions.integration.ts
@@ -41,14 +41,13 @@ describe('subscriptions', () => {
       const clientB = await graphQLClientWithSubscriptions()
       try {
         const originalSubscriptionsCount = await countSubscriptionsItems()
-        const mockCartId = random.uuid()
 
         // Let's create one subscription for one client
-        cartSubscription(clientA, mockCartId).subscribe(() => {})
+        cartSubscription(clientA, random.uuid()).subscribe(() => {})
 
         // Let's create two subscriptions for another client
-        cartSubscription(clientB, mockCartId).subscribe(() => {})
-        cartSubscription(clientB, mockCartId).subscribe(() => {})
+        cartSubscription(clientB, random.uuid()).subscribe(() => {})
+        cartSubscription(clientB, random.uuid()).subscribe(() => {})
 
         // Wait for for the subscriptions to arrive
         await waitForIt(countSubscriptionsItems, (newCount) => newCount == originalSubscriptionsCount + 3)


### PR DESCRIPTION
## Description
After a whole day of chasing the random errors we were getting in integration tests, it turned out that we needed to wait for some time after the deployment of the AWS stack. 

This explains why the integration tests always worked in stacks that had been already deployed before, and not in new stacks that had been deployed right before the tests start.

I also took the opportunity to do some other reactors to increase the reliability of tests

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- ~[ ] Updated documentation accordingly~

## Additional information
