### PR TITLE
[BOOST-925] Allow only single Role per User

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1420,7 +1420,7 @@ export class User {}
 ```
 
 Here, we have defined the `Admin` and `User` roles. The former contains the following attribute `allowSelfSignUp: false`,
-which means that when users sign-up, they can't specify the role `Admin` as one of its roles.
+which means that when users sign-up, they can't specify the role `Admin` as their role.
 The latter has this attribute set to `true`, which means that any user can self-assign the role `User` when signing up.
 
 If your Booster application has roles defined, an authentication API will be provisioned. It will allow your users to gain
@@ -1431,7 +1431,7 @@ Bearer Authorization header (`Authorization: Bearer`). It will be used to get th
 authorize it to access protected resources.
 
 #### Sign-up
-Users can use this endpoint to register in your application and get some roles assigned to them.
+Users can use this endpoint to register in your application and get a unique role assigned to them.
 Only roles with the attribute `allowSelfSignUp: true` can be specified upon sign-up. After calling this endpoint, the
 registration is not yet finished. Users need to confirm their emails by clicking in the link that will be sent to their 
 inbox.
@@ -1450,7 +1450,7 @@ POST https://<httpURL>/auth/sign-up
   "username": "string",
   "password": "string",
   "userAttributes": {
-   	"roles": ["string"]
+   	"role": "string"
   }
 }
 ```
@@ -1460,7 +1460,7 @@ Parameter | Description
 _clientId_ | The application client Id that you got as an output when the application was deployed.
 _username_ | The username of the user you want to register. It **must be an email**.
 _password_ | The password the user will use to later login into your application and get access tokens.
-_userAttributes_ | Here you can specify the attributes of your user. These are: <br/> -_**roles**_:  An array of roles this user will have. You can only specify here roles with the property `allowSelfSignUp = true`
+_userAttributes_ | Here you can specify the attributes of your user. These are: <br/> -_**role**_:  A unique role this user will have. You can only specify here a role with the property `allowSelfSignUp = true`
 
 
 ##### Response
@@ -2127,7 +2127,7 @@ Booster also provides you with user management for free, allowing you to sign-up
 	"username": "user@test.com",
 	"password": "passw0rd!",
 	"userAttributes": {
-		"roles": ["User"]
+		"role": "User"
 	}
 }
 ```

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -14,8 +14,10 @@ export class BoosterAuth {
     const userEnvelope = config.provider.auth.rawToEnvelope(rawMessage)
     logger.info('User envelope: ', userEnvelope)
 
-    userEnvelope.roles.forEach((roleName: string) => {
-      const roleMetadata = config.roles[roleName]
+    const roleName = userEnvelope.role
+    if (roleName) {
+      const roleMetadata = config.roles[userEnvelope.role]
+
       if (!roleMetadata) {
         throw new InvalidParameterError(`Unknown role ${roleName}`)
       }
@@ -24,7 +26,7 @@ export class BoosterAuth {
           `User with role ${roleName} can't sign up by themselves. Choose a different role or contact and administrator`
         )
       }
-    })
+    }
 
     return rawMessage
   }
@@ -46,5 +48,5 @@ export class BoosterAuth {
 }
 
 function userHasSomeRole(user: UserEnvelope, authorizedRoles: Array<Class<RoleInterface>>): boolean {
-  return authorizedRoles.some((roleClass) => user.roles.includes(roleClass.name))
+  return authorizedRoles.some((roleClass) => user.role === roleClass.name)
 }

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -39,7 +39,7 @@ describe('the "checkSignUp" method', () => {
       config.provider.auth,
       'rawToEnvelope',
       fake.returns({
-        role: 'NonExistingRole'
+        role: 'NonExistingRole',
       })
     )
 

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -39,7 +39,7 @@ describe('the "checkSignUp" method', () => {
       config.provider.auth,
       'rawToEnvelope',
       fake.returns({
-        roles: ['Developer', 'NonExistingRole', 'Admin'],
+        role: 'NonExistingRole'
       })
     )
 
@@ -52,7 +52,7 @@ describe('the "checkSignUp" method', () => {
       config.provider.auth,
       'rawToEnvelope',
       fake.returns({
-        roles: ['Developer', 'Admin'],
+        role: 'Admin',
       })
     )
 
@@ -67,7 +67,7 @@ describe('the "checkSignUp" method', () => {
       config.provider.auth,
       'rawToEnvelope',
       fake.returns({
-        roles: ['Developer'],
+        role: 'Developer',
       })
     )
 
@@ -96,7 +96,7 @@ describe('the "isUserAuthorized" method', () => {
     const authorizedRoles: RoleAccess['authorize'] = [Admin]
     const userEnvelope: UserEnvelope = {
       email: 'user@test.com',
-      roles: ['Developer'],
+      role: 'Developer',
     }
 
     expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(false)
@@ -106,7 +106,7 @@ describe('the "isUserAuthorized" method', () => {
     const authorizedRoles: RoleAccess['authorize'] = [Admin, Developer]
     const userEnvelope: UserEnvelope = {
       email: 'user@test.com',
-      roles: ['Developer'],
+      role: 'Developer',
     }
 
     expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(true)

--- a/packages/framework-core/test/booster-read-model-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-read-model-dispatcher.test.ts
@@ -80,7 +80,7 @@ describe('BoosterReadModelDispatcher', () => {
         version: 1,
         currentUser: {
           email: internet.email(),
-          roles: [],
+          role: '',
         },
       }
       await expect(readModelDispatcher.fetch(envelope)).to.eventually.be.rejectedWith(NotAuthorizedError)
@@ -108,7 +108,7 @@ describe('BoosterReadModelDispatcher', () => {
       filters,
       currentUser: {
         email: internet.email(),
-        roles: [UserRole.name],
+        role: UserRole.name,
       },
     }
 

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -123,7 +123,7 @@ describe('the `RegisterHandler` class', () => {
     }
     const user: UserEnvelope = {
       email: 'paco@example.com',
-      roles: ['Paco'],
+      role: 'Paco',
     }
     const register = new Register('1234', user)
     const event = new SomeEvent('a')

--- a/packages/framework-core/test/services/graphql/graphql-generator.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-generator.test.ts
@@ -119,7 +119,7 @@ describe('GraphQL generator', () => {
         requestID: mockRequestId,
         user: {
           email: mockEmail,
-          roles: [mockRole],
+          role: mockRole,
         },
       }
       mockResolverInfo = {}
@@ -145,7 +145,7 @@ describe('GraphQL generator', () => {
         const expectedFetchPayload = {
           currentUser: {
             email: mockEmail,
-            roles: [mockRole],
+            role: mockRole,
           },
           filters: {},
           requestID: mockRequestId,
@@ -239,7 +239,7 @@ describe('GraphQL generator', () => {
           requestID: mockRequestId,
           currentUser: {
             email: mockEmail,
-            roles: [mockRole],
+            role: mockRole,
           },
           typeName: mockType.name,
           value: mockInput,
@@ -368,7 +368,7 @@ describe('GraphQL generator', () => {
         expect(asyncIteratorStub).to.be.calledOnceWithExactly({
           currentUser: {
             email: mockEmail,
-            roles: [mockRole],
+            role: mockRole,
           },
           filters: {},
           requestID: mockRequestId,

--- a/packages/framework-integration-tests/integration/providers/aws/auth.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/auth.integration.ts
@@ -235,7 +235,7 @@ describe('With the auth API', () => {
           username: userEmail,
           password: userPassword,
           userAttributes: {
-            roles: ['User'],
+            role: 'User',
           },
         }),
         headers: {
@@ -263,7 +263,7 @@ describe('With the auth API', () => {
           username: adminEmail,
           password: adminPassword,
           userAttributes: {
-            roles: ['Admin'],
+            role: 'Admin',
           },
         }),
         headers: {
@@ -299,7 +299,7 @@ describe('With the auth API', () => {
           username: userEmail,
           password: userPassword,
           userAttributes: {
-            roles: ['User'],
+            role: 'User',
           },
         }),
         headers: {

--- a/packages/framework-integration-tests/integration/providers/aws/event-handlers.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/event-handlers.integration.ts
@@ -73,7 +73,7 @@ describe('Event handlers', () => {
         entityID: mockProductId,
         currentUser: {
           email: adminEmail,
-          roles: ['Admin'],
+          role: 'Admin',
         },
       }
       const stockMovedEvent = events.find((event) => event.typeName === 'StockMoved')
@@ -93,7 +93,7 @@ describe('Event handlers', () => {
         entityID: mockProductId,
         currentUser: {
           email: adminEmail,
-          roles: ['Admin'],
+          role: 'Admin',
         },
       }
       const productAvailabilityChangedEvent = events.find((event) => event.typeName === 'ProductAvailabilityChanged')

--- a/packages/framework-integration-tests/integration/providers/aws/utils.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/utils.ts
@@ -122,7 +122,7 @@ export async function createUser(username: string, password: string, role = 'Use
       Username: username,
       UserAttributes: [
         {
-          Name: 'custom:roles',
+          Name: 'custom:role',
           Value: role,
         },
       ],

--- a/packages/framework-integration-tests/integration/providers/local/auth.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/local/auth.integration.ts
@@ -22,7 +22,7 @@ describe('With the auth API', () => {
             username: userEmail,
             password: userPassword,
             userAttributes: {
-              roles: [],
+              role: '',
             },
           }),
           headers: {
@@ -54,7 +54,7 @@ describe('With the auth API', () => {
             username: userEmail,
             password: userPassword,
             userAttributes: {
-              roles: [],
+              role: '',
             },
           }),
           headers: {
@@ -74,7 +74,7 @@ describe('With the auth API', () => {
             username: userEmail,
             password: userPassword,
             userAttributes: {
-              roles: [],
+              role: '',
             },
           }),
           headers: {

--- a/packages/framework-integration-tests/integration/providers/local/commands.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/local/commands.integration.ts
@@ -59,7 +59,7 @@ describe('commands', () => {
         entityID: mockCartId,
         currentUser: {
           email: 'test@test.com',
-          roles: [],
+          role: '',
         },
         entityTypeName: 'Cart',
         typeName: 'CartItemChanged',

--- a/packages/framework-integration-tests/integration/providers/local/utils.ts
+++ b/packages/framework-integration-tests/integration/providers/local/utils.ts
@@ -6,14 +6,14 @@ import { LOCAL_PROVIDER_HOST } from './constants'
 
 // --- Auth helpers ---
 
-export async function createUser(username: string, password: string, roles: string[] = []): Promise<void> {
+export async function createUser(username: string, password: string, role = ''): Promise<void> {
   const response = await fetch(signUpURL(), {
     method: 'POST',
     body: JSON.stringify({
       username: username,
       password: password,
       userAttributes: {
-        roles: roles,
+        role: role,
       },
     }),
     headers: {

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/api-stack-velocity-templates.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/api-stack-velocity-templates.ts
@@ -1,7 +1,5 @@
 export const CognitoTemplates = {
   signUp: {
-    // This template is a bit more complex because we are transforming the attribute 'roles' from an array to a
-    // comma-separated string
     request: `#set($root = $input.path('$'))
              {
                "ClientId": "$root.clientId",
@@ -9,9 +7,9 @@ export const CognitoTemplates = {
                "Password": "$root.password",
                "UserAttributes": [
                  #foreach($attributeKey in $root.userAttributes.keySet())
-                     #if($attributeKey == "roles")
-                         #set($attributeName = "custom:roles")
-                         #set($attributeValue = "#foreach($rol in $root.userAttributes.get('roles'))$rol#if($foreach.hasNext),#end#end")
+                     #if($attributeKey == "role")
+                         #set($attributeName = "custom:role")
+                         #set($attributeValue = $root.userAttributes.get('role'))
                      #else
                          #set($attributeName = $attributeKey)
                          #set($attributeValue = $root.userAttributes.get($attributeKey))

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/auth-stack.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/auth-stack.ts
@@ -40,7 +40,7 @@ export class AuthStack {
         {
           attributeDataType: 'String',
           mutable: true,
-          name: 'roles',
+          name: 'role',
         },
       ],
       usernameAttributes: [UserPoolAttribute.EMAIL],

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/api-stack-velocity-templates.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/api-stack-velocity-templates.test.ts
@@ -14,7 +14,7 @@ function buildAwsTemplateContext(withData: Record<string, any>): Record<string, 
 describe('CognitoTemplates', () => {
   describe('SignUp', () => {
     describe('request', () => {
-      it('returns the Cognito expected input for a user without roles', () => {
+      it('returns the Cognito expected input for a user without role', () => {
         const input = {
           clientId: 'a-client-id',
           username: 'user@name.com',
@@ -33,41 +33,14 @@ describe('CognitoTemplates', () => {
         expect(gotOutputJSON).to.be.deep.equal(expectedOutput)
       })
 
-      it('returns the Cognito expected input for a user with ONE role', () => {
-        const input = {
-          clientId: 'a-client-id',
-          username: 'user@name.com',
-          password: 'test_password',
-          userAttributes: {
-            roles: ['Admin'],
-          },
-        }
-        const expectedOutput = {
-          ClientId: input.clientId,
-          Username: input.username,
-          Password: input.password,
-          UserAttributes: [
-            {
-              Name: 'custom:roles',
-              Value: 'Admin',
-            },
-          ],
-        }
-
-        const context = buildAwsTemplateContext(input)
-        const gotOutputJSON = JSON.parse(Velocity.render(CognitoTemplates.signUp.request, context))
-
-        expect(gotOutputJSON).to.be.deep.equal(expectedOutput)
-      })
-
-      it('returns the Cognito expected input for a user with MULTIPLE roles and other attributes', () => {
+      it('returns the Cognito expected input for a user with ONE role and other attributes', () => {
         const input = {
           clientId: 'a-client-id',
           username: 'user@name.com',
           password: 'test_password',
           userAttributes: {
             name: 'Test user',
-            roles: ['Admin', 'Sales', 'Business'],
+            role: 'Admin',
             age: 30,
           },
         }
@@ -81,8 +54,8 @@ describe('CognitoTemplates', () => {
               Value: 'Test user',
             },
             {
-              Name: 'custom:roles',
-              Value: 'Admin,Sales,Business',
+              Name: 'custom:role',
+              Value: 'Admin',
             },
             {
               Name: 'age',

--- a/packages/framework-provider-aws/src/library/user-envelopes.ts
+++ b/packages/framework-provider-aws/src/library/user-envelopes.ts
@@ -4,19 +4,15 @@ import { CognitoIdentityServiceProvider } from 'aws-sdk'
 
 export class UserEnvelopeBuilder {
   public static fromAttributeMap(attributes: AttributeMappingType): UserEnvelope {
-    const { email, 'custom:roles': rolesString } = attributes
+    const { email, 'custom:role': role } = attributes
     return {
       email,
-      roles: this.rolesStringToArray(rolesString),
+      role: role ? role.trim(): '',
     }
   }
 
   public static fromAttributeList(attributes: AttributeListType): UserEnvelope {
     return this.fromAttributeMap(this.attributeListToMap(attributes))
-  }
-
-  private static rolesStringToArray(rolesString: string): Array<string> {
-    return rolesString ? rolesString.split(',').map((role) => role.trim()) : []
   }
 
   private static attributeListToMap(attributes: AttributeListType): AttributeMappingType {

--- a/packages/framework-provider-aws/test/library/auth-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/auth-adapter.test.ts
@@ -15,14 +15,14 @@ describe('the auth-adapter', () => {
         request: {
           userAttributes: {
             email: 'test@user.com',
-            'custom:roles': 'Admin,User,Agent',
+            'custom:role': 'User',
           },
         },
       }
 
       const expectedOutput: UserEnvelope = {
         email: cognitoUserEvent.request.userAttributes.email,
-        roles: ['Admin', 'User', 'Agent'],
+        role: 'User',
       }
       const gotOutput = rawSignUpDataToUserEnvelope(cognitoUserEvent as any)
       expect(gotOutput).to.be.deep.equal(expectedOutput)

--- a/packages/framework-provider-aws/test/library/graphql-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/graphql-adapter.test.ts
@@ -35,7 +35,7 @@ describe('AWS Provider graphql-adapter', () => {
 
       expectedUser = {
         email: internet.email(),
-        roles: ['Admin'],
+        role: 'Admin',
       }
       expectedQuery = 'GraphQL query'
       expectedVariables = {

--- a/packages/framework-provider-aws/test/library/user-envelopes.ts
+++ b/packages/framework-provider-aws/test/library/user-envelopes.ts
@@ -8,28 +8,28 @@ import CognitoIdentityServiceProvider = require('aws-sdk/clients/cognitoidentity
 import { restore, replace, fake } from 'sinon'
 
 describe('the UserEnvelopeBuilder.fromAttributeMap', () => {
-  it('works with a user with no roles', () => {
+  it('works with a user with no role', () => {
     const input: AttributeMappingType = {
       email: 'test@user.com',
     }
 
     const expected: UserEnvelope = {
       email: input.email,
-      roles: [],
+      role: '',
     }
     const got = UserEnvelopeBuilder.fromAttributeMap(input)
     expect(got).to.be.deep.equal(expected)
   })
 
-  it('works with a user with empty roles', () => {
+  it('works with a user with empty role', () => {
     const input: AttributeMappingType = {
       email: 'test@user.com',
-      'custom:roles': '',
+      'custom:role': '',
     }
 
     const expected: UserEnvelope = {
       email: input.email,
-      roles: [],
+      role: '',
     }
     const got = UserEnvelopeBuilder.fromAttributeMap(input)
     expect(got).to.be.deep.equal(expected)
@@ -38,26 +38,12 @@ describe('the UserEnvelopeBuilder.fromAttributeMap', () => {
   it('works with a user with one role', () => {
     const input: AttributeMappingType = {
       email: 'test@user.com',
-      'custom:roles': 'Admin',
+      'custom:role': 'Admin',
     }
 
     const expected: UserEnvelope = {
       email: input.email,
-      roles: ['Admin'],
-    }
-    const got = UserEnvelopeBuilder.fromAttributeMap(input)
-    expect(got).to.be.deep.equal(expected)
-  })
-
-  it('works with a user with several roles', () => {
-    const input: AttributeMappingType = {
-      email: 'test@user.com',
-      'custom:roles': 'Admin,User,Tester,SalesAgent',
-    }
-
-    const expected: UserEnvelope = {
-      email: input.email,
-      roles: ['Admin', 'User', 'Tester', 'SalesAgent'],
+      role: 'Admin',
     }
     const got = UserEnvelopeBuilder.fromAttributeMap(input)
     expect(got).to.be.deep.equal(expected)
@@ -65,21 +51,21 @@ describe('the UserEnvelopeBuilder.fromAttributeMap', () => {
 })
 
 describe('the UserEnvelopeBuilder.fromAttributeList', () => {
-  it('works with a user with roles', () => {
+  it('works with a user with one role', () => {
     const input: AttributeListType = [
       {
         Name: 'email',
         Value: 'test@user.com',
       },
       {
-        Name: 'custom:roles',
-        Value: 'Admin,User',
+        Name: 'custom:role',
+        Value: 'User',
       },
     ]
 
     const expected: UserEnvelope = {
       email: 'test@user.com',
-      roles: ['Admin', 'User'],
+      role: 'User',
     }
 
     const got = UserEnvelopeBuilder.fromAttributeList(input)
@@ -111,13 +97,13 @@ describe('the fetchUserFromRequest function', () => {
         Value: 'test@user.com',
       },
       {
-        Name: 'custom:roles',
-        Value: 'Admin,User',
+        Name: 'custom:role',
+        Value: 'User',
       },
     ]
     const expectedUser = {
       email: 'test@user.com',
-      roles: ['Admin', 'User'],
+      role: 'User',
     }
 
     replace(

--- a/packages/framework-provider-local-infrastructure/test/controllers/auth.test.ts
+++ b/packages/framework-provider-local-infrastructure/test/controllers/auth.test.ts
@@ -26,7 +26,7 @@ describe('the auth controller', () => {
         clientId: faker.random.uuid(),
         username: faker.internet.email(),
         userAttributes: {
-          roles: [],
+          role: '',
         },
         password: faker.internet.password(),
       }
@@ -48,7 +48,7 @@ describe('the auth controller', () => {
         clientId: faker.random.uuid(),
         username: faker.internet.email(),
         userAttributes: {
-          roles: [],
+          role: '',
         },
         password: faker.internet.password(),
       }

--- a/packages/framework-provider-local/src/library/auth-adapter.ts
+++ b/packages/framework-provider-local/src/library/auth-adapter.ts
@@ -4,7 +4,7 @@ export interface User {
   username: string
   password: string
   userAttributes: {
-    roles: Array<string>
+    role: string
   }
   token: UUID
   confirmed: boolean
@@ -16,5 +16,5 @@ export type RegisteredUser = Pick<User, 'username' | 'password' | 'userAttribute
 export type AuthenticatedUser = Pick<User, 'username' | 'token'>
 
 export function rawSignUpDataToUserEnvelope(rawMessage: SignUpUser): UserEnvelope {
-  return { email: rawMessage.username, roles: rawMessage.userAttributes.roles }
+  return { email: rawMessage.username, role: rawMessage.userAttributes.role }
 }

--- a/packages/framework-provider-local/src/library/graphql-adapter.ts
+++ b/packages/framework-provider-local/src/library/graphql-adapter.ts
@@ -13,7 +13,7 @@ export async function rawGraphQLRequestToEnvelope(
     connectionID: undefined, // TODO: Retrieve connectionId if available,
     currentUser: {
       email: 'test@test.com',
-      roles: [],
+      role: '',
     },
     value: request.body,
   }

--- a/packages/framework-provider-local/src/services/user-registry.ts
+++ b/packages/framework-provider-local/src/services/user-registry.ts
@@ -94,7 +94,7 @@ export class UserRegistry {
             } else {
               resolve({
                 email: doc.username,
-                roles: doc.userAttributes.roles,
+                role: doc.userAttributes.role,
               })
             }
           })

--- a/packages/framework-provider-local/test/library/graphql-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/graphql-adapter.test.ts
@@ -54,7 +54,7 @@ describe('Local provider graphql-adapter', () => {
         connectionID: undefined,
         currentUser: {
           email: 'test@test.com',
-          roles: [],
+          role: '',
         },
         value: mockBody,
       })

--- a/packages/framework-provider-local/test/services/user-registry.test.ts
+++ b/packages/framework-provider-local/test/services/user-registry.test.ts
@@ -20,7 +20,7 @@ describe('the user registry', () => {
         clientId: faker.random.uuid(),
         username: faker.internet.email(),
         userAttributes: {
-          roles: [],
+          role: '',
         },
         password: faker.internet.password(),
       }
@@ -38,7 +38,7 @@ describe('the user registry', () => {
         clientId: faker.random.uuid(),
         username: faker.internet.email(),
         userAttributes: {
-          roles: [],
+          role: '',
         },
         password: faker.internet.password(),
       }
@@ -57,7 +57,7 @@ describe('the user registry', () => {
         clientId: faker.random.uuid(),
         username: faker.internet.email(),
         userAttributes: {
-          roles: [],
+          role: '',
         },
         password: faker.internet.password(),
       }
@@ -78,7 +78,7 @@ describe('the user registry', () => {
         clientId: faker.random.uuid(),
         username: faker.internet.email(),
         userAttributes: {
-          roles: [],
+          role: '',
         },
         password: faker.internet.password(),
       }
@@ -94,7 +94,7 @@ describe('the user registry', () => {
         clientId: faker.random.uuid(),
         username: faker.internet.email(),
         userAttributes: {
-          roles: [],
+          role: '',
         },
         password: faker.internet.password(),
       }
@@ -109,7 +109,7 @@ describe('the user registry', () => {
       const user = {
         username: faker.internet.email(),
         password: faker.internet.password(),
-        roles: [],
+        role: '',
       }
       userRegistry.registeredUsers.findOne = stub().yields(null, undefined)
       return expect(userRegistry.signIn(user)).to.be.rejectedWith(NotAuthorizedError)
@@ -120,7 +120,7 @@ describe('the user registry', () => {
       const user = {
         username: faker.internet.email(),
         password: faker.internet.password(),
-        roles: [],
+        role: '',
       }
       userRegistry.registeredUsers.findOne = stub().yields(null, { ...user, confirmed: false })
       return expect(userRegistry.signIn(user)).to.be.rejectedWith(NotAuthorizedError)
@@ -131,7 +131,7 @@ describe('the user registry', () => {
       const user = {
         username: faker.internet.email(),
         password: faker.internet.password(),
-        roles: [],
+        role: '',
       }
 
       const error = new Error(faker.lorem.words())
@@ -181,7 +181,7 @@ describe('the user registry', () => {
         clientId: faker.random.uuid(),
         username: faker.internet.email(),
         userAttributes: {
-          roles: [],
+          role: '',
         },
         password: faker.internet.password(),
       }
@@ -192,7 +192,7 @@ describe('the user registry', () => {
       const retrievedUser = await userRegistry.getAuthenticatedUser(mockToken)
       expect(userRegistry.authenticatedUsers.findOne).to.have.been.called
       expect(userRegistry.registeredUsers.findOne).to.have.been.called
-      expect(retrievedUser).to.deep.equal({ email: user.username, roles: user.userAttributes.roles })
+      expect(retrievedUser).to.deep.equal({ email: user.username, role: user.userAttributes.role })
     })
   })
 

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -66,5 +66,5 @@ export interface GraphQLOperation {
 
 export interface UserEnvelope {
   email: string
-  roles: Array<string>
+  role: string
 }


### PR DESCRIPTION
## Description
Allow only one role per user.

## Changes
After some conversations, we realized allowing a user to have multiple roles can be conflicting. Since roles have their one attributes, applying multiple roles to a single user with conflicting attributes values is misleading.

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly

## Additional information
Also ran integration tests. 