### PR TITLE
[BOOST-870] Return value different from 0 for  compilation error

### DIFF
--- a/packages/cli/src/common/script.ts
+++ b/packages/cli/src/common/script.ts
@@ -110,7 +110,7 @@ export class Script<TContext> {
       const defaultHandler = (e: Error): string => e.stack || e.message
       const handler = this.errorHandlers[err.name] || defaultHandler
       Script.logger.fail(handler(err))
-      throw new Error(err)
+      throw new Error()
     }
   }
 

--- a/packages/cli/src/common/script.ts
+++ b/packages/cli/src/common/script.ts
@@ -109,7 +109,7 @@ export class Script<TContext> {
     } catch (err) {
       const defaultHandler = (e: Error): string => e.stack || e.message
       const handler = this.errorHandlers[err.name] || defaultHandler
-      Script.logger.fail(handler(err))
+      throw new Error(handler(err))
     }
   }
 

--- a/packages/cli/src/common/script.ts
+++ b/packages/cli/src/common/script.ts
@@ -109,8 +109,7 @@ export class Script<TContext> {
     } catch (err) {
       const defaultHandler = (e: Error): string => e.stack || e.message
       const handler = this.errorHandlers[err.name] || defaultHandler
-      Script.logger.fail(handler(err))
-      throw new Error()
+      throw new Error(handler(err))
     }
   }
 

--- a/packages/cli/src/common/script.ts
+++ b/packages/cli/src/common/script.ts
@@ -109,7 +109,8 @@ export class Script<TContext> {
     } catch (err) {
       const defaultHandler = (e: Error): string => e.stack || e.message
       const handler = this.errorHandlers[err.name] || defaultHandler
-      throw new Error(handler(err))
+      Script.logger.fail(handler(err))
+      throw new Error(err)
     }
   }
 

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -25,12 +25,9 @@ describe('deploy', () => {
         const fakeLoader = Promise.reject(new Error('weird exception'))
         const fakeDeployer = fake()
 
-        try {
-          await runTasks('test-env', fakeLoader, fakeDeployer)
-        } catch (err) {
-          expect(ctx.stdout).to.include('weird exception')
-          expect(fakeDeployer).not.to.have.been.called
-        }
+        await expect(runTasks('test-env', fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith()
+        expect(ctx.stdout).to.include('weird exception')
+        expect(fakeDeployer).not.to.have.been.called
       })
     })
 
@@ -39,13 +36,9 @@ describe('deploy', () => {
         const fakeLoader = Promise.reject(new Error('An error when loading project'))
         const fakeDeployer = fake()
 
-        try {
-          await runTasks('test-env', fakeLoader, fakeDeployer)
-        } catch (err) {
-          expect(ctx.stdout).to.include('An error when loading project')
-
-          expect(fakeDeployer).not.to.have.been.called
-        }
+        await expect(runTasks('test-env', fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith()
+        expect(ctx.stdout).to.include('An error when loading project')
+        expect(fakeDeployer).not.to.have.been.called
       })
     })
 

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -25,10 +25,12 @@ describe('deploy', () => {
         const fakeLoader = Promise.reject(new Error('weird exception'))
         const fakeDeployer = fake()
 
-        await runTasks('test-env', fakeLoader, fakeDeployer)
-
-        expect(ctx.stdout).to.include('weird exception')
-        expect(fakeDeployer).not.to.have.been.called
+        try {
+          await runTasks('test-env', fakeLoader, fakeDeployer)
+        } catch (err) {
+          expect(ctx.stdout).to.include('weird exception')
+          expect(fakeDeployer).not.to.have.been.called
+        }
       })
     })
 
@@ -37,11 +39,13 @@ describe('deploy', () => {
         const fakeLoader = Promise.reject(new Error('An error when loading project'))
         const fakeDeployer = fake()
 
-        await runTasks('test-env', fakeLoader, fakeDeployer)
+        try {
+          await runTasks('test-env', fakeLoader, fakeDeployer)
+        } catch (err) {
+          expect(ctx.stdout).to.include('An error when loading project')
 
-        expect(ctx.stdout).to.include('An error when loading project')
-
-        expect(fakeDeployer).not.to.have.been.called
+          expect(fakeDeployer).not.to.have.been.called
+        }
       })
     })
 

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -22,22 +22,22 @@ describe('deploy', () => {
   describe('runTasks function', () => {
     context('when an unexpected problem happens', () => {
       fancy.stdout().it('fails gracefully showing the error message', async (ctx) => {
-        const fakeLoader = Promise.reject(new Error('weird exception'))
+        const msg = 'weird exception'
+        const fakeLoader = Promise.reject(new Error(msg))
         const fakeDeployer = fake()
 
-        await expect(runTasks('test-env', fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith()
-        expect(ctx.stdout).to.include('weird exception')
+        await expect(runTasks('test-env', fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })
 
     context('when index.ts structure is not correct', () => {
       fancy.stdout().it('fails gracefully', async (ctx) => {
-        const fakeLoader = Promise.reject(new Error('An error when loading project'))
+        const msg = 'An error when loading project'
+        const fakeLoader = Promise.reject(new Error(msg))
         const fakeDeployer = fake()
 
-        await expect(runTasks('test-env', fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith()
-        expect(ctx.stdout).to.include('An error when loading project')
+        await expect(runTasks('test-env', fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })

--- a/packages/cli/test/commands/nuke.test.ts
+++ b/packages/cli/test/commands/nuke.test.ts
@@ -23,12 +23,9 @@ describe('nuke', () => {
         const fakeLoader = Promise.reject(new Error('weird exception'))
         const fakeNuke = fake()
 
-        try {
-          await runTasks('test-env', fakeLoader, fakeNuke)
-        } catch (err) {
-          expect(ctx.stdout).to.include('weird exception')
-          expect(fakeNuke).not.to.have.been.called
-        }
+        await expect(runTasks('test-env', fakeLoader, fakeNuke)).to.eventually.be.rejectedWith()
+        expect(ctx.stdout).to.include('weird exception')
+        expect(fakeNuke).not.to.have.been.called
       })
     })
 
@@ -48,12 +45,9 @@ describe('nuke', () => {
         replace(prompter, 'defaultOrPrompt', fakePrompter)
         const fakeNuke = fake()
 
-        try {
-          await runTasks('test-env', loader(prompter, false, fakeConfig), fakeNuke)
-        } catch (err) {
-          expect(ctx.stdout).to.include('Wrong app name, stopping nuke!')
-          expect(fakeNuke).not.to.have.been.called
-        }
+        await expect(runTasks('test-env', loader(prompter, false, fakeConfig), fakeNuke)).to.eventually.be.rejectedWith()
+        expect(ctx.stdout).to.include('Wrong app name, stopping nuke!')
+        expect(fakeNuke).not.to.have.been.called
       })
     })
 
@@ -73,12 +67,9 @@ describe('nuke', () => {
         replace(prompter, 'defaultOrPrompt', fakePrompter)
         const fakeNuke = fake()
 
-        try{
-          await runTasks('test-env', loader(prompter, true, fakeConfig), fakeNuke)
-        } catch (err) {
-          expect(prompter.defaultOrPrompt).not.to.have.been.called
-          expect(fakeNuke).to.have.been.calledOnce
-        }
+        await expect(runTasks('test-env', loader(prompter, true, fakeConfig), fakeNuke)).to.eventually.be.rejectedWith()
+        expect(prompter.defaultOrPrompt).not.to.have.been.called
+        expect(fakeNuke).to.have.been.calledOnce
       })
     })
 

--- a/packages/cli/test/commands/nuke.test.ts
+++ b/packages/cli/test/commands/nuke.test.ts
@@ -23,11 +23,12 @@ describe('nuke', () => {
         const fakeLoader = Promise.reject(new Error('weird exception'))
         const fakeNuke = fake()
 
-        await runTasks('test-env', fakeLoader, fakeNuke)
-
-        expect(ctx.stdout).to.include('weird exception')
-
-        expect(fakeNuke).not.to.have.been.called
+        try {
+          await runTasks('test-env', fakeLoader, fakeNuke)
+        } catch (err) {
+          expect(ctx.stdout).to.include('weird exception')
+          expect(fakeNuke).not.to.have.been.called
+        }
       })
     })
 
@@ -47,11 +48,12 @@ describe('nuke', () => {
         replace(prompter, 'defaultOrPrompt', fakePrompter)
         const fakeNuke = fake()
 
-        await runTasks('test-env', loader(prompter, false, fakeConfig), fakeNuke)
-
-        expect(ctx.stdout).to.include('Wrong app name, stopping nuke!')
-
-        expect(fakeNuke).not.to.have.been.called
+        try {
+          await runTasks('test-env', loader(prompter, false, fakeConfig), fakeNuke)
+        } catch (err) {
+          expect(ctx.stdout).to.include('Wrong app name, stopping nuke!')
+          expect(fakeNuke).not.to.have.been.called
+        }
       })
     })
 
@@ -71,10 +73,12 @@ describe('nuke', () => {
         replace(prompter, 'defaultOrPrompt', fakePrompter)
         const fakeNuke = fake()
 
-        await runTasks('test-env', loader(prompter, true, fakeConfig), fakeNuke)
-
-        expect(prompter.defaultOrPrompt).not.to.have.been.called
-        expect(fakeNuke).to.have.been.calledOnce
+        try{
+          await runTasks('test-env', loader(prompter, true, fakeConfig), fakeNuke)
+        } catch (err) {
+          expect(prompter.defaultOrPrompt).not.to.have.been.called
+          expect(fakeNuke).to.have.been.calledOnce
+        }
       })
     })
 

--- a/packages/cli/test/commands/nuke.test.ts
+++ b/packages/cli/test/commands/nuke.test.ts
@@ -20,11 +20,11 @@ describe('nuke', () => {
   describe('runTasks function', () => {
     context('when an unexpected problem happens', () => {
       fancy.stdout().it('fails gracefully showing the error message', async (ctx) => {
-        const fakeLoader = Promise.reject(new Error('weird exception'))
+        const msg = 'weird exception'
+        const fakeLoader = Promise.reject(new Error(msg))
         const fakeNuke = fake()
 
-        await expect(runTasks('test-env', fakeLoader, fakeNuke)).to.eventually.be.rejectedWith()
-        expect(ctx.stdout).to.include('weird exception')
+        await expect(runTasks('test-env', fakeLoader, fakeNuke)).to.eventually.be.rejectedWith(msg)
         expect(fakeNuke).not.to.have.been.called
       })
     })
@@ -45,8 +45,8 @@ describe('nuke', () => {
         replace(prompter, 'defaultOrPrompt', fakePrompter)
         const fakeNuke = fake()
 
-        await expect(runTasks('test-env', loader(prompter, false, fakeConfig), fakeNuke)).to.eventually.be.rejectedWith()
-        expect(ctx.stdout).to.include('Wrong app name, stopping nuke!')
+        await expect(runTasks('test-env', loader(prompter, false, fakeConfig), fakeNuke))
+          .to.eventually.be.rejectedWith('Wrong app name, stopping nuke!')
         expect(fakeNuke).not.to.have.been.called
       })
     })

--- a/packages/cli/test/commands/nuke.test.ts
+++ b/packages/cli/test/commands/nuke.test.ts
@@ -44,9 +44,10 @@ describe('nuke', () => {
         const fakePrompter = fake.resolves('fake app 2') // The user entered wrong app name
         replace(prompter, 'defaultOrPrompt', fakePrompter)
         const fakeNuke = fake()
+        const errorMsg = 'Wrong app name, stopping nuke!'
 
         await expect(runTasks('test-env', loader(prompter, false, fakeConfig), fakeNuke))
-          .to.eventually.be.rejectedWith('Wrong app name, stopping nuke!')
+          .to.eventually.be.rejectedWith(errorMsg)
         expect(fakeNuke).not.to.have.been.called
       })
     })
@@ -66,8 +67,9 @@ describe('nuke', () => {
         const fakePrompter = fake.resolves('fake app 2') // The user entered wrong app name
         replace(prompter, 'defaultOrPrompt', fakePrompter)
         const fakeNuke = fake()
+        const errorMsg = 'Cannot read property'
 
-        await expect(runTasks('test-env', loader(prompter, true, fakeConfig), fakeNuke)).to.eventually.be.rejectedWith()
+        await expect(runTasks('test-env', loader(prompter, true, fakeConfig), fakeNuke)).to.eventually.be.rejectedWith(errorMsg)
         expect(prompter.defaultOrPrompt).not.to.have.been.called
         expect(fakeNuke).to.have.been.calledOnce
       })

--- a/packages/cli/test/services/script-service.test.ts
+++ b/packages/cli/test/services/script-service.test.ts
@@ -64,27 +64,25 @@ describe('The Script class', () => {
       const fakeAction3 = stub().resolves()
       const { loggerFail } = replaceLogger(Script)
 
-      try {
-        await Script.init('initializing test', Promise.resolve(testContext))
-          .step('step', fakeAction1)
-          .step('step', fakeAction2)
-          .step('step', fakeAction3)
-          .done()
-      } catch (err) {
-        expect(fakeAction1).to.have.been.calledOnce
-        // @ts-ignore
-        expect(fakeAction1).to.have.been.calledBefore(fakeAction2)
-        expect(fakeAction1).to.have.been.calledOnceWith({ ctxParam: 'value' })
-        // @ts-ignore
-        expect(fakeAction1).to.have.been.calledBefore(fakeAction2)
+      await expect(Script.init('initializing test', Promise.resolve(testContext))
+        .step('step', fakeAction1)
+        .step('step', fakeAction2)
+        .step('step', fakeAction3)
+        .done()).to.eventually.be.rejectedWith()
 
-        expect(fakeAction2).to.have.been.calledOnceWith({ ctxParam: 'value' })
+      expect(fakeAction1).to.have.been.calledOnce
+      // @ts-ignore
+      expect(fakeAction1).to.have.been.calledBefore(fakeAction2)
+      expect(fakeAction1).to.have.been.calledOnceWith({ ctxParam: 'value' })
+      // @ts-ignore
+      expect(fakeAction1).to.have.been.calledBefore(fakeAction2)
 
-        expect(fakeAction3).not.to.have.been.called
-        expect(fakeAction2).to.have.been.calledOnceWith({ ctxParam: 'value' })
+      expect(fakeAction2).to.have.been.calledOnceWith({ ctxParam: 'value' })
 
-        expect(loggerFail).to.have.been.calledOnce
-      }
+      expect(fakeAction3).not.to.have.been.called
+      expect(fakeAction2).to.have.been.calledOnceWith({ ctxParam: 'value' })
+
+      expect(loggerFail).to.have.been.calledOnce
     })
 
     it('prints the provided message', async () => {
@@ -102,11 +100,8 @@ describe('The Script class', () => {
       const initializer = stub().rejects(err)
       const { loggerFail } = replaceLogger(Script)
 
-      try {
-        await Script.init(msg, initializer()).done()
-      } catch (error) {
-        expect(loggerFail).to.have.been.calledWithMatch(err.stack)
-      }
+      await expect(Script.init(msg, initializer()).done()).to.eventually.be.rejectedWith()
+      expect(loggerFail).to.have.been.calledWithMatch(err.stack)
     })
   })
 
@@ -146,16 +141,13 @@ describe('The Script class', () => {
       const stepFn = stub().rejects(err)
       const { loggerStart, loggerSucceed, loggerFail } = replaceLogger(Script)
 
-      try {
-        await Script.init('initializing', Promise.resolve(testContext))
-          .step(msg, stepFn)
-          .done()
-      } catch (error) {
-        expect(loggerStart).to.have.been.calledOnceWith(msg)
-        expect(loggerSucceed).not.to.have.been.called
-        expect(loggerFail).to.have.been.calledOnceWith(err.stack)
-        expect(stepFn).to.have.been.calledOnceWith(testContext)
-      }
+      await expect(Script.init('initializing', Promise.resolve(testContext))
+        .step(msg, stepFn)
+        .done()).to.eventually.be.rejectedWith()
+      expect(loggerStart).to.have.been.calledOnceWith(msg)
+      expect(loggerSucceed).not.to.have.been.called
+      expect(loggerFail).to.have.been.calledOnceWith(err.stack)
+      expect(stepFn).to.have.been.calledOnceWith(testContext)
     })
   })
 
@@ -165,13 +157,10 @@ describe('The Script class', () => {
       const msg = 'much nicer message'
       const { loggerFail } = replaceLogger(Script)
 
-      try {
-        await Script.init('initializing', Promise.reject(err))
-          .catch('SyntaxError', () => msg)
-          .done()
-      } catch (err) {
-        expect(loggerFail).to.have.been.calledOnceWith(msg)
-      }
+      await expect(Script.init('initializing', Promise.reject(err))
+        .catch('SyntaxError', () => msg)
+        .done()).to.eventually.be.rejectedWith()
+      expect(loggerFail).to.have.been.calledOnceWith(msg)
     })
 
     it('prints the error message for non specified error types', async () => {
@@ -179,13 +168,10 @@ describe('The Script class', () => {
       const err = new Error(msg)
       const { loggerFail } = replaceLogger(Script)
 
-      try {
-        await Script.init('initializing', Promise.reject(err))
-          .catch('SyntaxError', () => msg)
-          .done()
-      } catch (error) {
-        expect(loggerFail).to.have.been.calledOnceWith(err.stack)
-      }
+      await expect(Script.init('initializing', Promise.reject(err))
+        .catch('SyntaxError', () => msg)
+        .done()).to.eventually.be.rejectedWith()
+      expect(loggerFail).to.have.been.calledOnceWith(err.stack)
     })
   })
 })

--- a/packages/cli/test/services/script-service.test.ts
+++ b/packages/cli/test/services/script-service.test.ts
@@ -62,7 +62,6 @@ describe('The Script class', () => {
       const fakeAction1 = stub().resolves()
       const fakeAction2 = stub().rejects('some error')
       const fakeAction3 = stub().resolves()
-      const { loggerFail } = replaceLogger(Script)
 
       await expect(Script.init('initializing test', Promise.resolve(testContext))
         .step('step', fakeAction1)
@@ -81,8 +80,6 @@ describe('The Script class', () => {
 
       expect(fakeAction3).not.to.have.been.called
       expect(fakeAction2).to.have.been.calledOnceWith({ ctxParam: 'value' })
-
-      expect(loggerFail).to.have.been.calledOnce
     })
 
     it('prints the provided message', async () => {
@@ -96,12 +93,11 @@ describe('The Script class', () => {
 
     it('fails gracefully in case of initializer failure', async () => {
       const msg = 'initializing'
-      const err = new Error('some error')
+      const errorMessage = 'some error'
+      const err = new Error(errorMessage)
       const initializer = stub().rejects(err)
-      const { loggerFail } = replaceLogger(Script)
 
-      await expect(Script.init(msg, initializer()).done()).to.eventually.be.rejectedWith()
-      expect(loggerFail).to.have.been.calledWithMatch(err.stack)
+      await expect(Script.init(msg, initializer()).done()).to.eventually.be.rejectedWith(errorMessage)
     })
   })
 
@@ -139,14 +135,13 @@ describe('The Script class', () => {
       const err = new Error('some error')
       const msg = 'That is no step for anyone'
       const stepFn = stub().rejects(err)
-      const { loggerStart, loggerSucceed, loggerFail } = replaceLogger(Script)
+      const { loggerStart, loggerSucceed} = replaceLogger(Script)
 
       await expect(Script.init('initializing', Promise.resolve(testContext))
         .step(msg, stepFn)
         .done()).to.eventually.be.rejectedWith()
       expect(loggerStart).to.have.been.calledOnceWith(msg)
       expect(loggerSucceed).not.to.have.been.called
-      expect(loggerFail).to.have.been.calledOnceWith(err.stack)
       expect(stepFn).to.have.been.calledOnceWith(testContext)
     })
   })
@@ -155,23 +150,19 @@ describe('The Script class', () => {
     it('prints a custom error message for specified error types', async () => {
       const err = new SyntaxError('other message')
       const msg = 'much nicer message'
-      const { loggerFail } = replaceLogger(Script)
 
       await expect(Script.init('initializing', Promise.reject(err))
         .catch('SyntaxError', () => msg)
-        .done()).to.eventually.be.rejectedWith()
-      expect(loggerFail).to.have.been.calledOnceWith(msg)
+        .done()).to.eventually.be.rejectedWith(msg)
     })
 
     it('prints the error message for non specified error types', async () => {
       const msg = 'some message'
       const err = new Error(msg)
-      const { loggerFail } = replaceLogger(Script)
 
       await expect(Script.init('initializing', Promise.reject(err))
         .catch('SyntaxError', () => msg)
-        .done()).to.eventually.be.rejectedWith()
-      expect(loggerFail).to.have.been.calledOnceWith(err.stack)
+        .done()).to.eventually.be.rejectedWith(msg)
     })
   })
 })

--- a/packages/cli/test/services/script-service.test.ts
+++ b/packages/cli/test/services/script-service.test.ts
@@ -64,25 +64,27 @@ describe('The Script class', () => {
       const fakeAction3 = stub().resolves()
       const { loggerFail } = replaceLogger(Script)
 
-      await Script.init('initializing test', Promise.resolve(testContext))
-        .step('step', fakeAction1)
-        .step('step', fakeAction2)
-        .step('step', fakeAction3)
-        .done()
+      try {
+        await Script.init('initializing test', Promise.resolve(testContext))
+          .step('step', fakeAction1)
+          .step('step', fakeAction2)
+          .step('step', fakeAction3)
+          .done()
+      } catch (err) {
+        expect(fakeAction1).to.have.been.calledOnce
+        // @ts-ignore
+        expect(fakeAction1).to.have.been.calledBefore(fakeAction2)
+        expect(fakeAction1).to.have.been.calledOnceWith({ ctxParam: 'value' })
+        // @ts-ignore
+        expect(fakeAction1).to.have.been.calledBefore(fakeAction2)
 
-      expect(fakeAction1).to.have.been.calledOnce
-      // @ts-ignore
-      expect(fakeAction1).to.have.been.calledBefore(fakeAction2)
-      expect(fakeAction1).to.have.been.calledOnceWith({ ctxParam: 'value' })
-      // @ts-ignore
-      expect(fakeAction1).to.have.been.calledBefore(fakeAction2)
+        expect(fakeAction2).to.have.been.calledOnceWith({ ctxParam: 'value' })
 
-      expect(fakeAction2).to.have.been.calledOnceWith({ ctxParam: 'value' })
+        expect(fakeAction3).not.to.have.been.called
+        expect(fakeAction2).to.have.been.calledOnceWith({ ctxParam: 'value' })
 
-      expect(fakeAction3).not.to.have.been.called
-      expect(fakeAction2).to.have.been.calledOnceWith({ ctxParam: 'value' })
-
-      expect(loggerFail).to.have.been.calledOnce
+        expect(loggerFail).to.have.been.calledOnce
+      }
     })
 
     it('prints the provided message', async () => {
@@ -100,9 +102,11 @@ describe('The Script class', () => {
       const initializer = stub().rejects(err)
       const { loggerFail } = replaceLogger(Script)
 
-      await Script.init(msg, initializer()).done()
-
-      expect(loggerFail).to.have.been.calledOnceWith(err.stack)
+      try {
+        await Script.init(msg, initializer()).done()
+      } catch (error) {
+        expect(loggerFail).to.have.been.calledWithMatch(err.stack)
+      }
     })
   })
 
@@ -142,14 +146,16 @@ describe('The Script class', () => {
       const stepFn = stub().rejects(err)
       const { loggerStart, loggerSucceed, loggerFail } = replaceLogger(Script)
 
-      await Script.init('initializing', Promise.resolve(testContext))
-        .step(msg, stepFn)
-        .done()
-
-      expect(loggerStart).to.have.been.calledOnceWith(msg)
-      expect(loggerSucceed).not.to.have.been.called
-      expect(loggerFail).to.have.been.calledOnceWith(err.stack)
-      expect(stepFn).to.have.been.calledOnceWith(testContext)
+      try {
+        await Script.init('initializing', Promise.resolve(testContext))
+          .step(msg, stepFn)
+          .done()
+      } catch (error) {
+        expect(loggerStart).to.have.been.calledOnceWith(msg)
+        expect(loggerSucceed).not.to.have.been.called
+        expect(loggerFail).to.have.been.calledOnceWith(err.stack)
+        expect(stepFn).to.have.been.calledOnceWith(testContext)
+      }
     })
   })
 
@@ -159,11 +165,13 @@ describe('The Script class', () => {
       const msg = 'much nicer message'
       const { loggerFail } = replaceLogger(Script)
 
-      await Script.init('initializing', Promise.reject(err))
-        .catch('SyntaxError', () => msg)
-        .done()
-
-      expect(loggerFail).to.have.been.calledOnceWith(msg)
+      try {
+        await Script.init('initializing', Promise.reject(err))
+          .catch('SyntaxError', () => msg)
+          .done()
+      } catch (err) {
+        expect(loggerFail).to.have.been.calledOnceWith(msg)
+      }
     })
 
     it('prints the error message for non specified error types', async () => {
@@ -171,11 +179,13 @@ describe('The Script class', () => {
       const err = new Error(msg)
       const { loggerFail } = replaceLogger(Script)
 
-      await Script.init('initializing', Promise.reject(err))
-        .catch('SyntaxError', () => msg)
-        .done()
-
-      expect(loggerFail).to.have.been.calledOnceWith(err.stack)
+      try {
+        await Script.init('initializing', Promise.reject(err))
+          .catch('SyntaxError', () => msg)
+          .done()
+      } catch (error) {
+        expect(loggerFail).to.have.been.calledOnceWith(err.stack)
+      }
     })
   })
 })

--- a/packages/cli/test/services/script-service.test.ts
+++ b/packages/cli/test/services/script-service.test.ts
@@ -59,15 +59,16 @@ describe('The Script class', () => {
     })
 
     it('runs a sequence of successful actions and stops on failure', async () => {
+      const errorMsg = 'some error'
       const fakeAction1 = stub().resolves()
-      const fakeAction2 = stub().rejects('some error')
+      const fakeAction2 = stub().rejects(errorMsg)
       const fakeAction3 = stub().resolves()
 
       await expect(Script.init('initializing test', Promise.resolve(testContext))
         .step('step', fakeAction1)
         .step('step', fakeAction2)
         .step('step', fakeAction3)
-        .done()).to.eventually.be.rejectedWith()
+        .done()).to.eventually.be.rejectedWith(errorMsg)
 
       expect(fakeAction1).to.have.been.calledOnce
       // @ts-ignore
@@ -132,14 +133,15 @@ describe('The Script class', () => {
     })
 
     it('fails gracefully on step function failure', async () => {
-      const err = new Error('some error')
+      const errorMsg = 'some error'
+      const err = new Error(errorMsg)
       const msg = 'That is no step for anyone'
       const stepFn = stub().rejects(err)
       const { loggerStart, loggerSucceed} = replaceLogger(Script)
 
       await expect(Script.init('initializing', Promise.resolve(testContext))
         .step(msg, stepFn)
-        .done()).to.eventually.be.rejectedWith()
+        .done()).to.eventually.be.rejectedWith(errorMsg)
       expect(loggerStart).to.have.been.calledOnceWith(msg)
       expect(loggerSucceed).not.to.have.been.called
       expect(stepFn).to.have.been.calledOnceWith(testContext)

--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -265,7 +265,7 @@ describe('Project', () => {
     describe('using an invalid provider', () => {
       it('should fail', async () => {
         const expectedOutputRegex = new RegExp(
-          /(.+) boost (.+)?new(.+)? (.+)\n- Creating project root\n(.+) Creating project root\n- Generating config files\n(.+) Generating config files\n- Installing dependencies\n/
+          /(.+) boost (.+)?new(.+)? (.+)\n- Creating project root\n(.+) Creating project root\n- Generating config files\n(.+) Generating config files\n- Installing dependencies\n(.+) Error: Could not install dependencies\n(.+)/
         )
         const flags = [
           `--author "${AUTHOR}"`,

--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -265,7 +265,7 @@ describe('Project', () => {
     describe('using an invalid provider', () => {
       it('should fail', async () => {
         const expectedOutputRegex = new RegExp(
-          /(.+) boost (.+)?new(.+)? (.+)\n- Creating project root\n(.+) Creating project root\n- Generating config files\n(.+) Generating config files\n- Installing dependencies\n(.+) Error: Could not install dependencies\n(.+)/
+          /(.+) boost (.+)?new(.+)? (.+)\n- Creating project root\n(.+) Creating project root\n- Generating config files\n(.+) Generating config files\n- Installing dependencies\n/
         )
         const flags = [
           `--author "${AUTHOR}"`,


### PR DESCRIPTION
## Description
When a compilation error happens, even if the error is logged the return value is actually 0. This is problematic when integrating booster applications with CD tools like Circle CI. As described in the ticket https://agilemonkeys.atlassian.net/browse/BOOST-870 the deploy step was marked successful because of the return value.

## Changes
Throw an exception instead of just logging the error.

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly

## Additional information
Also ran `lerna run integration/cli` to run the integration tests for the CLI package where all the changes happen. 