### PR TITLE
Increase timeout of waitForIt to 5min

### DIFF
--- a/packages/framework-integration-tests/integration/providers/aws/utils.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/utils.ts
@@ -509,7 +509,7 @@ export async function waitForIt<TResult>(
   tryFunction: () => Promise<TResult>,
   checkResult: (result: TResult) => boolean,
   tryEveryMs = 1000,
-  timeoutMs = 60000
+  timeoutMs = 300000
 ): Promise<TResult> {
   const start = Date.now()
   return doWaitFor()


### PR DESCRIPTION
## Description
Since the CI/CD job is failing due to a timeout, in this PR we've increased the timeout limit of `waitForIt` to 5min.  

