### PR TITLE
Split Integration Tests

### DIFF
--- a/.github/workflows/integration-tests-cli.yml
+++ b/.github/workflows/integration-tests-cli.yml
@@ -1,16 +1,16 @@
-name: Tests
+name: Integration
 on:
   issue_comment:
     types: [created, edited]
 
 jobs:
-  integration-tests:
-    name: Old Integration Tests (Deprecated)
-    if: "github.event.comment.body == 'bot: integration/old'"
+  cli-integration-tests:
+    name: CLI Integration Tests
+    if: "github.event.comment.body == 'integration: cli' || github.event.comment.body == 'integration: all'"
     strategy:
       matrix:
         os: [ubuntu-latest]
-      fail-fast: false
+      fail-fast: true
 
     runs-on: ${{ matrix.os }}
 
@@ -25,14 +25,14 @@ jobs:
 
       - name: Create a check for integration tests
         uses: octokit/request-action@v2.x
-        id: create_check_run
+        id: create_cli_integration_check_step
         with:
           route: POST /repos/${{ github.repository }}/check-runs
           mediaType: '{"previews": ["antiope"]}'
-          name: "Integration tests pass"
+          name: "CLI Integration"
           head_sha: ${{ fromJson(steps.pull_request_info.outputs.data).head.sha }}
           status: 'in_progress'
-          output: '{"title":"Integration tests", "summary":"Integration tests are running, you will see the result logs here whey they are finished. If you want to see them now, to the the Actions tab"}'
+          output: '{"title":"CLI Integration Tests", "summary":"CLI integration tests are running, you will see the result logs here whey they are finished. If you want to see them now, to the the Actions tab"}'
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -40,7 +40,7 @@ jobs:
       - name: Print integration tests check data (useful for debuging)
         run: echo "$DATA"
         env:
-          DATA: ${{ toJson(fromJson(steps.create_check_run.outputs.data)) }}
+          DATA: ${{ toJson(fromJson(steps.create_cli_integration_check_step.outputs.data)) }}
 
       - name: Checkout PR branch
         uses: actions/checkout@v2
@@ -68,13 +68,9 @@ jobs:
         run: npx lerna bootstrap
 
       - name: Run integration tests
-        continue-on-error: true
+        continue-on-error: false
         id: integration_tests_run
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.BOT_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.BOT_AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-        run: npx lerna run integration --stream
+        run: npx lerna run integration/cli --stream
 
       - name: Update integration tests check status
         uses: octokit/request-action@v2.x
@@ -82,8 +78,8 @@ jobs:
           route: PATCH /repos/:repository/check-runs/:check_run_id
           repository: ${{ github.repository }}
           mediaType: '{"previews": ["antiope"]}'
-          check_run_id: ${{ fromJson(steps.create_check_run.outputs.data).id }}
+          check_run_id: ${{ fromJson(steps.create_cli_integration_check_step.outputs.data).id }}
           conclusion: ${{ steps.integration_tests_run.outcome }}
-          output: '{"title":"Integration tests", "summary":"Integration tests finished. Here you can take a look at the logs", "text":"```console\n${{ steps.integration_tests_run.outputs.data }}\n``"}'
+          output: '{"title":"CLI Integration Tests", "summary":"Integration tests finished. Here you can take a look at the logs", "text":"```console\n${{ steps.integration_tests_run.outputs.data }}\n``"}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See #402 for further explanation. In this PR I'm adding new Github actions to separately run different modules integration tests:

### General:
- [ ] Removed the giant integration tests script
- [x] CLI Integration tests
- [ ] Local provider tests
### AWS
- [ ] Separate project deployment tests
- [ ] AWS integration tests
- [ ] End-to-end tests that depend on the AWS deployment
- [ ] Separate project "undeployment" tests
### Other providers
- [ ] Leave things ready to create integration tests for other cloud providers