### PR TITLE
Add graphqlws subprotocol to the subscription part of the documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1821,10 +1821,10 @@ in the *connection operation*, the **access token** in the **"Authorization"** h
 > Connecting to the web socket:
 
 ```sh
- wscat -c <websocketURL> -s graphqlws
+ wscat -c <websocketURL> -s graphql-ws
 ```
 
-**Note:** You should specify the `graphqlws` subprotocol to your clients via the `Sec-WebSocket-Protocol` header.
+**Note:** You should specify the `graphql-ws` subprotocol to your clients via the `Sec-WebSocket-Protocol` header.
 
 > Sending a message with the subscription
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1821,8 +1821,10 @@ in the *connection operation*, the **access token** in the **"Authorization"** h
 > Connecting to the web socket:
 
 ```sh
- wscat -c <websocketURL>
+ wscat -c <websocketURL> -s graphqlws
 ```
+
+**Note:** You should specify the `graphqlws` subprotocol to your clients via the `Sec-WebSocket-Protocol` header.
 
 > Sending a message with the subscription
 


### PR DESCRIPTION
## Changes
Changes the subscription docs so users know that they should specify the `Sec-WebSocket-Protocol` header to `graphql-ws` on their clients. Otherwise, you will receive this error:

`➜  ~ wscat -c wss://be2n7ubdoi.execute-api.eu-west-1.amazonaws.com/test/
error: Server sent a subprotocol but none was requested`


## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly

