### PR TITLE
Issue #289 - Add missing folders to project generator 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -358,6 +358,8 @@ There you should have these files and directories already generated:
 boosted-blog
 ├── .eslintignore
 ├── .gitignore
+├── .eslintrc.js
+├── .prettierrc.yaml
 ├── package-lock.json
 ├── package.json
 ├── src
@@ -367,7 +369,10 @@ boosted-blog
 │   │   └── config.ts
 │   ├── entities
 │   ├── events
+│   ├── event-handlers
+│   ├── read-models
 │   └── index.ts
+├── tsconfig.eslint.json
 └── tsconfig.json
 ```
 

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -102,7 +102,7 @@ const getProviderPackageName = async (prompter: Prompter, providerPackageName?: 
   }
 }
 
-const parseConfig = async (
+export const parseConfig = async (
   prompter: Prompter,
   flags: Partial<ProjectInitializerConfig>,
   boosterVersion: string

--- a/packages/cli/src/services/project-initializer.ts
+++ b/packages/cli/src/services/project-initializer.ts
@@ -33,6 +33,8 @@ export async function generateRootDirectory(config: ProjectInitializerConfig): P
     [srcDir, 'config'],
     [srcDir, 'entities'],
     [srcDir, 'events'],
+    [srcDir, 'event-handlers'],
+    [srcDir, 'read-models'],
   ]
   await Promise.all(dirs.map(createDirectory))
 }

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -32,8 +32,8 @@ describe('new', (): void => {
         author: 'superAuthor',
         homepage: '',
         license: 'MIT',
-        repository: '@boostercloud/framework-provider-aws (AWS)',
-        providerPackageName: '',
+        repository: '',
+        providerPackageName: '@boostercloud/framework-provider-aws',
         boosterVersion: '0.5.1',
       } as ProjectInitializerConfig
 

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -1,5 +1,58 @@
-// import {expect, test} from '@oclif/test'
+import * as Project from '../../src/commands/new/project'
+import * as ProjectInitializer from '../../src/services/project-initializer'
+import { IConfig } from '@oclif/config'
+import * as fs from 'fs'
+import { expect } from '../expect'
+import { restore, replace, fake } from 'sinon'
+import ErrnoException = NodeJS.ErrnoException
+import { ProjectInitializerConfig } from '../../src/services/project-initializer'
 
 describe('new', (): void => {
-  // TODO: Write proper tests
+  describe('project', () => {
+    context('file generation', () => {
+      const projectName = 'test-project'
+      const projectDirectory = `./${projectName}`
+      const expectedDirectoryContent = {
+        rootPath: [
+          '.eslintignore',
+          '.eslintrc.js',
+          '.gitignore',
+          '.prettierrc.yaml',
+          'package.json',
+          'src',
+          'tsconfig.eslint.json',
+          'tsconfig.json',
+        ],
+        src: ['commands', 'events', 'event-handlers', 'entities', 'read-models', 'config', 'common', 'index.ts'],
+      }
+      const projectInitializerConfig = {
+        projectName: projectName,
+        description: '0.1.0',
+        version: '0.1.0',
+        author: 'superAuthor',
+        homepage: '',
+        license: 'MIT',
+        repository: '@boostercloud/framework-provider-aws (AWS)',
+        providerPackageName: '',
+        boosterVersion: '0.5.1',
+      } as ProjectInitializerConfig
+
+      afterEach(() => {
+        fs.rmdir(projectDirectory, { recursive: true }, (e: ErrnoException | null) => console.error(e))
+        restore()
+      })
+
+      it('generates all required files and folders', async () => {
+        replace(Project, 'parseConfig', fake.returns(projectInitializerConfig))
+        replace(ProjectInitializer, 'installDependencies', fake.returns({}))
+        expect(fs.existsSync(projectDirectory)).to.be.false
+
+        await new Project.default([projectName], {} as IConfig).run()
+
+        expect(fs.existsSync(projectDirectory)).to.be.true
+        expect(fs.readdirSync(projectDirectory)).to.have.all.members(expectedDirectoryContent.rootPath)
+        expect(fs.readdirSync(`${projectDirectory}/src`)).to.have.all.members(expectedDirectoryContent.src)
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Description
Right now, the `boost new:project <project-name>` was missing generating two folders in the `src` directory of our project: event-handlers and read-models.

## Changes
- Add `event-handlers` and `read-models` folders to the project initializer
- Created a test to check the content of our project (directory-based) by checking the project's root and src directories

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly

## Additional information
**Related issue:** https://github.com/boostercloud/booster/issues/289

As usual, let me know if you think I'm missing something. Thanks!