### PR TITLE
[BOOST-707] Add phone authentication

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1454,7 +1454,7 @@ Users can use this endpoint to register in your application and get a role assig
 Only roles that filled `signUpMethods` with valid entries can be used upon sign-up. After calling this endpoint, the
 registration isn't completed yet. 
 Users that sign up with their emails will receive a confirmation link in their inbox. They just need to click it to confirm their registration.
-Users that sign up with their phones will receive a confirmation code as an SMS message. That code needs to be sent back using the [confirmation endpoint](#confirm-sign-up)
+Users that sign up with their phones will receive a confirmation code as an SMS message. That code needs to be sent back using the [confirmation endpoint](#sign-up/confirm)
 
 ![confirmation email](./img/sign-up-verificaiton-email.png)
 ![email confirmed](./img/sign-up-confirmed.png)
@@ -1503,11 +1503,11 @@ You will get an HTTP status code different from 2XX and a body with a message te
 ##### Confirm-sign-up
 
 Whenever a User signs up with their phone number, an SMS message will be sent with a confirmation code.
-They will need to provide this code to confirm registation by calling the`confirm-sign-up` endpoint 
+They will need to provide this code to confirm registation by calling the`sign-up/confirm` endpoint 
 
 ###### Endpoint
 ```http request
-POST https://<httpURL>/auth/confirm-sign-up
+POST https://<httpURL>/auth/sign-up/confirm
 ```
 
 ###### Request body

--- a/docs/README.md
+++ b/docs/README.md
@@ -1432,7 +1432,7 @@ export class User {}
 export class SuperUser {}
 ```
 
-Here, we have defined the `Admin`, `User` and `SuperUser` roles. They all contain an `authentication` attribute. This one contains a `signUpMethods` attribute. When this value is empty (`Admin` role) a user sign-up can't use this role to sign up.
+Here, we have defined the `Admin`, `User` and `SuperUser` roles. They all contain an `authentication` attribute. This one contains a `signUpMethods` attribute. When this value is empty (`Admin` role) a user can't use this role to sign up.
 
 `signUpMethods` is an array with limited possible values: `email` or `phone` or a combination of both.
 Users with the `User` role will only be able to sign up with their emails, whereas the ones with the `SuperUser` role will be able to sign up with either their email or their phone number.
@@ -1449,12 +1449,12 @@ The authentication API consists of several endpoints that allow you to manage us
 
 The base URL of all these endpoints is the `httpURL` output of your application. See the ["Application Outputs"](#application-outputs) section to know more.
 
-#### Sign-up
+##### Sign-up
 Users can use this endpoint to register in your application and get a role assigned to them.
 Only roles that filled `signUpMethods` with valid entries can be used upon sign-up. After calling this endpoint, the
 registration isn't completed yet. 
 Users that sign up with their emails will receive a confirmation link in their inbox. They just need to click it to confirm their registration.
-Users that sign up with their phones will receive a confirmation code as an SMS message. 
+Users that sign up with their phones will receive a confirmation code as an SMS message. That code needs to be sent back using the [confirmation endpoint](#confirm-sign-up)
 
 ![confirmation email](./img/sign-up-verificaiton-email.png)
 ![email confirmed](./img/sign-up-confirmed.png)
@@ -1480,7 +1480,7 @@ Parameter | Description
 _clientId_ | The application client Id that you got as an output when the application was deployed.
 _username_ | The username of the user you want to register. It **must be an email**.
 _password_ | The password the user will use to later login into your application and get access tokens.
-_userAttributes_ | Here you can specify the attributes of your user. These are: <br/> -_**role**_:  A unique role this user will have. You can only specify here a role where the `signUpOptions` property is not empty and has a valid entry.
+_userAttributes_ | Here you can specify the attributes of your user. These are: <br/> -_**role**_:  A unique role this user will have. You can only specify here a role where the `signUpOptions` property is not empty.
 
 
 ###### Response
@@ -1500,17 +1500,17 @@ Example: The `username` is not an email or a phone number:
 
 You will get an HTTP status code different from 2XX and a body with a message telling you the reason of the error.
 
-#### Confirm-sign-up
+##### Confirm-sign-up
 
 Whenever a User signs up with their phone number, an SMS message will be sent with a confirmation code.
 They will need to provide this code to confirm registation by calling the`confirm-sign-up` endpoint 
 
-##### Endpoint
+###### Endpoint
 ```http request
 POST https://<httpURL>/auth/confirm-sign-up
 ```
 
-##### Request body
+###### Request body
 ```json
 {
   "clientId": "string",
@@ -1525,15 +1525,15 @@ _clientId_ | The application client Id that you got as an output when the applic
 _confirmationCode_ | The confirmation code received in the SMS message.
 _username_ | The username of the user you want to sign in. They must have previously signed up.
 
-##### Response
+###### Response
 An Empty Body
 
-##### Errors
+###### Errors
 
 You will get an HTTP status code different from 2XX and a body with a message telling you the reason of the error.
 Common errors would be like submitting an expired confirmation code or a non valid one.
 
-#### Sign-in
+##### Sign-in
 This endpoint creates a session for an already registered user, returning an access token that can be used
 to access role-protected resources
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1409,7 +1409,7 @@ In the following example we define two roles, `Admin` and `User`:
 // src/roles.ts
 
 @Role({
-  authentication: {
+  auth: {
     // Do not specify (or use an empty array) if you don't want to allow sign-ups
     signUpMethods: [],
   }
@@ -1417,7 +1417,7 @@ In the following example we define two roles, `Admin` and `User`:
 export class Admin {}
 
 @Role({
-  authentication: {
+  auth: {
     // Do not specify (or use an empty array) if you don't want to allow sign-ups
     signUpMethods: ['email'],
   },
@@ -1425,14 +1425,14 @@ export class Admin {}
 export class User {}
 
 @Role({
-  authentication: {
+  auth: {
     signUpMethods: ['email', 'phone'],
   },
 })
 export class SuperUser {}
 ```
 
-Here, we have defined the `Admin`, `User` and `SuperUser` roles. They all contain an `authentication` attribute. This one contains a `signUpMethods` attribute. When this value is empty (`Admin` role) a user can't use this role to sign up.
+Here, we have defined the `Admin`, `User` and `SuperUser` roles. They all contain an `auth` attribute. This one contains a `signUpMethods` attribute. When this value is empty (`Admin` role) a user can't use this role to sign up.
 
 `signUpMethods` is an array with limited possible values: `email` or `phone` or a combination of both.
 Users with the `User` role will only be able to sign up with their emails, whereas the ones with the `SuperUser` role will be able to sign up with either their email or their phone number.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1409,19 +1409,33 @@ In the following example we define two roles, `Admin` and `User`:
 // src/roles.ts
 
 @Role({
-  allowSelfSignUp: false,
+  authentication: {
+    // Do not specify (or use an empty array) if you don't want to allow sign-ups
+    signUpMethods: [],
+  }
 })
 export class Admin {}
 
 @Role({
-  allowSelfSignUp: true,
+  authentication: {
+    // Do not specify (or use an empty array) if you don't want to allow sign-ups
+    signUpMethods: ['email'],
+  },
 })
 export class User {}
+
+@Role({
+  authentication: {
+    signUpMethods: ['email', 'phone'],
+  },
+})
+export class SuperUser {}
 ```
 
-The `Admin` role contains the following attribute `allowSelfSignUp: false`,
-which means that when users sign-up, they can't specify themselves the role `Admin` as their role.
-The `User` role has this attribute set to `true`, so users can self-assign this role to themselves.
+Here, we have defined the `Admin`, `User` and `SuperUser` roles. They all contain an `authentication` attribute. This one contains a `signUpMethods` attribute. When this value is empty (`Admin` role) a user sign-up can't use this role to sign up.
+
+`signUpMethods` is an array with limited possible values: `email` or `phone` or a combination of both.
+Users with the `User` role will only be able to sign up with their emails, whereas the ones with the `SuperUser` role will be able to sign up with either their email or their phone number.
 
 If your Booster application has roles defined, an [authentication API](#authentication-api) will be provisioned. It will allow your users to gain
 access to your resources.
@@ -1435,11 +1449,12 @@ The authentication API consists of several endpoints that allow you to manage us
 
 The base URL of all these endpoints is the `httpURL` output of your application. See the ["Application Outputs"](#application-outputs) section to know more.
 
-##### Sign-up
+#### Sign-up
 Users can use this endpoint to register in your application and get a role assigned to them.
-Only roles with the attribute `allowSelfSignUp: true` can be specified upon sign-up. After calling this endpoint, the
-registration is not yet finished. Users need to confirm their emails by clicking in the link that will be sent to their 
-inbox.
+Only roles that filled `signUpMethods` with valid entries can be used upon sign-up. After calling this endpoint, the
+registration isn't completed yet. 
+Users that sign up with their emails will receive a confirmation link in their inbox. They just need to click it to confirm their registration.
+Users that sign up with their phones will receive a confirmation code as an SMS message. 
 
 ![confirmation email](./img/sign-up-verificaiton-email.png)
 ![email confirmed](./img/sign-up-confirmed.png)
@@ -1465,7 +1480,7 @@ Parameter | Description
 _clientId_ | The application client Id that you got as an output when the application was deployed.
 _username_ | The username of the user you want to register. It **must be an email**.
 _password_ | The password the user will use to later login into your application and get access tokens.
-_userAttributes_ | Here you can specify the attributes of your user. These are: <br/> -_**role**_:  A unique role this user will have. You can only specify here a role with the property `allowSelfSignUp = true`
+_userAttributes_ | Here you can specify the attributes of your user. These are: <br/> -_**role**_:  A unique role this user will have. You can only specify here a role where the `signUpOptions` property is not empty and has a valid entry.
 
 
 ###### Response
@@ -1474,15 +1489,51 @@ An Empty Body
 ###### Errors
 You will get an HTTP status code different from 2XX and a body with a message telling you the reason of the error.
 
-Example: The `username` is not an email:
+Example: The `username` is not an email or a phone number:
 
 ```json
 {
   "__type": "InvalidParameterException",
-  "message": "Username should be an email."
+  "message": "Username should be an email or a phone number."
 }
 ```
-##### Sign-in
+
+You will get an HTTP status code different from 2XX and a body with a message telling you the reason of the error.
+
+#### Confirm-sign-up
+
+Whenever a User signs up with their phone number, an SMS message will be sent with a confirmation code.
+They will need to provide this code to confirm registation by calling the`confirm-sign-up` endpoint 
+
+##### Endpoint
+```http request
+POST https://<httpURL>/auth/confirm-sign-up
+```
+
+##### Request body
+```json
+{
+  "clientId": "string",
+  "confirmationCode": "string",
+  "password": "string"
+}
+```
+
+Parameter | Description
+--------- | -----------
+_clientId_ | The application client Id that you got as an output when the application was deployed.
+_confirmationCode_ | The confirmation code received in the SMS message.
+_username_ | The username of the user you want to sign in. They must have previously signed up.
+
+##### Response
+An Empty Body
+
+##### Errors
+
+You will get an HTTP status code different from 2XX and a body with a message telling you the reason of the error.
+Common errors would be like submitting an expired confirmation code or a non valid one.
+
+#### Sign-in
 This endpoint creates a session for an already registered user, returning an access token that can be used
 to access role-protected resources
 

--- a/packages/framework-core/package.json
+++ b/packages/framework-core/package.json
@@ -35,7 +35,8 @@
     "graphql-type-json": "^0.3.1",
     "inflection": "^1.12.0",
     "iterall": "^1.3.0",
-    "reflect-metadata": "^0.1"
+    "reflect-metadata": "^0.1",
+    "validator": "^13.1.1"
   },
   "devDependencies": {
     "@types/faker": "^4.1.12",

--- a/packages/framework-core/package.json
+++ b/packages/framework-core/package.json
@@ -42,6 +42,7 @@
     "@types/faker": "^4.1.12",
     "@types/graphql-type-json": "^0.3.2",
     "@types/inflection": "^1.5.28",
+    "@types/validator": "^13.1.0",
     "faker": "^4.1.0"
   },
   "gitHead": "121816dbe55d57df5860b54a871c06dcda761101"

--- a/packages/framework-core/package.json
+++ b/packages/framework-core/package.json
@@ -35,8 +35,7 @@
     "graphql-type-json": "^0.3.1",
     "inflection": "^1.12.0",
     "iterall": "^1.3.0",
-    "reflect-metadata": "^0.1",
-    "validator": "^13.1.1"
+    "reflect-metadata": "^0.1"
   },
   "devDependencies": {
     "@types/faker": "^4.1.12",

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -17,13 +17,31 @@ export class BoosterAuth {
     const roleName = userEnvelope.role
     if (roleName) {
       const roleMetadata = config.roles[userEnvelope.role]
-
       if (!roleMetadata) {
         throw new InvalidParameterError(`Unknown role ${roleName}`)
       }
-      if (!roleMetadata.allowSelfSignUp) {
+
+      const authenticationMetadata = roleMetadata.authentication
+      if (
+        !authenticationMetadata ||
+        !authenticationMetadata.signUpMethods ||
+        (Array.isArray(authenticationMetadata.signUpMethods) && !authenticationMetadata.signUpMethods.length)
+      ) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up by themselves. Choose a different role or contact and administrator`
+        )
+      }
+
+      const signUpOptions = authenticationMetadata.signUpMethods
+      const username = userEnvelope.username
+
+      if (signUpOptions === 'phone' && username.type === 'email') {
+        throw new InvalidParameterError(
+          `User with role ${roleName} can't sign up with an email, a phone number is expected`
+        )
+      } else if (signUpOptions === 'email' && username.type === 'phone') {
+        throw new InvalidParameterError(
+          `User with role ${roleName} can't sign up with a phone number, an email is expected`
         )
       }
     }

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -33,11 +33,13 @@ export class BoosterAuth {
       const signUpOptions = authenticationMetadata.signUpMethods
       const username = userEnvelope.username
 
-      if (JSON.stringify(signUpOptions) == JSON.stringify(['phone']) && validator.isEmail(username)) {
+      if (validator.isEmail(username) && !signUpOptions.includes('email')) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up with an email, a phone number is expected`
         )
-      } else if (JSON.stringify(signUpOptions) == JSON.stringify(['email']) && !validator.isEmail(username)) {
+      }
+
+      if (!validator.isEmail(username) && !signUpOptions.includes('phone')) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up with a phone number, an email is expected`
         )

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -8,6 +8,8 @@ import {
   InvalidParameterError,
 } from '@boostercloud/framework-types'
 
+const validator = require('validator')
+
 export class BoosterAuth {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public static checkSignUp(rawMessage: any, config: BoosterConfig, logger: Logger): any {
@@ -36,11 +38,11 @@ export class BoosterAuth {
       const signUpOptions = authenticationMetadata.signUpMethods
       const username = userEnvelope.username
 
-      if (signUpOptions === 'phone' && username.type === 'email') {
+      if (signUpOptions === 'phone' && validator.isEmail(username)) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up with an email, a phone number is expected`
         )
-      } else if (signUpOptions === 'email' && username.type === 'phone') {
+      } else if (signUpOptions === 'email' && !validator.isEmail(username)) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up with a phone number, an email is expected`
         )

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -23,14 +23,14 @@ export class BoosterAuth {
         throw new InvalidParameterError(`Unknown role ${roleName}`)
       }
 
-      const authenticationMetadata = roleMetadata.authentication
-      if (!authenticationMetadata?.signUpMethods?.length) {
+      const authMetadata = roleMetadata.auth
+      if (!authMetadata?.signUpMethods?.length) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up by themselves. Choose a different role or contact and administrator`
         )
       }
 
-      const signUpOptions = authenticationMetadata.signUpMethods
+      const signUpOptions = authMetadata.signUpMethods
       const username = userEnvelope.username
 
       if (validator.isEmail(username) && !signUpOptions.includes('email')) {

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -8,7 +8,7 @@ import {
   InvalidParameterError,
 } from '@boostercloud/framework-types'
 
-const validator = require('validator')
+import * as validator from 'validator'
 
 export class BoosterAuth {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,13 +33,13 @@ export class BoosterAuth {
       const signUpOptions = authMetadata.signUpMethods
       const username = userEnvelope.username
 
-      if (validator.isEmail(username) && !signUpOptions.includes('email')) {
+      if (validator.default.isEmail(username) && !signUpOptions.includes('email')) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up with an email, a phone number is expected`
         )
       }
 
-      if (!validator.isEmail(username) && !signUpOptions.includes('phone')) {
+      if (!validator.default.isEmail(username) && !signUpOptions.includes('phone')) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up with a phone number, an email is expected`
         )

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -25,6 +25,7 @@ export class BoosterAuth {
       if (
         !authenticationMetadata ||
         !authenticationMetadata.signUpMethods ||
+        // eslint-disable-next-line @typescript-eslint/no-extra-parens
         (Array.isArray(authenticationMetadata.signUpMethods) && !authenticationMetadata.signUpMethods.length)
       ) {
         throw new InvalidParameterError(

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -24,12 +24,7 @@ export class BoosterAuth {
       }
 
       const authenticationMetadata = roleMetadata.authentication
-      if (
-        !authenticationMetadata ||
-        !authenticationMetadata.signUpMethods ||
-        // eslint-disable-next-line @typescript-eslint/no-extra-parens
-        (Array.isArray(authenticationMetadata.signUpMethods) && !authenticationMetadata.signUpMethods.length)
-      ) {
+      if (!authenticationMetadata?.signUpMethods?.length) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up by themselves. Choose a different role or contact and administrator`
         )
@@ -38,11 +33,11 @@ export class BoosterAuth {
       const signUpOptions = authenticationMetadata.signUpMethods
       const username = userEnvelope.username
 
-      if (signUpOptions === 'phone' && validator.isEmail(username)) {
+      if (JSON.stringify(signUpOptions) == JSON.stringify(['phone']) && validator.isEmail(username)) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up with an email, a phone number is expected`
         )
-      } else if (signUpOptions === 'email' && !validator.isEmail(username)) {
+      } else if (JSON.stringify(signUpOptions) == JSON.stringify(['email']) && !validator.isEmail(username)) {
         throw new InvalidParameterError(
           `User with role ${roleName} can't sign up with a phone number, an email is expected`
         )

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -78,7 +78,7 @@ describe('the "checkSignUp" method', () => {
     )
   })
 
-  it('succeeds user to sign up with email when SignUpOptions has email as value', () => {
+  it('succeeds when the user signs up with an email and SignUpOptions has email as value', () => {
     const config = buildBoosterConfig()
     replace(
       config.provider.auth,
@@ -92,7 +92,7 @@ describe('the "checkSignUp" method', () => {
     expect(() => BoosterAuth.checkSignUp({}, config, logger)).not.to.throw()
   })
 
-  it('succeeds user to sign up with phone when SignUpOptions has phone as value', () => {
+  it('succeeds when the user signs up with a phone number and SignUpOptions has phone as value', () => {
     const config = buildBoosterConfig()
     replace(
       config.provider.auth,

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -25,24 +25,24 @@ describe('the "checkSignUp" method', () => {
       auth: { rawToEnvelope: () => {} },
     } as unknown) as ProviderLibrary
     config.roles['Admin'] = {
-      authentication: {
+      auth: {
         signUpMethods: [],
       },
     }
     config.roles['UserWithEmail'] = {
-      authentication: {
+      auth: {
         signUpMethods: ['email'],
       },
     }
 
     config.roles['UserWithPhone'] = {
-      authentication: {
+      auth: {
         signUpMethods: ['phone'],
       },
     }
 
     config.roles['SuperUser'] = {
-      authentication: {
+      auth: {
         signUpMethods: ['phone', 'email'],
       },
     }

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -85,10 +85,7 @@ describe('the "checkSignUp" method', () => {
       'rawToEnvelope',
       fake.returns({
         role: 'Developer',
-        username: {
-          value: 'test@gmail.com',
-          type: 'email',
-        },
+        username: 'test@gmail.com',
       })
     )
 
@@ -102,10 +99,7 @@ describe('the "checkSignUp" method', () => {
       'rawToEnvelope',
       fake.returns({
         role: 'User',
-        username: {
-          value: '+59165783459',
-          type: 'phone',
-        },
+        username: '+59165783459',
       })
     )
 
@@ -119,10 +113,7 @@ describe('the "checkSignUp" method', () => {
       'rawToEnvelope',
       fake.returns({
         role: 'SuperUser',
-        username: {
-          value: 'test@gmail.com',
-          type: 'email',
-        },
+        username: 'test@gmail.com',
       })
     )
 
@@ -136,10 +127,7 @@ describe('the "checkSignUp" method', () => {
       'rawToEnvelope',
       fake.returns({
         role: 'SuperUser',
-        username: {
-          value: '+59165783459',
-          type: 'phone',
-        },
+        username: '+59165783459',
       })
     )
 
@@ -153,10 +141,7 @@ describe('the "checkSignUp" method', () => {
       'rawToEnvelope',
       fake.returns({
         role: 'Developer',
-        username: {
-          value: '+59165783459',
-          type: 'phone',
-        },
+        username: '+59165783459',
       })
     )
 
@@ -172,10 +157,7 @@ describe('the "checkSignUp" method', () => {
       'rawToEnvelope',
       fake.returns({
         role: 'User',
-        username: {
-          value: 'test@gmail.com',
-          type: 'email',
-        },
+        username: 'test@gmail.com',
       })
     )
 
@@ -205,10 +187,7 @@ describe('the "isUserAuthorized" method', () => {
   it('returns false when the user does not have any of the "authorizedRoles"', () => {
     const authorizedRoles: RoleAccess['authorize'] = [Admin]
     const userEnvelope: UserEnvelope = {
-      username: {
-        value: 'user@test.com',
-        type: 'email',
-      },
+      username: 'user@test.com',
       role: 'Developer',
     }
 
@@ -218,10 +197,7 @@ describe('the "isUserAuthorized" method', () => {
   it('returns true when the user has any of the "authorizedRoles"', () => {
     const authorizedRoles: RoleAccess['authorize'] = [Admin, Developer]
     const userEnvelope: UserEnvelope = {
-      username: {
-        value: 'user@test.com',
-        type: 'email',
-      },
+      username: 'user@test.com',
       role: 'Developer',
     }
 

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -29,15 +29,15 @@ describe('the "checkSignUp" method', () => {
         signUpMethods: [],
       },
     }
-    config.roles['Developer'] = {
+    config.roles['UserWithEmail'] = {
       authentication: {
-        signUpMethods: 'email',
+        signUpMethods: ['email'],
       },
     }
 
-    config.roles['User'] = {
+    config.roles['UserWithPhone'] = {
       authentication: {
-        signUpMethods: 'phone',
+        signUpMethods: ['phone'],
       },
     }
 
@@ -84,7 +84,7 @@ describe('the "checkSignUp" method', () => {
       config.provider.auth,
       'rawToEnvelope',
       fake.returns({
-        role: 'Developer',
+        role: 'UserWithEmail',
         username: 'test@gmail.com',
       })
     )
@@ -98,7 +98,7 @@ describe('the "checkSignUp" method', () => {
       config.provider.auth,
       'rawToEnvelope',
       fake.returns({
-        role: 'User',
+        role: 'UserWithPhone',
         username: '+59165783459',
       })
     )
@@ -140,13 +140,13 @@ describe('the "checkSignUp" method', () => {
       config.provider.auth,
       'rawToEnvelope',
       fake.returns({
-        role: 'Developer',
+        role: 'UserWithEmail',
         username: '+59165783459',
       })
     )
 
     expect(() => BoosterAuth.checkSignUp({}, config, logger)).to.throw(
-      /User with role Developer can't sign up with a phone number, an email is expected/
+      /User with role UserWithEmail can't sign up with a phone number, an email is expected/
     )
   })
 
@@ -156,13 +156,13 @@ describe('the "checkSignUp" method', () => {
       config.provider.auth,
       'rawToEnvelope',
       fake.returns({
-        role: 'User',
+        role: 'UserWithPhone',
         username: 'test@gmail.com',
       })
     )
 
     expect(() => BoosterAuth.checkSignUp({}, config, logger)).to.throw(
-      /User with role User can't sign up with an email, a phone number is expected/
+      /User with role UserWithPhone can't sign up with an email, a phone number is expected/
     )
   })
 })
@@ -170,7 +170,7 @@ describe('the "checkSignUp" method', () => {
 describe('the "isUserAuthorized" method', () => {
   // Define some roles to use in tests
   class Admin {}
-  class Developer {}
+  class UserWithEmail {}
 
   it('returns true when the "authorizedRoles" is "all"', () => {
     const authorizedRoles: RoleAccess['authorize'] = 'all'
@@ -179,7 +179,7 @@ describe('the "isUserAuthorized" method', () => {
   })
 
   it('returns false when the "authorizedRoles" is not "all" and no user was provided', () => {
-    const authorizedRoles: RoleAccess['authorize'] = [Admin, Developer]
+    const authorizedRoles: RoleAccess['authorize'] = [Admin, UserWithEmail]
 
     expect(BoosterAuth.isUserAuthorized(authorizedRoles)).to.eq(false)
   })
@@ -188,17 +188,17 @@ describe('the "isUserAuthorized" method', () => {
     const authorizedRoles: RoleAccess['authorize'] = [Admin]
     const userEnvelope: UserEnvelope = {
       username: 'user@test.com',
-      role: 'Developer',
+      role: 'UserWithEmail',
     }
 
     expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(false)
   })
 
   it('returns true when the user has any of the "authorizedRoles"', () => {
-    const authorizedRoles: RoleAccess['authorize'] = [Admin, Developer]
+    const authorizedRoles: RoleAccess['authorize'] = [Admin, UserWithEmail]
     const userEnvelope: UserEnvelope = {
       username: 'user@test.com',
-      role: 'Developer',
+      role: 'UserWithEmail',
     }
 
     expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(true)

--- a/packages/framework-core/test/booster-read-model-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-read-model-dispatcher.test.ts
@@ -79,7 +79,10 @@ describe('BoosterReadModelDispatcher', () => {
         requestID: random.uuid(),
         version: 1,
         currentUser: {
-          email: internet.email(),
+          username: {
+            value: internet.email(),
+            type: 'email',
+          },
           role: '',
         },
       }
@@ -107,7 +110,10 @@ describe('BoosterReadModelDispatcher', () => {
       version: 1,
       filters,
       currentUser: {
-        email: internet.email(),
+        username: {
+          value: internet.email(),
+          type: 'email',
+        },
         role: UserRole.name,
       },
     }

--- a/packages/framework-core/test/booster-read-model-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-read-model-dispatcher.test.ts
@@ -79,10 +79,7 @@ describe('BoosterReadModelDispatcher', () => {
         requestID: random.uuid(),
         version: 1,
         currentUser: {
-          username: {
-            value: internet.email(),
-            type: 'email',
-          },
+          username: internet.email(),
           role: '',
         },
       }
@@ -110,10 +107,7 @@ describe('BoosterReadModelDispatcher', () => {
       version: 1,
       filters,
       currentUser: {
-        username: {
-          value: internet.email(),
-          type: 'email',
-        },
+        username: internet.email(),
         role: UserRole.name,
       },
     }

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -122,7 +122,10 @@ describe('the `RegisterHandler` class', () => {
       methodName: 'someReducer',
     }
     const user: UserEnvelope = {
-      email: 'paco@example.com',
+      username: {
+        value: 'paco@example.com',
+        type: 'email',
+      },
       role: 'Paco',
     }
     const register = new Register('1234', user)

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -122,10 +122,7 @@ describe('the `RegisterHandler` class', () => {
       methodName: 'someReducer',
     }
     const user: UserEnvelope = {
-      username: {
-        value: 'paco@example.com',
-        type: 'email',
-      },
+      username: 'paco@example.com',
       role: 'Paco',
     }
     const register = new Register('1234', user)

--- a/packages/framework-integration-tests/integration/end-to-end/cart.integration.ts
+++ b/packages/framework-integration-tests/integration/end-to-end/cart.integration.ts
@@ -171,7 +171,7 @@ describe('Cart end-to-end tests', () => {
     before(async () => {
       userEmail = internet.email()
       // TODO: Make retrieval of auth token cloud agnostic
-      await createUser(userEmail, mockPassword, 'User')
+      await createUser(userEmail, mockPassword, 'UserWithEmail')
       userAuthInformation = await getUserAuthInformation(userEmail, mockPassword)
       client = await graphQLClient(userAuthInformation.accessToken)
     })

--- a/packages/framework-integration-tests/integration/providers/aws/auth.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/auth.integration.ts
@@ -221,7 +221,7 @@ describe('With the auth API', () => {
       await expect(subscriptionPromise).to.eventually.be.fulfilled
     })
 
-    it('can sign up for a user account', async () => {
+    it('can sign up with an email', async () => {
       const userEmail = internet.email()
       const userPassword = createPassword()
 
@@ -235,7 +235,35 @@ describe('With the auth API', () => {
           username: userEmail,
           password: userPassword,
           userAttributes: {
-            role: 'User',
+            role: 'UserWithEmail',
+          },
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const message = await response.json()
+      expect(message).to.be.empty
+
+      expect(response.status).to.equal(200)
+    })
+
+    it('can sign up with a phone number', async () => {
+      const userEmail = internet.email()
+      const userPassword = createPassword()
+
+      const url = await signUpURL()
+      const clientId = await authClientID()
+
+      const response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify({
+          clientId: clientId,
+          username: userEmail,
+          password: userPassword,
+          userAttributes: {
+            role: 'UserWithPhone',
           },
         }),
         headers: {
@@ -299,7 +327,7 @@ describe('With the auth API', () => {
           username: userEmail,
           password: userPassword,
           userAttributes: {
-            role: 'User',
+            role: 'UserWithEmail',
           },
         }),
         headers: {

--- a/packages/framework-integration-tests/integration/providers/aws/auth.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/auth.integration.ts
@@ -17,7 +17,7 @@ import {
 import gql from 'graphql-tag'
 import { expect } from 'chai'
 import * as chai from 'chai'
-import { random, internet, finance, lorem } from 'faker'
+import { random, internet, finance, lorem, phone } from 'faker'
 import fetch from 'cross-fetch'
 
 chai.use(require('chai-as-promised'))
@@ -250,7 +250,7 @@ describe('With the auth API', () => {
     })
 
     it('can sign up with a phone number', async () => {
-      const userEmail = internet.email()
+      const userPhoneNumber = phone.phoneNumber('+1##########')
       const userPassword = createPassword()
 
       const url = await signUpURL()
@@ -260,10 +260,10 @@ describe('With the auth API', () => {
         method: 'POST',
         body: JSON.stringify({
           clientId: clientId,
-          username: userEmail,
+          username: userPhoneNumber,
           password: userPassword,
           userAttributes: {
-            role: 'UserWithPhone',
+            role: 'SuperUser',
           },
         }),
         headers: {
@@ -305,10 +305,72 @@ describe('With the auth API', () => {
 
       expect(response.status).to.equal(400)
     })
+
+    it("can't sign up with an email if specified role only has phone as sign up option", async () => {
+      const userEmail = internet.email()
+      const userPassword = createPassword()
+
+      const url = await signUpURL()
+      const clientId = await authClientID()
+
+      const response = await fetch(url, {
+        method: 'post',
+        body: JSON.stringify({
+          clientId: clientId,
+          username: userEmail,
+          password: userPassword,
+          userAttributes: {
+            role: 'UserWithPhone',
+          },
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const message = await response.json()
+      expect(message).not.to.be.empty
+      expect(message.message).to.match(
+        /PreSignUp failed with error User with role UserWithPhone can't sign up with an email, a phone number is expected./
+      )
+
+      expect(response.status).to.equal(400)
+    })
+
+    it("can't sign up with a phone number if specified role only has email as sign up option", async () => {
+      const userPhoneNumber = phone.phoneNumber('+1##########')
+      const userPassword = createPassword()
+
+      const url = await signUpURL()
+      const clientId = await authClientID()
+
+      const response = await fetch(url, {
+        method: 'post',
+        body: JSON.stringify({
+          clientId: clientId,
+          username: userPhoneNumber,
+          password: userPassword,
+          userAttributes: {
+            role: 'UserWithEmail',
+          },
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const message = await response.json()
+      expect(message).not.to.be.empty
+      expect(message.message).to.match(
+        /PreSignUp failed with error User with role UserWithEmail can't sign up with a phone number, an email is expected./
+      )
+
+      expect(response.status).to.equal(400)
+    })
   })
 
-  // The User role is configured in the test project to allow sign ups
-  context('someone with a user account', () => {
+  // The UserWithEmail role is configured in the test project to allow sign ups
+  context('someone with a user with email account', () => {
     let userEmail: string
     let userPassword: string
 
@@ -765,6 +827,66 @@ describe('With the auth API', () => {
           await expect(subscriptionPromise).to.eventually.be.fulfilled
         })
       })
+    })
+  })
+
+  // The UserWithPhone role is configured in the test project to allow sign ups
+  context('someone with a user with phone number account', () => {
+    let userPhoneNumber: string
+    let userPassword: string
+
+    before(async () => {
+      userPhoneNumber = phone.phoneNumber('+1##########')
+      userPassword = createPassword()
+
+      // Create user
+      const url = await signUpURL()
+      const clientId = await authClientID()
+
+      await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify({
+          clientId: clientId,
+          username: userPhoneNumber,
+          password: userPassword,
+          userAttributes: {
+            role: 'UserWithPhone',
+          },
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      // Confirm user
+      await confirmUser(userPhoneNumber)
+    })
+
+    after(async () => {
+      await deleteUser(userPhoneNumber)
+    })
+
+    it('can sign in their account and get a valid token', async () => {
+      const url = await signInURL()
+      const clientId = await authClientID()
+
+      const response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify({
+          clientId: clientId,
+          username: userPhoneNumber,
+          password: userPassword,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      expect(response.status).to.equal(200)
+
+      const message = await response.json()
+      expect(message).not.to.be.empty
+      expect(message.accessToken).not.to.be.empty
     })
   })
 

--- a/packages/framework-integration-tests/integration/providers/aws/event-handlers.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/event-handlers.integration.ts
@@ -72,7 +72,7 @@ describe('Event handlers', () => {
         typeName: 'StockMoved',
         entityID: mockProductId,
         currentUser: {
-          email: adminEmail,
+          username: adminEmail,
           role: 'Admin',
         },
       }
@@ -92,7 +92,7 @@ describe('Event handlers', () => {
         typeName: 'ProductAvailabilityChanged',
         entityID: mockProductId,
         currentUser: {
-          email: adminEmail,
+          username: adminEmail,
           role: 'Admin',
         },
       }

--- a/packages/framework-integration-tests/integration/providers/aws/utils.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/utils.ts
@@ -88,7 +88,7 @@ export async function userPoolPhysicalResourceId(): Promise<string> {
   }
 }
 
-export async function createUser(username: string, password: string, role = 'User'): Promise<void> {
+export async function createUser(username: string, password: string, role = 'UserWithEmail'): Promise<void> {
   const physicalResourceId = await userPoolPhysicalResourceId()
   const clientId = await authClientID()
   const temporaryPassword = 'ChangeMePleas3!'

--- a/packages/framework-integration-tests/integration/providers/local/commands.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/local/commands.integration.ts
@@ -58,7 +58,7 @@ describe('commands', () => {
         kind: 'event',
         entityID: mockCartId,
         currentUser: {
-          email: 'test@test.com',
+          username: 'test@test.com',
           role: '',
         },
         entityTypeName: 'Cart',

--- a/packages/framework-integration-tests/src/commands/CreateProduct.ts
+++ b/packages/framework-integration-tests/src/commands/CreateProduct.ts
@@ -1,11 +1,11 @@
 import { Command } from '@boostercloud/framework-core'
 import { ProductCreated } from '../events/ProductCreated'
 import { Register, UUID } from '@boostercloud/framework-types'
-import { User, Admin } from '../roles'
+import { UserWithEmail, Admin } from '../roles'
 import { SKU } from '../common/sku'
 
 @Command({
-  authorize: [Admin, User],
+  authorize: [Admin, UserWithEmail],
 })
 export class CreateProduct {
   public constructor(

--- a/packages/framework-integration-tests/src/read-models/product-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/product-read-model.ts
@@ -1,5 +1,5 @@
 import { ReadModel, Projects } from '@boostercloud/framework-core'
-import { User } from '../roles'
+import { UserWithEmail } from '../roles'
 import { UUID } from '@boostercloud/framework-types'
 import { Product } from '../entities/Product'
 import { SKU } from '../common/sku'
@@ -7,7 +7,7 @@ import { Money } from '../common/money'
 
 // This is an example read model for a possible admin-exclusive report to show last and previous updates to products
 @ReadModel({
-  authorize: [User],
+  authorize: [UserWithEmail],
 })
 export class ProductReadModel {
   public constructor(

--- a/packages/framework-integration-tests/src/roles.ts
+++ b/packages/framework-integration-tests/src/roles.ts
@@ -10,8 +10,21 @@ export class Admin {}
 
 @Role({
   auth: {
-    // Do not specify (or use an empty array) if you don't want to allow sign-ups
     signUpMethods: ['email'],
   },
 })
-export class User {}
+export class UserWithEmail {}
+
+@Role({
+  auth: {
+    signUpMethods: ['phone'],
+  },
+})
+export class UserWithPhone {}
+
+@Role({
+  auth: {
+    signUpMethods: ['email', 'phone'],
+  },
+})
+export class SuperUser {}

--- a/packages/framework-integration-tests/src/roles.ts
+++ b/packages/framework-integration-tests/src/roles.ts
@@ -11,7 +11,7 @@ export class Admin {}
 @Role({
   authentication: {
     // Do not specify (or use an empty array) if you don't want to allow sign-ups
-    signUpMethods: 'email',
+    signUpMethods: ['email'],
   },
 })
 export class User {}

--- a/packages/framework-integration-tests/src/roles.ts
+++ b/packages/framework-integration-tests/src/roles.ts
@@ -4,7 +4,7 @@ import { Role } from '@boostercloud/framework-core'
   authentication: {
     // Do not specify (or use an empty array) if you don't want to allow sign-ups
     signUpMethods: [],
-  }
+  },
 })
 export class Admin {}
 
@@ -12,6 +12,6 @@ export class Admin {}
   authentication: {
     // Do not specify (or use an empty array) if you don't want to allow sign-ups
     signUpMethods: 'email',
-  }
+  },
 })
 export class User {}

--- a/packages/framework-integration-tests/src/roles.ts
+++ b/packages/framework-integration-tests/src/roles.ts
@@ -1,11 +1,17 @@
 import { Role } from '@boostercloud/framework-core'
 
 @Role({
-  allowSelfSignUp: false,
+  authentication: {
+    // Do not specify (or use an empty array) if you don't want to allow sign-ups
+    signUpMethods: [],
+  }
 })
 export class Admin {}
 
 @Role({
-  allowSelfSignUp: true,
+  authentication: {
+    // Do not specify (or use an empty array) if you don't want to allow sign-ups
+    signUpMethods: 'email',
+  }
 })
 export class User {}

--- a/packages/framework-integration-tests/src/roles.ts
+++ b/packages/framework-integration-tests/src/roles.ts
@@ -1,7 +1,7 @@
 import { Role } from '@boostercloud/framework-core'
 
 @Role({
-  authentication: {
+  auth: {
     // Do not specify (or use an empty array) if you don't want to allow sign-ups
     signUpMethods: [],
   },
@@ -9,7 +9,7 @@ import { Role } from '@boostercloud/framework-core'
 export class Admin {}
 
 @Role({
-  authentication: {
+  auth: {
     // Do not specify (or use an empty array) if you don't want to allow sign-ups
     signUpMethods: ['email'],
   },

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/api-stack-velocity-templates.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/api-stack-velocity-templates.ts
@@ -23,6 +23,15 @@ export const CognitoTemplates = {
              }`,
     response: '{}',
   },
+  confirmSignUp: {
+    request: `#set($root = $input.path('$'))
+             {
+               "ClientId": "$root.clientId",
+               "ConfirmationCode": "$root.confirmationCode",
+               "Username": "$root.username"
+             }`,
+    response: '{}',
+  },
   signIn: {
     request: `#set($root = $input.path('$'))
               {

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/auth-stack.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/auth-stack.ts
@@ -113,11 +113,10 @@ export class AuthStack {
         },
       ],
     }
-    authResource
-      .addResource('sign-up')
-      .addMethod('POST', this.buildSignUpIntegration(cognitoIntegrationRole), methodOptions)
-    authResource
-      .addResource('confirm-sign-up')
+    const signUpResource = authResource.addResource('sign-up')
+    signUpResource.addMethod('POST', this.buildSignUpIntegration(cognitoIntegrationRole), methodOptions)
+    signUpResource
+      .addResource('confirm')
       .addMethod('POST', this.buildConfirmSignUpIntegration(cognitoIntegrationRole), methodOptions)
     authResource
       .addResource('sign-in')

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/auth-stack.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/auth-stack.ts
@@ -150,7 +150,8 @@ export class AuthStack {
   private buildCognitoRoleToSendSNSMessages(): Role {
     return new Role(this.stack, 'cognito-sns-messages-role', {
       assumedBy: new ServicePrincipal('cognito-idp.amazonaws.com'),
-      description: 'An IAM Role to allow Cognito to send SNS messages',
+      description:
+        'An IAM Role to allow Cognito to send SNS messages in order for users to be register themselves through their phones',
       inlinePolicies: {
         'cognito-sns-managed-policy': new PolicyDocument({
           statements: [

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/api-stack-velocity-templates.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/api-stack-velocity-templates.test.ts
@@ -87,6 +87,42 @@ describe('CognitoTemplates', () => {
     })
   })
 
+  describe('ConfirmSignUp', () => {
+    describe('request', () => {
+      it('returns the Cognito expected input', () => {
+        const input = {
+          clientId: 'a-client-id',
+          confirmationCode: '12345',
+          username: 'user@name.com',
+        }
+        const expectedOutput = {
+          ClientId: input.clientId,
+          ConfirmationCode: input.confirmationCode,
+          Username: input.username,
+        }
+
+        const context = buildAwsTemplateContext(input)
+        const gotOutputJSON = JSON.parse(Velocity.render(CognitoTemplates.confirmSignUp.request, context))
+
+        expect(gotOutputJSON).to.be.deep.equal(expectedOutput)
+      })
+    })
+    describe('response', () => {
+      it('returns an empty json object', () => {
+        const input = {
+          any: 'field',
+          other: 'value',
+        }
+        const expectedOutput = {}
+
+        const context = buildAwsTemplateContext(input)
+        const gotOutputJSON = JSON.parse(Velocity.render(CognitoTemplates.confirmSignUp.response, context))
+
+        expect(gotOutputJSON).to.be.deep.equal(expectedOutput)
+      })
+    })
+  })
+
   describe('SignIn', () => {
     describe('request', () => {
       it('returns the Cognito expected input', () => {

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/application-stack.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/application-stack.test.ts
@@ -83,7 +83,7 @@ describe('the application stack builder', () => {
 
   it('builds the application stack of an app with roles correctly', () => {
     config.roles['Admin'] = {
-      authentication: {
+      auth: {
         signUpMethods: [],
       }
     }

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/application-stack.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/application-stack.test.ts
@@ -83,7 +83,9 @@ describe('the application stack builder', () => {
 
   it('builds the application stack of an app with roles correctly', () => {
     config.roles['Admin'] = {
-      allowSelfSignUp: false,
+      authentication: {
+        signUpMethods: [],
+      }
     }
 
     const boosterApp = new App()

--- a/packages/framework-provider-aws/src/library/user-envelopes.ts
+++ b/packages/framework-provider-aws/src/library/user-envelopes.ts
@@ -7,7 +7,7 @@ export class UserEnvelopeBuilder {
     // eslint-disable-next-line @typescript-eslint/camelcase
     const { phone_number, email, 'custom:role': role } = attributes
     // eslint-disable-next-line @typescript-eslint/camelcase
-    const username = email ? { value: email, type: 'email' } : { value: phone_number, type: 'phone' }
+    const username = email ? email : phone_number
 
     return {
       username,

--- a/packages/framework-provider-aws/src/library/user-envelopes.ts
+++ b/packages/framework-provider-aws/src/library/user-envelopes.ts
@@ -11,7 +11,7 @@ export class UserEnvelopeBuilder {
 
     return {
       username,
-      role: role ? role.trim() : '',
+      role: role?.trim() ?? '',
     }
   }
 

--- a/packages/framework-provider-aws/src/library/user-envelopes.ts
+++ b/packages/framework-provider-aws/src/library/user-envelopes.ts
@@ -4,10 +4,14 @@ import { CognitoIdentityServiceProvider } from 'aws-sdk'
 
 export class UserEnvelopeBuilder {
   public static fromAttributeMap(attributes: AttributeMappingType): UserEnvelope {
-    const { email, 'custom:role': role } = attributes
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    const { phone_number, email, 'custom:role': role } = attributes
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    const username = email ? { value: email, type: 'email' } : { value: phone_number, type: 'phone' }
+
     return {
-      email,
-      role: role ? role.trim(): '',
+      username,
+      role: role ? role.trim() : '',
     }
   }
 

--- a/packages/framework-provider-aws/test/library/auth-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/auth-adapter.test.ts
@@ -21,7 +21,10 @@ describe('the auth-adapter', () => {
       }
 
       const expectedOutput: UserEnvelope = {
-        email: cognitoUserEvent.request.userAttributes.email,
+        username: {
+          value: cognitoUserEvent.request.userAttributes.email,
+          type: 'email',
+        },
         role: 'User',
       }
       const gotOutput = rawSignUpDataToUserEnvelope(cognitoUserEvent as any)

--- a/packages/framework-provider-aws/test/library/auth-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/auth-adapter.test.ts
@@ -21,10 +21,7 @@ describe('the auth-adapter', () => {
       }
 
       const expectedOutput: UserEnvelope = {
-        username: {
-          value: cognitoUserEvent.request.userAttributes.email,
-          type: 'email',
-        },
+        username: cognitoUserEvent.request.userAttributes.email,
         role: 'User',
       }
       const gotOutput = rawSignUpDataToUserEnvelope(cognitoUserEvent as any)

--- a/packages/framework-provider-aws/test/library/graphql-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/graphql-adapter.test.ts
@@ -34,7 +34,10 @@ describe('AWS Provider graphql-adapter', () => {
       mockConnectionId = random.uuid()
 
       expectedUser = {
-        email: internet.email(),
+        username: {
+          value: internet.email(),
+          type: 'email',
+        },
         role: 'Admin',
       }
       expectedQuery = 'GraphQL query'

--- a/packages/framework-provider-aws/test/library/graphql-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/graphql-adapter.test.ts
@@ -34,10 +34,7 @@ describe('AWS Provider graphql-adapter', () => {
       mockConnectionId = random.uuid()
 
       expectedUser = {
-        username: {
-          value: internet.email(),
-          type: 'email',
-        },
+        username: internet.email(),
         role: 'Admin',
       }
       expectedQuery = 'GraphQL query'

--- a/packages/framework-provider-local/src/library/auth-adapter.ts
+++ b/packages/framework-provider-local/src/library/auth-adapter.ts
@@ -16,5 +16,5 @@ export type RegisteredUser = Pick<User, 'username' | 'password' | 'userAttribute
 export type AuthenticatedUser = Pick<User, 'username' | 'token'>
 
 export function rawSignUpDataToUserEnvelope(rawMessage: SignUpUser): UserEnvelope {
-  return { email: rawMessage.username, role: rawMessage.userAttributes.role }
+  return { username: { value:rawMessage.username, type:'email' }, role: rawMessage.userAttributes.role }
 }

--- a/packages/framework-provider-local/src/library/auth-adapter.ts
+++ b/packages/framework-provider-local/src/library/auth-adapter.ts
@@ -16,5 +16,5 @@ export type RegisteredUser = Pick<User, 'username' | 'password' | 'userAttribute
 export type AuthenticatedUser = Pick<User, 'username' | 'token'>
 
 export function rawSignUpDataToUserEnvelope(rawMessage: SignUpUser): UserEnvelope {
-  return { username: { value:rawMessage.username, type:'email' }, role: rawMessage.userAttributes.role }
+  return { username: rawMessage.username, role: rawMessage.userAttributes.role }
 }

--- a/packages/framework-provider-local/src/library/graphql-adapter.ts
+++ b/packages/framework-provider-local/src/library/graphql-adapter.ts
@@ -12,7 +12,10 @@ export async function rawGraphQLRequestToEnvelope(
     eventType: 'MESSAGE', // TODO: (request.requestContext?.eventType as GraphQLRequestEnvelope['eventType']) ?? 'MESSAGE',
     connectionID: undefined, // TODO: Retrieve connectionId if available,
     currentUser: {
-      email: 'test@test.com',
+      username: {
+        value: 'test@test.com',
+        type: 'email',
+      },
       role: '',
     },
     value: request.body,

--- a/packages/framework-provider-local/src/library/graphql-adapter.ts
+++ b/packages/framework-provider-local/src/library/graphql-adapter.ts
@@ -12,10 +12,7 @@ export async function rawGraphQLRequestToEnvelope(
     eventType: 'MESSAGE', // TODO: (request.requestContext?.eventType as GraphQLRequestEnvelope['eventType']) ?? 'MESSAGE',
     connectionID: undefined, // TODO: Retrieve connectionId if available,
     currentUser: {
-      username: {
-        value: 'test@test.com',
-        type: 'email',
-      },
+      username: 'test@test.com',
       role: '',
     },
     value: request.body,

--- a/packages/framework-provider-local/src/services/user-registry.ts
+++ b/packages/framework-provider-local/src/services/user-registry.ts
@@ -93,10 +93,7 @@ export class UserRegistry {
               reject(err)
             } else {
               resolve({
-                username: {
-                  value: doc.username,
-                  type: 'email',
-                },
+                username: doc.username,
                 role: doc.userAttributes.role,
               })
             }

--- a/packages/framework-provider-local/src/services/user-registry.ts
+++ b/packages/framework-provider-local/src/services/user-registry.ts
@@ -93,7 +93,10 @@ export class UserRegistry {
               reject(err)
             } else {
               resolve({
-                email: doc.username,
+                username: {
+                  value: doc.username,
+                  type: 'email',
+                },
                 role: doc.userAttributes.role,
               })
             }

--- a/packages/framework-provider-local/test/library/graphql-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/graphql-adapter.test.ts
@@ -53,10 +53,7 @@ describe('Local provider graphql-adapter', () => {
         eventType: 'MESSAGE',
         connectionID: undefined,
         currentUser: {
-          username: {
-            value: 'test@test.com',
-            type: 'email',
-          },
+          username: 'test@test.com',
           role: '',
         },
         value: mockBody,

--- a/packages/framework-provider-local/test/library/graphql-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/graphql-adapter.test.ts
@@ -53,7 +53,10 @@ describe('Local provider graphql-adapter', () => {
         eventType: 'MESSAGE',
         connectionID: undefined,
         currentUser: {
-          email: 'test@test.com',
+          username: {
+            value: 'test@test.com',
+            type: 'email',
+          },
           role: '',
         },
         value: mockBody,

--- a/packages/framework-provider-local/test/services/user-registry.test.ts
+++ b/packages/framework-provider-local/test/services/user-registry.test.ts
@@ -193,7 +193,7 @@ describe('the user registry', () => {
       expect(userRegistry.authenticatedUsers.findOne).to.have.been.called
       expect(userRegistry.registeredUsers.findOne).to.have.been.called
       expect(retrievedUser).to.deep.equal({
-        username: { value: user.username, type: 'email' },
+        username: user.username,
         role: user.userAttributes.role,
       })
     })

--- a/packages/framework-provider-local/test/services/user-registry.test.ts
+++ b/packages/framework-provider-local/test/services/user-registry.test.ts
@@ -192,7 +192,10 @@ describe('the user registry', () => {
       const retrievedUser = await userRegistry.getAuthenticatedUser(mockToken)
       expect(userRegistry.authenticatedUsers.findOne).to.have.been.called
       expect(userRegistry.registeredUsers.findOne).to.have.been.called
-      expect(retrievedUser).to.deep.equal({ email: user.username, role: user.userAttributes.role })
+      expect(retrievedUser).to.deep.equal({
+        username: { value: user.username, type: 'email' },
+        role: user.userAttributes.role,
+      })
     })
   })
 

--- a/packages/framework-types/src/concepts/role.ts
+++ b/packages/framework-types/src/concepts/role.ts
@@ -4,7 +4,11 @@ import { Class } from '../typelevel'
 export interface RoleInterface {}
 
 export interface RoleMetadata {
-  readonly allowSelfSignUp: boolean
+  readonly authentication: AuthenticationMetadata
+}
+
+export interface AuthenticationMetadata {
+  readonly signUpMethods: 'email' | 'phone' | ['email', 'phone'] | ['phone', 'email'] | []
 }
 
 export interface RoleAccess {

--- a/packages/framework-types/src/concepts/role.ts
+++ b/packages/framework-types/src/concepts/role.ts
@@ -10,7 +10,7 @@ export interface RoleMetadata {
 export type SignUpMethod = 'email' | 'phone'
 
 export interface AuthMetadata {
-  readonly signUpMethods: Array<SignUpMethod>
+  readonly signUpMethods?: Array<SignUpMethod>
 }
 
 export interface RoleAccess {

--- a/packages/framework-types/src/concepts/role.ts
+++ b/packages/framework-types/src/concepts/role.ts
@@ -4,12 +4,12 @@ import { Class } from '../typelevel'
 export interface RoleInterface {}
 
 export interface RoleMetadata {
-  readonly authentication: AuthenticationMetadata
+  readonly auth: AuthMetadata
 }
 
 export type SignUpMethod = 'email' | 'phone'
 
-export interface AuthenticationMetadata {
+export interface AuthMetadata {
   readonly signUpMethods: Array<SignUpMethod>
 }
 

--- a/packages/framework-types/src/concepts/role.ts
+++ b/packages/framework-types/src/concepts/role.ts
@@ -7,8 +7,10 @@ export interface RoleMetadata {
   readonly authentication: AuthenticationMetadata
 }
 
+export type SignUpMethod = 'email' | 'phone'
+
 export interface AuthenticationMetadata {
-  readonly signUpMethods: 'email' | 'phone' | ['email', 'phone'] | ['phone', 'email'] | []
+  readonly signUpMethods: Array<SignUpMethod>
 }
 
 export interface RoleAccess {

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -64,7 +64,12 @@ export interface GraphQLOperation {
   variables?: Record<string, any>
 }
 
+export interface UserName {
+  value: string
+  type: string
+}
+
 export interface UserEnvelope {
-  email: string
+  username: UserName
   role: string
 }

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -64,12 +64,7 @@ export interface GraphQLOperation {
   variables?: Record<string, any>
 }
 
-export interface UserName {
-  value: string
-  type: string
-}
-
 export interface UserEnvelope {
-  username: UserName
+  username: string
   role: string
 }

--- a/packages/framework-types/test/config.test.ts
+++ b/packages/framework-types/test/config.test.ts
@@ -48,7 +48,7 @@ describe('the config type', () => {
     it('returns true when there are roles defined', () => {
       const config = new BoosterConfig('test')
       config.roles['test-role'] = {
-        authentication: {
+        auth: {
           signUpMethods: [],
         },
       }

--- a/packages/framework-types/test/config.test.ts
+++ b/packages/framework-types/test/config.test.ts
@@ -48,7 +48,9 @@ describe('the config type', () => {
     it('returns true when there are roles defined', () => {
       const config = new BoosterConfig('test')
       config.roles['test-role'] = {
-        allowSelfSignUp: false,
+        authentication: {
+          signUpMethods: [],
+        },
       }
 
       expect(config.thereAreRoles).to.be.equal(true)


### PR DESCRIPTION
## Description
- Add phone authentication
- Add authentication wrapper in Role Decorator
- Change boolean allowSelfSignUp with array SignUpOptions with values email and/or phone

## Changes
Added phone authentication properly working with AWS provider (Cognito) 

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly

## Additional information
