### PR TITLE
fix(cli) error messages on empty artifact names

### DIFF
--- a/packages/cli/src/commands/new/command.ts
+++ b/packages/cli/src/commands/new/command.ts
@@ -32,7 +32,7 @@ export default class Command extends Oclif.Command {
     try {
       const fields = flags.fields || []
       if (!args.commandName)
-        throw new Error("You haven't provided a command name, but it is required, run with --help for usage")
+        throw "You haven't provided a command name, but it is required, run with --help for usage"
       return run(args.commandName, fields)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/command.ts
+++ b/packages/cli/src/commands/new/command.ts
@@ -31,8 +31,7 @@ export default class Command extends Oclif.Command {
     const { args, flags } = this.parse(Command)
     try {
       const fields = flags.fields || []
-      if (!args.commandName)
-        throw "You haven't provided a command name, but it is required, run with --help for usage"
+      if (!args.commandName) throw "You haven't provided a command name, but it is required, run with --help for usage"
       return run(args.commandName, fields)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/entity.ts
+++ b/packages/cli/src/commands/new/entity.ts
@@ -39,8 +39,7 @@ export default class Entity extends Oclif.Command {
     try {
       const fields = flags.fields || []
       const events = flags.reduces || []
-      if (!args.entityName)
-        throw "You haven't provided an entity name, but it is required, run with --help for usage"
+      if (!args.entityName) throw "You haven't provided an entity name, but it is required, run with --help for usage"
       return run(args.entityName, fields, events)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/entity.ts
+++ b/packages/cli/src/commands/new/entity.ts
@@ -40,7 +40,7 @@ export default class Entity extends Oclif.Command {
       const fields = flags.fields || []
       const events = flags.reduces || []
       if (!args.entityName)
-        throw new Error("You haven't provided an entity name, but it is required, run with --help for usage")
+        throw "You haven't provided an entity name, but it is required, run with --help for usage"
       return run(args.entityName, fields, events)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/event-handler.ts
+++ b/packages/cli/src/commands/new/event-handler.ts
@@ -32,8 +32,8 @@ export default class EventHandler extends Oclif.Command {
     try {
       const event = flags.event
       if (!args.eventHandlerName)
-        throw new Error("You haven't provided an event handler name, but it is required, run with --help for usage")
-      if (!event) throw new Error("You haven't provided an event, but it is required, run with --help for usage")
+        throw "You haven't provided an event handler name, but it is required, run with --help for usage"
+      if (!event) throw "You haven't provided an event, but it is required, run with --help for usage"
       return run(args.eventHandlerName, event)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/event.ts
+++ b/packages/cli/src/commands/new/event.ts
@@ -32,13 +32,14 @@ export default class Event extends Oclif.Command {
     try {
       const fields = flags.fields || []
       if (!args.eventName)
-        throw new Error("You haven't provided an event name, but it is required, run with --help for usage")
+        throw "You haven't provided an event name, but it is required, run with --help for usage"
       return run(args.eventName, fields)
     } catch (error) {
       console.error(error)
     }
   }
 }
+
 
 type EventInfo = HasName & HasFields
 

--- a/packages/cli/src/commands/new/event.ts
+++ b/packages/cli/src/commands/new/event.ts
@@ -31,15 +31,13 @@ export default class Event extends Oclif.Command {
     const { args, flags } = this.parse(Event)
     try {
       const fields = flags.fields || []
-      if (!args.eventName)
-        throw "You haven't provided an event name, but it is required, run with --help for usage"
+      if (!args.eventName) throw "You haven't provided an event name, but it is required, run with --help for usage"
       return run(args.eventName, fields)
     } catch (error) {
       console.error(error)
     }
   }
 }
-
 
 type EventInfo = HasName & HasFields
 

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -52,7 +52,7 @@ export default class Project extends Command {
     const { args, flags } = this.parse(Project)
     try {
       if (!args.projectName)
-        throw new Error("You haven't provided a project name, but it is required, run with --help for usage")
+        throw "You haven't provided a project name, but it is required, run with --help for usage"
       assertNameIsCorrect(args.projectName)
       const parsedFlags = {
         projectName: args.projectName,

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -51,8 +51,7 @@ export default class Project extends Command {
   public async run(): Promise<void> {
     const { args, flags } = this.parse(Project)
     try {
-      if (!args.projectName)
-        throw "You haven't provided a project name, but it is required, run with --help for usage"
+      if (!args.projectName) throw "You haven't provided a project name, but it is required, run with --help for usage"
       assertNameIsCorrect(args.projectName)
       const parsedFlags = {
         projectName: args.projectName,

--- a/packages/cli/src/commands/new/read-model.ts
+++ b/packages/cli/src/commands/new/read-model.ts
@@ -40,7 +40,7 @@ export default class ReadModel extends Oclif.Command {
       const fields = flags.fields ?? []
       const projections = flags.projects ?? []
       if (!args.readModelName)
-        throw new Error("You haven't provided a read model name, but it is required, run with --help for usage")
+        throw "You haven't provided a read model name, but it is required, run with --help for usage"
       return run(args.readModelName, fields, projections)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/type.ts
+++ b/packages/cli/src/commands/new/type.ts
@@ -25,8 +25,7 @@ export default class Type extends Oclif.Command {
     const { args, flags } = this.parse(Type)
     try {
       const fields = flags.fields || []
-      if (!args.typeName)
-        throw "You haven't provided a type name, but it is required, run with --help for usage"
+      if (!args.typeName) throw "You haven't provided a type name, but it is required, run with --help for usage"
       return run(args.typeName, fields)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/commands/new/type.ts
+++ b/packages/cli/src/commands/new/type.ts
@@ -26,7 +26,7 @@ export default class Type extends Oclif.Command {
     try {
       const fields = flags.fields || []
       if (!args.typeName)
-        throw new Error("You haven't provided a type name, but it is required, run with --help for usage")
+        throw "You haven't provided a type name, but it is required, run with --help for usage"
       return run(args.typeName, fields)
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
## Description
This PR fix how we were returning error messages, so instead of throwing the whole Error object we simply return the string error message.