### PR TITLE
I115 - Allow generating a new project with default parameters

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -334,8 +334,13 @@ configured [here](#set-up-an-aws-account).
 ℹ Project generated!
 ```
 
-**Note:** If you prefer to create the project with default parameters (i.e. --license='MIT'), you can run the command as `boost new:project booster-blog --default`. Keep
-in mind that the default cloud provider is AWS!
+**Note:** If you prefer to create the project with default parameters, you can run the command as `boost new:project booster-blog --default`. The default
+parameters are as follows:
+- Project name: The one provided when running the command, in this case "booster-blog"
+- Provider: AWS
+- Description, author, homepage and repository: ""
+- License: MIT
+- Version: 0.1.0
 
 > Booster CLI commands follow this structure: `boost <subcommand> [<flags>] [<parameters>]`. 
 > Let's break down the command we have just executed:

--- a/docs/README.md
+++ b/docs/README.md
@@ -334,6 +334,9 @@ configured [here](#set-up-an-aws-account).
 ℹ Project generated!
 ```
 
+**Note:** If you prefer to create the project with default parameters (i.e. --license='MIT'), you can run the command as `boost new:project booster-blog --default`. Keep
+in mind that the default cloud provider is AWS!
+
 > Booster CLI commands follow this structure: `boost <subcommand> [<flags>] [<parameters>]`. 
 > Let's break down the command we have just executed:
 >

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -47,7 +47,7 @@ export default class Project extends Command {
     default: flags.boolean({
       char: 'd',
       description: 'generates the project with default parameters (i.e. --license=MIT)',
-      default: true,
+      default: false,
     }),
   }
 

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -44,6 +44,11 @@ export default class Project extends Command {
       description:
         'package name implementing the cloud provider integration where the application will be deployed (i.e: "@boostercloud/framework-provider-aws"',
     }),
+    default: flags.boolean({
+      char: 'd',
+      description: 'generates the project with default parameters (i.e. --license=MIT)',
+      default: true,
+    }),
   }
 
   public static args = [{ name: 'projectName' }]
@@ -107,6 +112,21 @@ export const parseConfig = async (
   flags: Partial<ProjectInitializerConfig>,
   boosterVersion: string
 ): Promise<ProjectInitializerConfig> => {
+  if (flags.default) {
+    return Promise.resolve({
+      projectName: flags.projectName as string,
+      providerPackageName: '@boostercloud/framework-provider-aws',
+      description: '',
+      version: '0.1.0',
+      author: '',
+      homepage: '',
+      license: 'MIT',
+      repository: '',
+      boosterVersion,
+      default: flags.default,
+    })
+  }
+
   const description = await prompter.defaultOrPrompt(
     flags.description,
     'What\'s your project description? (default: "")'
@@ -136,5 +156,6 @@ export const parseConfig = async (
     license,
     repository,
     boosterVersion,
+    default: false,
   })
 }

--- a/packages/cli/src/services/project-initializer.ts
+++ b/packages/cli/src/services/project-initializer.ts
@@ -49,6 +49,7 @@ export interface ProjectInitializerConfig {
   repository: string
   providerPackageName: string
   boosterVersion: string
+  default: boolean
 }
 
 function renderToFile(templateData: ProjectInitializerConfig): (_: [Array<string>, string]) => Promise<void> {

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -1,12 +1,10 @@
 import { ProjectInitializerConfig } from '../../src/services/project-initializer'
 import * as fs from 'fs'
 import { restore, replace, fake, spy } from 'sinon'
-import ErrnoException = NodeJS.ErrnoException
 import * as ProjectInitializer from '../../src/services/project-initializer'
 import * as Project from '../../src/commands/new/project'
 import { IConfig } from '@oclif/config'
 import { expect } from '../expect'
-import sinon = require('sinon')
 
 describe('new', (): void => {
   describe('project', () => {
@@ -28,25 +26,26 @@ describe('new', (): void => {
         ],
         src: ['commands', 'events', 'event-handlers', 'entities', 'read-models', 'config', 'common', 'index.ts'],
       }
-      const projectInitializerConfig = {
+      const defaultProjectInitializerConfig = {
         projectName: projectName,
-        description: '0.1.0',
+        description: '',
         version: '0.1.0',
-        author: 'superAuthor',
+        author: '',
         homepage: '',
         license: 'MIT',
         repository: '',
-        providerPackageName: '@boostercloud/framework-provider-aws',
+        providerPackageName: defaultProvider,
         boosterVersion: '0.5.1',
+        default: true,
       } as ProjectInitializerConfig
 
       afterEach(() => {
-        fs.rmdir(projectDirectory, { recursive: true }, (e: ErrnoException | null) => console.error(e))
+        fs.rmdirSync(projectDirectory, { recursive: true })
         restore()
       })
 
       it('generates all required files and folders', async () => {
-        replace(Project, 'parseConfig', fake.returns(projectInitializerConfig))
+        replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
         replace(ProjectInitializer, 'installDependencies', fake.returns({}))
         expect(fs.existsSync(projectDirectory)).to.be.false
 
@@ -58,33 +57,20 @@ describe('new', (): void => {
       })
 
       it('generates project with default parameters when using --default flag', async () => {
+        const parseConfigSpy = spy(Project, 'parseConfig')
         replace(ProjectInitializer, 'installDependencies', fake.returns({}))
         expect(fs.existsSync(projectDirectory)).to.be.false
-        const parseConfigSpy = spy(Project, 'parseConfig')
 
-        await new Project.default([projectName, '--default'], {} as IConfig).run()
-        // TODO: check spy (not checking returned value properly) and booster version issue
+        await new Project.default([projectName, '--default'], { version: '0.5.1' } as IConfig).run()
+
         expect(fs.existsSync(projectDirectory)).to.be.true
-        expect(parseConfigSpy).to.have.returned(
-          sinon.match.same(
-            Promise.resolve({
-              projectName: projectName,
-              providerPackageName: defaultProvider,
-              description: '',
-              version: '0.1.0',
-              author: '',
-              homepage: '',
-              license: 'MIT',
-              repository: '',
-              boosterVersion: '0.5.1',
-              default: true,
-            })
-          )
-        ).and.to.have.been.calledOnce
+        expect(parseConfigSpy).to.have.been.calledOnce
+        expect(await parseConfigSpy.firstCall.returnValue).to.be.deep.equal(
+          defaultProjectInitializerConfig as ProjectInitializerConfig
+        )
 
         const packageJson = JSON.parse(fs.readFileSync(`${projectDirectory}/package.json`).toString())
         expect(packageJson.name).to.be.equal(projectName)
-        expect(packageJson.dependencies[defaultProvider]).to.not.be.undefined
         expect(packageJson.dependencies[defaultProvider]).to.be.equal('*')
         expect(packageJson.description).to.be.equal('')
         expect(packageJson.version).to.be.equal('0.1.0')
@@ -92,7 +78,6 @@ describe('new', (): void => {
         expect(packageJson.homepage).to.be.equal('')
         expect(packageJson.license).to.be.equal('MIT')
         expect(packageJson.repository).to.be.equal('')
-        expect(packageJson.boosterVersion).to.be.equal('0.5.1')
       })
     })
   })

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -1,17 +1,20 @@
-import * as Project from '../../src/commands/new/project'
-import * as ProjectInitializer from '../../src/services/project-initializer'
-import { IConfig } from '@oclif/config'
-import * as fs from 'fs'
-import { expect } from '../expect'
-import { restore, replace, fake } from 'sinon'
-import ErrnoException = NodeJS.ErrnoException
 import { ProjectInitializerConfig } from '../../src/services/project-initializer'
+import * as fs from 'fs'
+import { restore, replace, fake, spy } from 'sinon'
+import ErrnoException = NodeJS.ErrnoException
+import * as ProjectInitializer from '../../src/services/project-initializer'
+import * as Project from '../../src/commands/new/project'
+import { IConfig } from '@oclif/config'
+import { expect } from '../expect'
+import sinon = require('sinon')
 
 describe('new', (): void => {
   describe('project', () => {
     context('file generation', () => {
       const projectName = 'test-project'
       const projectDirectory = `./${projectName}`
+      const defaultProvider = '@boostercloud/framework-provider-aws'
+
       const expectedDirectoryContent = {
         rootPath: [
           '.eslintignore',
@@ -52,6 +55,44 @@ describe('new', (): void => {
         expect(fs.existsSync(projectDirectory)).to.be.true
         expect(fs.readdirSync(projectDirectory)).to.have.all.members(expectedDirectoryContent.rootPath)
         expect(fs.readdirSync(`${projectDirectory}/src`)).to.have.all.members(expectedDirectoryContent.src)
+      })
+
+      it('generates project with default parameters when using --default flag', async () => {
+        replace(ProjectInitializer, 'installDependencies', fake.returns({}))
+        expect(fs.existsSync(projectDirectory)).to.be.false
+        const parseConfigSpy = spy(Project, 'parseConfig')
+
+        await new Project.default([projectName, '--default'], {} as IConfig).run()
+        // TODO: check spy (not checking returned value properly) and booster version issue
+        expect(fs.existsSync(projectDirectory)).to.be.true
+        expect(parseConfigSpy).to.have.returned(
+          sinon.match.same(
+            Promise.resolve({
+              projectName: projectName,
+              providerPackageName: defaultProvider,
+              description: '',
+              version: '0.1.0',
+              author: '',
+              homepage: '',
+              license: 'MIT',
+              repository: '',
+              boosterVersion: '0.5.1',
+              default: true,
+            })
+          )
+        ).and.to.have.been.calledOnce
+
+        const packageJson = JSON.parse(fs.readFileSync(`${projectDirectory}/package.json`).toString())
+        expect(packageJson.name).to.be.equal(projectName)
+        expect(packageJson.dependencies[defaultProvider]).to.not.be.undefined
+        expect(packageJson.dependencies[defaultProvider]).to.be.equal('*')
+        expect(packageJson.description).to.be.equal('')
+        expect(packageJson.version).to.be.equal('0.1.0')
+        expect(packageJson.author).to.be.equal('')
+        expect(packageJson.homepage).to.be.equal('')
+        expect(packageJson.license).to.be.equal('MIT')
+        expect(packageJson.repository).to.be.equal('')
+        expect(packageJson.boosterVersion).to.be.equal('0.5.1')
       })
     })
   })


### PR DESCRIPTION
## Description
Now, when running `boost new:project <my-project> --default`, booster will create the project with all default parameters, without asking the user.

## Changes
- Added a `--default` (or `-d`) flag
- Stopped the "CLI prompt flow" and returned the default parameters from `parseConfig` function when that flag is present
- Wrote tests and refactor common cases from both ones

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly

Fixes #115 