### PR TITLE
Disable line length for markdown linter

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,9 +1,6 @@
 {
     "_comment": "Other rules are described here https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#rules",
     "default": true,
-    "line-length": {
-        "line_length": 90,
-        "code_blocks": false
-    },
+    "line-length": false,
     "no-trailing-punctuation": false
 }


### PR DESCRIPTION
Most editors wrap lines at the desired column and this rule is making code review harder