### PR TITLE
Revert "Delete read model"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -573,7 +573,7 @@ export class PostReadModel {
   public constructor(public id: UUID, readonly title: string, readonly author: string) {}
 
   @Projects(Post, 'postId')
-  public static projectPost(entity: Post, currentPostReadModel?: PostReadModel): ProjectionResult<PostReadModel> {
+  public static projectPost(entity: Post, currentPostReadModel?: PostReadModel): PostReadModel {
     return new PostReadModel(entity.id, entity.title, entity.author)
   }
 }
@@ -1349,12 +1349,12 @@ export class ReadModelName {
   ) {}
 
   @Projects(SomeEntity, 'entityField')
-  public static projectionName(entity: SomeEntity, currentEntityReadModel?: ReadModelName): ProjectionResult<ReadModelName> {
+  public static projectionName(entity: SomeEntity, currentEntityReadModel?: ReadModelName): ReadModelName {
     return new ReadModelName(/* initialize here your constructor properties */)
   }
   
   @Projects(SomeEntity, 'othetEntityField')
-  public static projectionName(entity: SomeEntity, currentEntityReadModel?: ReadModelName): ProjectionResult<ReadModelName> {
+  public static projectionName(entity: SomeEntity, currentEntityReadModel?: ReadModelName): ReadModelName {
     return new ReadModelName(/* initialize here your constructor properties */)
   }
   /* as many projections as needed */
@@ -1363,7 +1363,7 @@ export class ReadModelName {
 
 #### Read models naming convention
 
-As it has been previously commented, semantics plays an important role in designing a coherent system and your application should reflect your domain concepts, we recommend choosing a representative domain name and use the `ReadModel` suffix in your read models name.
+As it has been previously commented, semantics plays an important role in designing a coherent system and your application should reflect your domain concepts, we recommend to chooose a representative domain name and use the `ReadModel` suffix in your read models name.
 
 Despite you can place your read models in any directory, we strongly recommend you to put them in `<project-root>/src/read-models`. Having all the read models in one place will help you to understand your application's capabilities at a glance.
 
@@ -1402,34 +1402,13 @@ export class UserReadModel {
   public constructor(readonly username: string, /* ...(other interesting fields from users)... */) {}
   
   @Projects(User, 'id')
-  public static projectUser(entity: User, current?: UserReadModel): ProjectionResult<UserReadModel> { // Here we update the user fields}
+  public static projectUser(entity: User, current?: UserReadModel) { // Here we update the user fields}
 
   @Projects(Post, 'ownerId')
-  public static projectUserPost(entity: Post, current?: UserReadModel): ProjectionResult<UserReadModel> { //Here we can adapt the read model to show specific user information related with the Post entity}
+  public static projectUserPost(entity: Post, current?: UserReadModel) { //Here we can adapt the read model to show specific user information related with the Post entity}
 }
 ```
 In the previous example we are projecting the `User` entity using the user `id` and also we are projecting the `User` entity based on the `ownerId` of the `Post` entity. Notice that both join keys are references to the `User` identifier, but it's not required that the join key is an identifier.
-
-As you may have notice from the `ProjectionResult` type, projections can also return `ReadModelAction`, which includes:
-
-1. Deletion of read models by returning the `ReadModelAction.Delete` value
-2. You can also return `ReadModelAction.Nothing` to keep the read model untouched
-
-```
-@ReadModel
-export class UserReadModel {
-  public constructor(readonly username: string, /* ...(other interesting fields from users)... */) {}
-  
-  @Projects(User, 'id')
-  public static projectUser(entity: User, current?: UserReadModel): ProjectionResult<UserReadModel>  {
-    if (current?.deleted) {
-      return ReadModelAction.Delete
-    } else if (!current?.modified) {
-      return ReadModelAction.Nothing
-    }
-    return new UserReadModel(...)
-  }
-```
 
 #### Authorizing read models
 
@@ -1450,7 +1429,7 @@ export class CartReadModel {
     ) {}
 
   @Projects(Cart, "id")
-  public static projectCart(entity:Cart, currentReadModel: CartReadModel): ProjectionResult<CartReadModel> {
+  public static projectCart(entity:Cart, currentReadModel: CartReadModel): CartReadModel {
     return new CartReadModel(entity.id, entity.items)
   }
 }

--- a/packages/cli/src/commands/new/read-model.ts
+++ b/packages/cli/src/commands/new/read-model.ts
@@ -78,7 +78,7 @@ function generateImports(info: ReadModelInfo): Array<ImportDeclaration> {
     },
     {
       packagePath: '@boostercloud/framework-types',
-      commaSeparatedComponents: 'UUID, ProjectionResult',
+      commaSeparatedComponents: 'UUID',
     },
     ...eventsImports,
   ]

--- a/packages/cli/src/templates/read-model.ts
+++ b/packages/cli/src/templates/read-model.ts
@@ -15,7 +15,7 @@ export class {{{name}}} {
 
   {{#projections}}
   @Projects({{{entityName}}}, "{{{entityId}}}")
-  public static project{{{entityName}}}(entity: {{{entityName}}}, current{{{name}}}?: {{{name}}}): ProjectionResult<{{{name}}}> {
+  public static project{{{entityName}}}(entity: {{{entityName}}}, current{{{name}}}?: {{{name}}}): {{{name}}} {
     return /* NEW {{name}} HERE */
   }
 

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -1,62 +1,13 @@
-import * as ProjectChecker from '../../src/services/project-checker'
 import * as Project from '../../src/commands/new/project'
 import * as ProjectInitializer from '../../src/services/project-initializer'
 import { IConfig } from '@oclif/config'
 import * as fs from 'fs'
 import { expect } from '../expect'
-import { restore, replace, fake, stub } from 'sinon'
+import { restore, replace, fake } from 'sinon'
 import ErrnoException = NodeJS.ErrnoException
 import { ProjectInitializerConfig } from '../../src/services/project-initializer'
-import ReadModel from '../../src/commands/new/read-model'
-import { templates } from '../../src/templates'
-import Mustache = require('mustache')
 
 describe('new', (): void => {
-  describe('Read model', () => {
-    const readModel = 'ExampleReadModel'
-    const readModelsRoot = './src/read-models/'
-    const readModelPath = `${readModelsRoot}${readModel}.ts`
-    afterEach(() => {
-      if (fs.existsSync(readModelPath)) {
-        fs.rmdir(readModelsRoot, { recursive: true }, (err: ErrnoException | null) => console.log(err))
-      }
-      restore()
-    })
-    context('projections', () => {
-      it('renders according to the template', async () => {
-        stub(ProjectChecker, 'checkItIsABoosterProject').returnsThis()
-        await new ReadModel([readModel, '--fields', 'title:string', '--projects', 'Post:id'], {} as IConfig).run()
-        const readModelFileContent = fs.readFileSync(readModelPath).toString()
-        const renderedReadModel = Mustache.render(templates.readModel, {
-          imports: [
-            {
-              packagePath: '@boostercloud/framework-core',
-              commaSeparatedComponents: 'ReadModel, Projects',
-            },
-            {
-              packagePath: '@boostercloud/framework-types',
-              commaSeparatedComponents: 'UUID, ProjectionResult',
-            },
-            {
-              packagePath: '../entities/Post',
-              commaSeparatedComponents: 'Post',
-            },
-          ],
-          name: readModel,
-          fields: [{ name: 'title', type: 'string' }],
-          projections: [
-            {
-              entityName: 'Post',
-              entityId: 'id',
-            },
-          ],
-        })
-
-        expect(readModelFileContent).to.be.equal(renderedReadModel)
-      })
-    })
-  })
-
   describe('project', () => {
     context('file generation', () => {
       const projectName = 'test-project'

--- a/packages/framework-core/src/decorators/projection.ts
+++ b/packages/framework-core/src/decorators/projection.ts
@@ -1,5 +1,5 @@
 import { Booster } from '../booster'
-import { Class, EntityInterface, ProjectionMetadata, ProjectionResult } from '@boostercloud/framework-types'
+import { Class, EntityInterface, ProjectionMetadata } from '@boostercloud/framework-types'
 
 /**
  * Decorator to register a read model method as a projection
@@ -35,6 +35,4 @@ function registerProjection(originName: string, projectionMetadata: ProjectionMe
   })
 }
 
-type ProjectionMethod<TEntity, TReadModel> = TypedPropertyDescriptor<
-  (_: TEntity, readModel?: TReadModel) => ProjectionResult<TReadModel>
->
+type ProjectionMethod<TEntity, TReadModel> = TypedPropertyDescriptor<(_: TEntity, readModel?: TReadModel) => TReadModel>

--- a/packages/framework-core/src/services/read-model-store.ts
+++ b/packages/framework-core/src/services/read-model-store.ts
@@ -9,7 +9,6 @@ import {
   UUID,
   EntityInterface,
   InvalidParameterError,
-  ReadModelAction,
 } from '@boostercloud/framework-types'
 
 export class ReadModelStore {
@@ -31,6 +30,7 @@ export class ReadModelStore {
       )
       return
     }
+
     await Promise.all(
       projections.map(async (projectionMetadata: ProjectionMetadata) => {
         const readModelName = projectionMetadata.class.name
@@ -43,20 +43,6 @@ export class ReadModelStore {
           ' to build new state of read model ${readModelName} with ID ${readModelID}'
         )
         const newReadModel = this.reducerForProjection(projectionMetadata)(entitySnapshot, readModel)
-
-        if (newReadModel === ReadModelAction.Delete) {
-          this.logger.debug(
-            `[ReadModelDelete#project] Deleting read model ${readModelName} with ID ${readModelID}:`,
-            readModel
-          )
-          return this.provider.readModels.delete(this.config, this.logger, readModelName, readModel)
-        } else if (newReadModel === ReadModelAction.Nothing) {
-          this.logger.debug(
-            `[ReadModelStore#project] Skipping actions for ${readModelName} with ID ${readModelID}:`,
-            newReadModel
-          )
-          return
-        }
         this.logger.debug(
           `[ReadModelStore#project] Storing new version of read model ${readModelName} with ID ${readModelID}:`,
           newReadModel
@@ -83,7 +69,7 @@ export class ReadModelStore {
     return joinKey
   }
 
-  public reducerForProjection(projectionMetadata: ProjectionMetadata): Function {
+  private reducerForProjection(projectionMetadata: ProjectionMetadata): Function {
     try {
       return (projectionMetadata.class as any)[projectionMetadata.methodName]
     } catch {

--- a/packages/framework-core/test/decorators/read-model.test.ts
+++ b/packages/framework-core/test/decorators/read-model.test.ts
@@ -2,7 +2,7 @@
 import { expect } from '../expect'
 import { describe } from 'mocha'
 import { ReadModel, Booster, Entity, Projects } from '../../src/index'
-import { UUID, ProjectionResult } from '@boostercloud/framework-types'
+import { UUID } from '@boostercloud/framework-types'
 
 describe('the `ReadModel` decorator', () => {
   afterEach(() => {
@@ -71,7 +71,7 @@ describe('the `Projection` decorator', () => {
       public constructor(readonly id: UUID) {}
 
       @Projects(SomeEntity, 'id')
-      public static observeSomeEntity(entity: SomeEntity): ProjectionResult<SomeReadModel> {
+      public static observeSomeEntity(entity: SomeEntity): SomeReadModel {
         throw new Error(`not implemented for ${entity}`)
       }
     }

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -3,14 +3,7 @@ import { describe } from 'mocha'
 import { restore, fake, replace, spy } from 'sinon'
 import { ReadModelStore } from '../../src/services/read-model-store'
 import { buildLogger } from '../../src/booster-logger'
-import {
-  Level,
-  BoosterConfig,
-  EventEnvelope,
-  UUID,
-  ProviderLibrary,
-  ReadModelAction,
-} from '@boostercloud/framework-types'
+import { Level, BoosterConfig, EventEnvelope, UUID, ProviderLibrary } from '@boostercloud/framework-types'
 import { expect } from '../expect'
 
 describe('ReadModelStore', () => {
@@ -42,7 +35,6 @@ describe('ReadModelStore', () => {
   config.provider = ({
     readModels: {
       store: () => {},
-      delete: () => {},
       fetch: () => {},
     },
   } as unknown) as ProviderLibrary
@@ -94,40 +86,6 @@ describe('ReadModelStore', () => {
 
         expect(config.provider.readModels.store).not.to.have.been.called
         expect(readModelStore.fetchReadModel).not.to.have.been.called
-      })
-    })
-
-    context('when the new read model returns ReadModelAction.Delete', () => {
-      it('deletes the associated read model', async () => {
-        replace(config.provider.readModels, 'store', fake())
-        replace(config.provider.readModels, 'delete', fake())
-        replace(
-          ReadModelStore.prototype,
-          'reducerForProjection',
-          fake.returns(() => ReadModelAction.Delete)
-        )
-        const readModelStore = new ReadModelStore(config, logger)
-
-        await readModelStore.project(anEntitySnapshot)
-        expect(config.provider.readModels.store).not.to.have.been.called
-        expect(config.provider.readModels.delete).to.have.been.calledTwice
-      })
-    })
-
-    context('when the new read model returns ReadModelAction.Nothing', () => {
-      it('ignores the read model', async () => {
-        replace(config.provider.readModels, 'store', fake())
-        replace(config.provider.readModels, 'delete', fake())
-        replace(
-          ReadModelStore.prototype,
-          'reducerForProjection',
-          fake.returns(() => ReadModelAction.Nothing)
-        )
-        const readModelStore = new ReadModelStore(config, logger)
-
-        await readModelStore.project(anEntitySnapshot)
-        expect(config.provider.readModels.store).not.to.have.been.called
-        expect(config.provider.readModels.delete).not.to.have.been.called
       })
     })
 

--- a/packages/framework-integration-tests/integration/end-to-end/cart.integration.ts
+++ b/packages/framework-integration-tests/integration/end-to-end/cart.integration.ts
@@ -307,11 +307,22 @@ describe('Cart end-to-end tests', () => {
               `,
             })
           },
-          () => true
+          (result) => result?.data?.ProductReadModel?.deleted && result?.data?.ProductReadModel?.id === productId
         )
 
         const productData = queryResult.data.ProductReadModel
-        expect(productData).to.be.null
+        const expectedResult = {
+          __typename: 'ProductReadModel',
+          id: productId,
+          sku: '<DELETED>',
+          displayName: '',
+          description: '',
+          price: null,
+          availability: 0,
+          deleted: true,
+        }
+
+        expect(productData).to.be.deep.equal(expectedResult)
       })
     })
   })

--- a/packages/framework-integration-tests/integration/fixtures/read-models/CartReadModel.ts
+++ b/packages/framework-integration-tests/integration/fixtures/read-models/CartReadModel.ts
@@ -1,5 +1,5 @@
 import { ReadModel } from '@boostercloud/framework-core'
-import { UUID, ProjectionResult } from '@boostercloud/framework-types'
+import { UUID } from '@boostercloud/framework-types'
 
 @ReadModel({
   authorize: // Specify authorized roles here. Use 'all' to authorize anyone

--- a/packages/framework-integration-tests/integration/fixtures/read-models/CartWithFieldsReadModel.ts
+++ b/packages/framework-integration-tests/integration/fixtures/read-models/CartWithFieldsReadModel.ts
@@ -1,5 +1,5 @@
 import { ReadModel } from '@boostercloud/framework-core'
-import { UUID, ProjectionResult } from '@boostercloud/framework-types'
+import { UUID } from '@boostercloud/framework-types'
 
 @ReadModel({
   authorize: // Specify authorized roles here. Use 'all' to authorize anyone

--- a/packages/framework-integration-tests/integration/fixtures/read-models/CartWithProjectionReadModel.ts
+++ b/packages/framework-integration-tests/integration/fixtures/read-models/CartWithProjectionReadModel.ts
@@ -1,5 +1,5 @@
 import { ReadModel, Projects } from '@boostercloud/framework-core'
-import { UUID, ProjectionResult } from '@boostercloud/framework-types'
+import { UUID } from '@boostercloud/framework-types'
 import { Cart } from '../entities/Cart'
 
 @ReadModel({
@@ -12,7 +12,7 @@ export class CartWithProjectionReadModel {
   ) {}
 
   @Projects(Cart, "id")
-  public static projectCart(entity: Cart, currentCartWithProjectionReadModel?: CartWithProjectionReadModel): ProjectionResult<CartWithProjectionReadModel> {
+  public static projectCart(entity: Cart, currentCartWithProjectionReadModel?: CartWithProjectionReadModel): CartWithProjectionReadModel {
     return /* NEW CartWithProjectionReadModel HERE */
   }
 

--- a/packages/framework-integration-tests/src/read-models/cart-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/cart-read-model.ts
@@ -1,5 +1,5 @@
 import { ReadModel, Projects } from '@boostercloud/framework-core'
-import { UUID, ProjectionResult } from '@boostercloud/framework-types'
+import { UUID } from '@boostercloud/framework-types'
 import { CartItem } from '../common/cart-item'
 import { Address } from '../common/address'
 import { Cart } from '../entities/Cart'
@@ -17,15 +17,12 @@ export class CartReadModel {
   ) {}
 
   @Projects(Cart, 'id')
-  public static updateWithCart(cart: Cart, oldCartReadModel?: CartReadModel): ProjectionResult<CartReadModel> {
+  public static updateWithCart(cart: Cart, oldCartReadModel?: CartReadModel): CartReadModel {
     return new CartReadModel(cart.id, cart.cartItems, cart.shippingAddress, oldCartReadModel?.payment)
   }
 
   @Projects(Payment, 'cartId')
-  public static updateCartPaymentStatus(
-    payment: Payment,
-    oldCartReadModel?: CartReadModel
-  ): ProjectionResult<CartReadModel> {
+  public static updateCartPaymentStatus(payment: Payment, oldCartReadModel?: CartReadModel): CartReadModel {
     if (!oldCartReadModel) {
       return new CartReadModel(payment.cartId, [], undefined, payment)
     }

--- a/packages/framework-integration-tests/src/read-models/product-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/product-read-model.ts
@@ -1,13 +1,13 @@
 import { ReadModel, Projects } from '@boostercloud/framework-core'
-import { Admin, UserWithEmail } from '../roles'
-import { UUID, ProjectionResult, ReadModelAction } from '@boostercloud/framework-types'
+import { UserWithEmail } from '../roles'
+import { UUID } from '@boostercloud/framework-types'
 import { Product } from '../entities/Product'
 import { SKU } from '../common/sku'
 import { Money } from '../common/money'
 
 // This is an example read model for a possible admin-exclusive report to show last and previous updates to products
 @ReadModel({
-  authorize: [UserWithEmail, Admin],
+  authorize: [UserWithEmail],
 })
 export class ProductReadModel {
   public constructor(
@@ -21,9 +21,10 @@ export class ProductReadModel {
   ) {}
 
   @Projects(Product, 'id')
-  public static updateWithProduct(product: Product): ProjectionResult<ProductReadModel> {
+  public static updateWithProduct(product: Product): ProductReadModel {
     if (product.deleted) {
-      return ReadModelAction.Delete
+      // TODO: Consider solutions to delete read models from the database (see BOOST-587)
+      return new ProductReadModel(product.id, '<DELETED>', '', '', 0, true)
     } else {
       return new ProductReadModel(
         product.id,

--- a/packages/framework-integration-tests/src/read-models/product-updates-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/product-updates-read-model.ts
@@ -1,6 +1,6 @@
 import { ReadModel, Projects } from '@boostercloud/framework-core'
 import { Admin } from '../roles'
-import { UUID, ProjectionResult } from '@boostercloud/framework-types'
+import { UUID } from '@boostercloud/framework-types'
 import { Product } from '../entities/Product'
 
 // This is an example read model for a possible admin-exclusive report to show last and previous updates to products
@@ -16,10 +16,7 @@ export class ProductUpdatesReadModel {
   ) {}
 
   @Projects(Product, 'id')
-  public static updateWithProduct(
-    product: Product,
-    previous?: ProductUpdatesReadModel
-  ): ProjectionResult<ProductUpdatesReadModel> {
+  public static updateWithProduct(product: Product, previous?: ProductUpdatesReadModel): ProductUpdatesReadModel {
     return new ProductUpdatesReadModel(product.id, product.availability, new Date(), previous?.lastUpdate)
   }
 }

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
@@ -52,9 +52,7 @@ export const setupPermissions = (
 
   const tableArns = readModelTables.map((table): string => table.tableArn)
   if (tableArns.length > 0) {
-    eventsLambda.addToRolePolicy(
-      createPolicyStatement(tableArns, ['dynamodb:Get*', 'dynamodb:Put*', 'dynamodb:DeleteItem*'])
-    )
+    eventsLambda.addToRolePolicy(createPolicyStatement(tableArns, ['dynamodb:Get*', 'dynamodb:Put*']))
     graphQLLambda.addToRolePolicy(createPolicyStatement(tableArns, ['dynamodb:Query*', 'dynamodb:Scan*']))
   }
 }

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
@@ -192,7 +192,7 @@ describe('permissions', () => {
         it('should create read model permissions', () => {
           expect(createPolicyStatementStub).calledWithExactly(
             [mockReadModelTableArn],
-            ['dynamodb:Get*', 'dynamodb:Put*', 'dynamodb:DeleteItem*']
+            ['dynamodb:Get*', 'dynamodb:Put*']
           )
         })
       })

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -5,12 +5,7 @@ import {
   readEntityLatestSnapshot,
   readEntityEventsSince,
 } from './library/events-adapter'
-import {
-  fetchReadModel,
-  storeReadModel,
-  rawReadModelEventsToEnvelopes,
-  deleteReadModel,
-} from './library/read-model-adapter'
+import { fetchReadModel, storeReadModel, rawReadModelEventsToEnvelopes } from './library/read-model-adapter'
 import { rawGraphQLRequestToEnvelope } from './library/graphql-adapter'
 import { DynamoDB, CognitoIdentityServiceProvider } from 'aws-sdk'
 import { ProviderInfrastructure, ProviderLibrary } from '@boostercloud/framework-types'
@@ -47,7 +42,6 @@ export const Provider: ProviderLibrary = {
     fetch: fetchReadModel.bind(null, dynamoDB),
     search: searchReadModel.bind(null, dynamoDB),
     store: storeReadModel.bind(null, dynamoDB),
-    delete: deleteReadModel.bind(null, dynamoDB),
     subscribe: subscribeToReadModel.bind(null, dynamoDB),
     fetchSubscriptions: fetchSubscriptions.bind(null, dynamoDB),
     deleteSubscription: deleteSubscription.bind(null, dynamoDB),

--- a/packages/framework-provider-aws/src/library/read-model-adapter.ts
+++ b/packages/framework-provider-aws/src/library/read-model-adapter.ts
@@ -49,22 +49,6 @@ export async function storeReadModel(
   logger.debug('[ReadModelAdapter#storeReadModel] Read model stored')
 }
 
-export async function deleteReadModel(
-  db: DynamoDB.DocumentClient,
-  config: BoosterConfig,
-  logger: Logger,
-  readModelName: string,
-  readModel: ReadModelInterface
-): Promise<void> {
-  await db
-    .delete({
-      TableName: config.resourceNames.forReadModel(readModelName),
-      Key: { id: readModel.id },
-    })
-    .promise()
-  logger.debug('[ReadModelAdapter#deleteReadModel] Read model deleted')
-}
-
 function toReadModelEnvelope(config: BoosterConfig, record: DynamoDBRecord): ReadModelEnvelope {
   if (!record.dynamodb?.NewImage || !record.eventSourceARN) {
     throw new Error('Received a DynamoDB stream event without "eventSourceARN" or "NewImage" field. They are required')

--- a/packages/framework-provider-aws/test/library/read-model-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/read-model-adapter.test.ts
@@ -1,12 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from '../expect'
 import { replace, fake } from 'sinon'
-import {
-  fetchReadModel,
-  storeReadModel,
-  rawReadModelEventsToEnvelopes,
-  deleteReadModel,
-} from '../../src/library/read-model-adapter'
+import { fetchReadModel, storeReadModel, rawReadModelEventsToEnvelopes } from '../../src/library/read-model-adapter'
 import { DynamoDB } from 'aws-sdk'
 import { BoosterConfig, Logger, ReadModelEnvelope } from '@boostercloud/framework-types'
 import { DynamoDBStreamEvent } from 'aws-lambda'
@@ -171,29 +166,6 @@ describe('the "storeReadModel" method', () => {
       Item: { id: 777, some: 'object' },
     })
     expect(something).not.to.be.null
-  })
-})
-
-describe('the "deleteReadModel"', () => {
-  it('deletes an existing read model', async () => {
-    const db: DynamoDB.DocumentClient = new DynamoDB.DocumentClient()
-    const config = new BoosterConfig('test')
-    replace(
-      db,
-      'delete',
-      fake.returns({
-        promise: fake.resolves({
-          $response: {},
-        }),
-      })
-    )
-
-    await deleteReadModel(db, config, logger, 'SomeReadModel', { id: 777, some: 'object' } as any)
-
-    expect(db.delete).to.have.been.calledOnceWithExactly({
-      TableName: 'new-booster-app-app-SomeReadModel',
-      Key: { id: 777 },
-    })
   })
 })
 

--- a/packages/framework-provider-azure/src/index.ts
+++ b/packages/framework-provider-azure/src/index.ts
@@ -31,7 +31,6 @@ export const Provider: ProviderLibrary = {
     fetch: fetchReadModel.bind(null, cosmosClient),
     search: searchReadModel.bind(null, cosmosClient),
     subscribe: undefined as any,
-    delete: undefined as any,
     rawToEnvelopes: undefined as any,
     fetchSubscriptions: undefined as any,
     store: storeReadModel.bind(null, cosmosClient),

--- a/packages/framework-provider-kubernetes/src/index.ts
+++ b/packages/framework-provider-kubernetes/src/index.ts
@@ -15,7 +15,6 @@ export const Provider: ProviderLibrary = {
     fetch: undefined as any,
     search: undefined as any,
     store: undefined as any,
-    delete: undefined as any,
     subscribe: undefined as any,
     fetchSubscriptions: undefined as any,
     deleteSubscription: undefined as any,

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -36,9 +36,8 @@ export const Provider: ProviderLibrary = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     search: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    store: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete: undefined as any,
+    store: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subscribe: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/framework-provider-local/src/library/graphql-adapter.ts
+++ b/packages/framework-provider-local/src/library/graphql-adapter.ts
@@ -7,8 +7,8 @@ export async function rawGraphQLRequestToEnvelope(
 ): Promise<GraphQLRequestEnvelope | GraphQLRequestEnvelopeError> {
   logger.debug('Received GraphQL request: \n- Headers: ', request.headers, '\n- Body: ', request.body)
   const requestID = UUID.generate() // TODO: Retrieve request ID from request
-  const eventType = 'MESSAGE' // TODO: (request.requestContext?.eventType as GraphQLRequestEnvelope['eventType']) ?? 'MESSAGE'
-  const connectionID = undefined // TODO: Retrieve connectionId if available
+  const eventType = 'MESSAGE' // TODO: (request.requestContext?.eventType as GraphQLRequestEnvelope['eventType']) ?? 'MESSAGE',
+  const connectionID = undefined // TODO: Retrieve connectionId if available,
   try {
     return {
       requestID,

--- a/packages/framework-provider-local/test/library/graphql-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/graphql-adapter.test.ts
@@ -42,12 +42,7 @@ describe('Local provider graphql-adapter', () => {
     it('should call logger.debug', async () => {
       await rawGraphQLRequestToEnvelope(mockRequest, logger)
 
-      expect(debugStub).to.have.been.calledOnceWith(
-        'Received GraphQL request: \n- Headers: ',
-        mockRequest.headers,
-        '\n- Body: ',
-        mockRequest.body
-      )
+      expect(debugStub).to.have.been.calledOnceWith('Received GraphQL request: ', mockRequest)
     })
 
     it('should generate expected envelop', async () => {

--- a/packages/framework-types/src/concepts/projection-metadata.ts
+++ b/packages/framework-types/src/concepts/projection-metadata.ts
@@ -6,10 +6,3 @@ export interface ProjectionMetadata {
   methodName: string
   joinKey: string
 }
-
-export type ProjectionResult<TReadModel> = TReadModel | ReadModelAction
-
-export enum ReadModelAction {
-  Delete,
-  Nothing,
-}

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -51,7 +51,6 @@ export interface ProviderReadModelsLibrary {
     filters: Record<string, Filter<unknown>>
   ): Promise<Array<TReadModel>>
   store(config: BoosterConfig, logger: Logger, readModelName: string, readModel: ReadModelInterface): Promise<unknown>
-  delete(config: BoosterConfig, logger: Logger, readModelName: string, readModel: ReadModelInterface): Promise<any>
   subscribe(config: BoosterConfig, logger: Logger, subscriptionEnvelope: SubscriptionEnvelope): Promise<void>
   fetchSubscriptions(
     config: BoosterConfig,


### PR DESCRIPTION
This reverts commit a17b4d46a2c60204f5391ff6d4804e74e1fb9564, reversing
changes made to e53db551811da3acfcf25b07122a45ba8a1290ac.

## Description
It looks like the integration tests had some errors, I'm reverting and opening a new PR. It was a mix of lint issues and this `Error: Timeout of 80000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves` (??). I'll check it

This reverts: https://github.com/boostercloud/booster/pull/404
