### PR TITLE
fix(cli): h flag exit error

### DIFF
--- a/packages/cli/src/commands/new/command.ts
+++ b/packages/cli/src/commands/new/command.ts
@@ -32,7 +32,7 @@ export default class Command extends Oclif.Command {
     try {
       const fields = flags.fields || []
       if (!args.commandName)
-        return Promise.reject("You haven't provided a command name, but it is required, run with --help for usage")
+        throw new Error("You haven't provided a command name, but it is required, run with --help for usage")
       return run(args.commandName, fields)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/command.ts
+++ b/packages/cli/src/commands/new/command.ts
@@ -28,15 +28,15 @@ export default class Command extends Oclif.Command {
   public static args = [{ name: 'commandName' }]
 
   public async run(): Promise<void> {
-    return this.runWithErrors().catch(console.error)
-  }
-
-  private async runWithErrors(): Promise<void> {
     const { args, flags } = this.parse(Command)
-    const fields = flags.fields || []
-    if (!args.commandName)
-      return Promise.reject("You haven't provided a command name, but it is required, run with --help for usage")
-    return run(args.commandName, fields)
+    try {
+      const fields = flags.fields || []
+      if (!args.commandName)
+        return Promise.reject("You haven't provided a command name, but it is required, run with --help for usage")
+      return run(args.commandName, fields)
+    } catch (error) {
+      console.error(error)
+    }
   }
 }
 

--- a/packages/cli/src/commands/new/entity.ts
+++ b/packages/cli/src/commands/new/entity.ts
@@ -40,7 +40,7 @@ export default class Entity extends Oclif.Command {
       const fields = flags.fields || []
       const events = flags.reduces || []
       if (!args.entityName)
-        return Promise.reject("You haven't provided an entity name, but it is required, run with --help for usage")
+        throw new Error("You haven't provided an entity name, but it is required, run with --help for usage")
       return run(args.entityName, fields, events)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/entity.ts
+++ b/packages/cli/src/commands/new/entity.ts
@@ -35,16 +35,16 @@ export default class Entity extends Oclif.Command {
   public static args = [{ name: 'entityName' }]
 
   public async run(): Promise<void> {
-    return this.runWithErrors().catch(console.error)
-  }
-
-  private async runWithErrors(): Promise<void> {
     const { args, flags } = this.parse(Entity)
-    const fields = flags.fields || []
-    const events = flags.reduces || []
-    if (!args.entityName)
-      return Promise.reject("You haven't provided an entity name, but it is required, run with --help for usage")
-    return run(args.entityName, fields, events)
+    try {
+      const fields = flags.fields || []
+      const events = flags.reduces || []
+      if (!args.entityName)
+        return Promise.reject("You haven't provided an entity name, but it is required, run with --help for usage")
+      return run(args.entityName, fields, events)
+    } catch (error) {
+      console.error(error)
+    }
   }
 }
 

--- a/packages/cli/src/commands/new/event-handler.ts
+++ b/packages/cli/src/commands/new/event-handler.ts
@@ -32,10 +32,8 @@ export default class EventHandler extends Oclif.Command {
     try {
       const event = flags.event
       if (!args.eventHandlerName)
-        return Promise.reject(
-          "You haven't provided an event handler name, but it is required, run with --help for usage"
-        )
-      if (!event) return Promise.reject("You haven't provided an event, but it is required, run with --help for usage")
+        throw new Error("You haven't provided an event handler name, but it is required, run with --help for usage")
+      if (!event) throw new Error("You haven't provided an event, but it is required, run with --help for usage")
       return run(args.eventHandlerName, event)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/event-handler.ts
+++ b/packages/cli/src/commands/new/event-handler.ts
@@ -28,16 +28,18 @@ export default class EventHandler extends Oclif.Command {
   public static args = [{ name: 'eventHandlerName' }]
 
   public async run(): Promise<void> {
-    return this.runWithErrors().catch(console.error)
-  }
-
-  private async runWithErrors(): Promise<void> {
     const { args, flags } = this.parse(EventHandler)
-    const event = flags.event
-    if (!args.eventHandlerName)
-      return Promise.reject("You haven't provided an event handler name, but it is required, run with --help for usage")
-    if (!event) return Promise.reject("You haven't provided an event, but it is required, run with --help for usage")
-    return run(args.eventHandlerName, event)
+    try {
+      const event = flags.event
+      if (!args.eventHandlerName)
+        return Promise.reject(
+          "You haven't provided an event handler name, but it is required, run with --help for usage"
+        )
+      if (!event) return Promise.reject("You haven't provided an event, but it is required, run with --help for usage")
+      return run(args.eventHandlerName, event)
+    } catch (error) {
+      console.error(error)
+    }
   }
 }
 

--- a/packages/cli/src/commands/new/event.ts
+++ b/packages/cli/src/commands/new/event.ts
@@ -32,7 +32,7 @@ export default class Event extends Oclif.Command {
     try {
       const fields = flags.fields || []
       if (!args.eventName)
-        return Promise.reject("You haven't provided an event name, but it is required, run with --help for usage")
+        throw new Error("You haven't provided an event name, but it is required, run with --help for usage")
       return run(args.eventName, fields)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/event.ts
+++ b/packages/cli/src/commands/new/event.ts
@@ -28,15 +28,15 @@ export default class Event extends Oclif.Command {
   public static args = [{ name: 'eventName' }]
 
   public async run(): Promise<void> {
-    return this.runWithErrors().catch(console.error)
-  }
-
-  private async runWithErrors(): Promise<void> {
     const { args, flags } = this.parse(Event)
-    const fields = flags.fields || []
-    if (!args.eventName)
-      return Promise.reject("You haven't provided an event name, but it is required, run with --help for usage")
-    return run(args.eventName, fields)
+    try {
+      const fields = flags.fields || []
+      if (!args.eventName)
+        return Promise.reject("You haven't provided an event name, but it is required, run with --help for usage")
+      return run(args.eventName, fields)
+    } catch (error) {
+      console.error(error)
+    }
   }
 }
 

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -49,19 +49,19 @@ export default class Project extends Command {
   public static args = [{ name: 'projectName' }]
 
   public async run(): Promise<void> {
-    return this.runWithErrors().catch(console.error)
-  }
-
-  private async runWithErrors(): Promise<void> {
     const { args, flags } = this.parse(Project)
-    if (!args.projectName)
-      return Promise.reject("You haven't provided a project name, but it is required, run with --help for usage")
-    assertNameIsCorrect(args.projectName)
-    const parsedFlags = {
-      projectName: args.projectName,
-      ...flags,
+    try {
+      if (!args.projectName)
+        return Promise.reject("You haven't provided a project name, but it is required, run with --help for usage")
+      assertNameIsCorrect(args.projectName)
+      const parsedFlags = {
+        projectName: args.projectName,
+        ...flags,
+      }
+      await run(parsedFlags as Partial<ProjectInitializerConfig>, this.config.version)
+    } catch (error) {
+      console.error(error)
     }
-    await run(parsedFlags as Partial<ProjectInitializerConfig>, this.config.version)
   }
 }
 

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -52,7 +52,7 @@ export default class Project extends Command {
     const { args, flags } = this.parse(Project)
     try {
       if (!args.projectName)
-        return Promise.reject("You haven't provided a project name, but it is required, run with --help for usage")
+        throw new Error("You haven't provided a project name, but it is required, run with --help for usage")
       assertNameIsCorrect(args.projectName)
       const parsedFlags = {
         projectName: args.projectName,

--- a/packages/cli/src/commands/new/read-model.ts
+++ b/packages/cli/src/commands/new/read-model.ts
@@ -40,7 +40,7 @@ export default class ReadModel extends Oclif.Command {
       const fields = flags.fields ?? []
       const projections = flags.projects ?? []
       if (!args.readModelName)
-        return Promise.reject("You haven't provided a read model name, but it is required, run with --help for usage")
+        throw new Error("You haven't provided a read model name, but it is required, run with --help for usage")
       return run(args.readModelName, fields, projections)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/read-model.ts
+++ b/packages/cli/src/commands/new/read-model.ts
@@ -35,16 +35,16 @@ export default class ReadModel extends Oclif.Command {
   public static args = [{ name: 'readModelName' }]
 
   public async run(): Promise<void> {
-    return this.runWithErrors().catch(console.error)
-  }
-
-  private async runWithErrors(): Promise<void> {
     const { args, flags } = this.parse(ReadModel)
-    const fields = flags.fields ?? []
-    const projections = flags.projects ?? []
-    if (!args.readModelName)
-      return Promise.reject("You haven't provided a read model name, but it is required, run with --help for usage")
-    return run(args.readModelName, fields, projections)
+    try {
+      const fields = flags.fields ?? []
+      const projections = flags.projects ?? []
+      if (!args.readModelName)
+        return Promise.reject("You haven't provided a read model name, but it is required, run with --help for usage")
+      return run(args.readModelName, fields, projections)
+    } catch (error) {
+      console.error(error)
+    }
   }
 }
 

--- a/packages/cli/src/commands/new/type.ts
+++ b/packages/cli/src/commands/new/type.ts
@@ -22,15 +22,15 @@ export default class Type extends Oclif.Command {
   public static args = [{ name: 'typeName' }]
 
   public async run(): Promise<void> {
-    return this.runWithErrors().catch(console.error)
-  }
-
-  private async runWithErrors(): Promise<void> {
     const { args, flags } = this.parse(Type)
-    const fields = flags.fields || []
-    if (!args.typeName)
-      return Promise.reject("You haven't provided a type name, but it is required, run with --help for usage")
-    return run(args.typeName, fields)
+    try {
+      const fields = flags.fields || []
+      if (!args.typeName)
+        return Promise.reject("You haven't provided a type name, but it is required, run with --help for usage")
+      return run(args.typeName, fields)
+    } catch (error) {
+      console.error(error)
+    }
   }
 }
 

--- a/packages/cli/src/commands/new/type.ts
+++ b/packages/cli/src/commands/new/type.ts
@@ -26,7 +26,7 @@ export default class Type extends Oclif.Command {
     try {
       const fields = flags.fields || []
       if (!args.typeName)
-        return Promise.reject("You haven't provided a type name, but it is required, run with --help for usage")
+        throw new Error("You haven't provided a type name, but it is required, run with --help for usage")
       return run(args.typeName, fields)
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
## Description
This resolves the exit error that happens when appending the -h flag on any booster new: command.

## Changes
_This changes were applied to every command on `booster/packages/cli/src/commands/new/`_

- Remove `runWithErrors()` and copy its content to `run()` inside a try-catch block
- Put `this.parse()` call outside the try block (as this is why the [exit error shows in console](https://github.com/oclif/command/blob/b3efe1e5e052a7a1a0b98b25bf4d8a521b5850d5/src/command.ts#L200))
- Because now everything is inside a try-catch, instead of `Promise.reject()` use `throw new Error()`.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly: does not need any change on documentation.

## Additional information
