### PR TITLE
Delete read models when projecting null

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -581,7 +581,7 @@ export class PostReadModel {
   public constructor(public id: UUID, readonly title: string, readonly author: string) {}
 
   @Projects(Post, 'postId')
-  public static projectPost(entity: Post, currentPostReadModel?: PostReadModel): PostReadModel {
+  public static projectPost(entity: Post, currentPostReadModel?: PostReadModel): ProjectionResult<PostReadModel> {
     return new PostReadModel(entity.id, entity.title, entity.author)
   }
 }
@@ -1357,12 +1357,12 @@ export class ReadModelName {
   ) {}
 
   @Projects(SomeEntity, 'entityField')
-  public static projectionName(entity: SomeEntity, currentEntityReadModel?: ReadModelName): ReadModelName {
+  public static projectionName(entity: SomeEntity, currentEntityReadModel?: ReadModelName): ProjectionResult<ReadModelName> {
     return new ReadModelName(/* initialize here your constructor properties */)
   }
   
   @Projects(SomeEntity, 'othetEntityField')
-  public static projectionName(entity: SomeEntity, currentEntityReadModel?: ReadModelName): ReadModelName {
+  public static projectionName(entity: SomeEntity, currentEntityReadModel?: ReadModelName): ProjectionResult<ReadModelName> {
     return new ReadModelName(/* initialize here your constructor properties */)
   }
   /* as many projections as needed */
@@ -1371,7 +1371,7 @@ export class ReadModelName {
 
 #### Read models naming convention
 
-As it has been previously commented, semantics plays an important role in designing a coherent system and your application should reflect your domain concepts, we recommend to chooose a representative domain name and use the `ReadModel` suffix in your read models name.
+As it has been previously commented, semantics plays an important role in designing a coherent system and your application should reflect your domain concepts, we recommend choosing a representative domain name and use the `ReadModel` suffix in your read models name.
 
 Despite you can place your read models in any directory, we strongly recommend you to put them in `<project-root>/src/read-models`. Having all the read models in one place will help you to understand your application's capabilities at a glance.
 
@@ -1410,13 +1410,32 @@ export class UserReadModel {
   public constructor(readonly username: string, /* ...(other interesting fields from users)... */) {}
   
   @Projects(User, 'id')
-  public static projectUser(entity: User, current?: UserReadModel) { // Here we update the user fields}
+  public static projectUser(entity: User, current?: ProjectionResult<UserReadModel>) { // Here we update the user fields}
 
   @Projects(Post, 'ownerId')
-  public static projectUserPost(entity: Post, current?: UserReadModel) { //Here we can adapt the read model to show specific user information related with the Post entity}
+  public static projectUserPost(entity: Post, current?: ProjectionResult<UserReadModel>) { //Here we can adapt the read model to show specific user information related with the Post entity}
 }
 ```
 In the previous example we are projecting the `User` entity using the user `id` and also we are projecting the `User` entity based on the `ownerId` of the `Post` entity. Notice that both join keys are references to the `User` identifier, but it's not required that the join key is an identifier.
+
+As you may have notice from the `ProjectionResult` type, projections can also return `ReadModelAction`, which includes:
+1. Deletion of read models by returning the `ReadModelAction.Delete` value
+2. You can also return `ReadModelAction.Nothing` to keep the read model untouched
+```
+@ReadModel
+export class UserReadModel {
+  public constructor(readonly username: string, /* ...(other interesting fields from users)... */) {}
+  
+  @Projects(User, 'id')
+  public static projectUser(entity: User, current?: UserReadModel): ProjectionResult<UserReadModel>  {
+    if (current?.deleted) {
+      return ReadModelAction.Delete
+    } else if (!current?.modified) {
+      return ReadModelAction.Nothing
+    }
+    return new UserReadModel(...)
+  }
+```
 
 #### Authorizing read models
 
@@ -1437,7 +1456,7 @@ export class CartReadModel {
     ) {}
 
   @Projects(Cart, "id")
-  public static projectCart(entity:Cart, currentReadModel: CartReadModel): CartReadModel {
+  public static projectCart(entity:Cart, currentReadModel: CartReadModel): ProjectionResult<CartReadModel> {
     return new CartReadModel(entity.id, entity.items)
   }
 }

--- a/packages/cli/src/commands/new/read-model.ts
+++ b/packages/cli/src/commands/new/read-model.ts
@@ -78,7 +78,7 @@ function generateImports(info: ReadModelInfo): Array<ImportDeclaration> {
     },
     {
       packagePath: '@boostercloud/framework-types',
-      commaSeparatedComponents: 'UUID',
+      commaSeparatedComponents: 'UUID, ProjectionResult',
     },
     ...eventsImports,
   ]

--- a/packages/cli/src/commands/new/read-model.ts
+++ b/packages/cli/src/commands/new/read-model.ts
@@ -78,7 +78,7 @@ function generateImports(info: ReadModelInfo): Array<ImportDeclaration> {
     },
     {
       packagePath: '@boostercloud/framework-types',
-      commaSeparatedComponents: 'UUID, ProjectionResult',
+      commaSeparatedComponents: info.projections.length > 0 ? 'UUID, ProjectionResult' : 'UUID',
     },
     ...eventsImports,
   ]

--- a/packages/cli/src/templates/read-model.ts
+++ b/packages/cli/src/templates/read-model.ts
@@ -15,7 +15,7 @@ export class {{{name}}} {
 
   {{#projections}}
   @Projects({{{entityName}}}, "{{{entityId}}}")
-  public static project{{{entityName}}}(entity: {{{entityName}}}, current{{{name}}}?: {{{name}}}): {{{name}}} {
+  public static project{{{entityName}}}(entity: {{{entityName}}}, current{{{name}}}?: {{{name}}}): ProjectionResult<{{{name}}}> {
     return /* NEW {{name}} HERE */
   }
 

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -1,12 +1,61 @@
+import * as ProjectChecker from '../../src/services/project-checker'
+import { restore, replace, fake, stub, spy } from 'sinon'
+import ErrnoException = NodeJS.ErrnoException
 import { ProjectInitializerConfig } from '../../src/services/project-initializer'
+import ReadModel from '../../src/commands/new/read-model'
+import { templates } from '../../src/templates'
+import Mustache = require('mustache')
 import * as fs from 'fs'
-import { restore, replace, fake, spy } from 'sinon'
-import * as ProjectInitializer from '../../src/services/project-initializer'
-import * as Project from '../../src/commands/new/project'
 import { IConfig } from '@oclif/config'
 import { expect } from '../expect'
+import * as Project from '../../src/commands/new/project'
+import * as ProjectInitializer from '../../src/services/project-initializer'
 
 describe('new', (): void => {
+  describe('Read model', () => {
+    const readModel = 'ExampleReadModel'
+    const readModelsRoot = './src/read-models/'
+    const readModelPath = `${readModelsRoot}${readModel}.ts`
+    afterEach(() => {
+      if (fs.existsSync(readModelPath)) {
+        fs.rmdir(readModelsRoot, { recursive: true }, (err: ErrnoException | null) => console.log(err))
+      }
+      restore()
+    })
+    context('projections', () => {
+      it('renders according to the template', async () => {
+        stub(ProjectChecker, 'checkItIsABoosterProject').returnsThis()
+        await new ReadModel([readModel, '--fields', 'title:string', '--projects', 'Post:id'], {} as IConfig).run()
+        const readModelFileContent = fs.readFileSync(readModelPath).toString()
+        const renderedReadModel = Mustache.render(templates.readModel, {
+          imports: [
+            {
+              packagePath: '@boostercloud/framework-core',
+              commaSeparatedComponents: 'ReadModel, Projects',
+            },
+            {
+              packagePath: '@boostercloud/framework-types',
+              commaSeparatedComponents: 'UUID, ProjectionResult',
+            },
+            {
+              packagePath: '../entities/Post',
+              commaSeparatedComponents: 'Post',
+            },
+          ],
+          name: readModel,
+          fields: [{ name: 'title', type: 'string' }],
+          projections: [
+            {
+              entityName: 'Post',
+              entityId: 'id',
+            },
+          ],
+        })
+
+        expect(readModelFileContent).to.be.equal(renderedReadModel)
+      })
+    })
+  })
   describe('project', () => {
     context('file generation', () => {
       const projectName = 'test-project'

--- a/packages/framework-core/src/decorators/projection.ts
+++ b/packages/framework-core/src/decorators/projection.ts
@@ -1,5 +1,5 @@
 import { Booster } from '../booster'
-import { Class, EntityInterface, ProjectionMetadata } from '@boostercloud/framework-types'
+import { Class, EntityInterface, ProjectionMetadata, ProjectionResult } from '@boostercloud/framework-types'
 
 /**
  * Decorator to register a read model method as a projection
@@ -35,4 +35,6 @@ function registerProjection(originName: string, projectionMetadata: ProjectionMe
   })
 }
 
-type ProjectionMethod<TEntity, TReadModel> = TypedPropertyDescriptor<(_: TEntity, readModel?: TReadModel) => TReadModel>
+type ProjectionMethod<TEntity, TReadModel> = TypedPropertyDescriptor<
+  (_: TEntity, readModel?: TReadModel) => ProjectionResult<TReadModel>
+>

--- a/packages/framework-core/test/decorators/read-model.test.ts
+++ b/packages/framework-core/test/decorators/read-model.test.ts
@@ -2,7 +2,7 @@
 import { expect } from '../expect'
 import { describe } from 'mocha'
 import { ReadModel, Booster, Entity, Projects } from '../../src/index'
-import { UUID } from '@boostercloud/framework-types'
+import { UUID, ProjectionResult } from '@boostercloud/framework-types'
 
 describe('the `ReadModel` decorator', () => {
   afterEach(() => {
@@ -71,7 +71,7 @@ describe('the `Projection` decorator', () => {
       public constructor(readonly id: UUID) {}
 
       @Projects(SomeEntity, 'id')
-      public static observeSomeEntity(entity: SomeEntity): SomeReadModel {
+      public static observeSomeEntity(entity: SomeEntity): ProjectionResult<SomeReadModel> {
         throw new Error(`not implemented for ${entity}`)
       }
     }

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -3,7 +3,14 @@ import { describe } from 'mocha'
 import { restore, fake, replace, spy } from 'sinon'
 import { ReadModelStore } from '../../src/services/read-model-store'
 import { buildLogger } from '../../src/booster-logger'
-import { Level, BoosterConfig, EventEnvelope, UUID, ProviderLibrary } from '@boostercloud/framework-types'
+import {
+  Level,
+  BoosterConfig,
+  EventEnvelope,
+  UUID,
+  ProviderLibrary,
+  ReadModelAction,
+} from '@boostercloud/framework-types'
 import { expect } from '../expect'
 
 describe('ReadModelStore', () => {
@@ -35,6 +42,7 @@ describe('ReadModelStore', () => {
   config.provider = ({
     readModels: {
       store: () => {},
+      delete: () => {},
       fetch: () => {},
     },
   } as unknown) as ProviderLibrary
@@ -86,6 +94,40 @@ describe('ReadModelStore', () => {
 
         expect(config.provider.readModels.store).not.to.have.been.called
         expect(readModelStore.fetchReadModel).not.to.have.been.called
+      })
+    })
+
+    context('when the new read model returns ReadModelAction.Delete', () => {
+      it('deletes the associated read model', async () => {
+        replace(config.provider.readModels, 'store', fake())
+        replace(config.provider.readModels, 'delete', fake())
+        replace(
+          ReadModelStore.prototype,
+          'reducerForProjection',
+          fake.returns(() => ReadModelAction.Delete)
+        )
+        const readModelStore = new ReadModelStore(config, logger)
+
+        await readModelStore.project(anEntitySnapshot)
+        expect(config.provider.readModels.store).not.to.have.been.called
+        expect(config.provider.readModels.delete).to.have.been.calledTwice
+      })
+    })
+
+    context('when the new read model returns ReadModelAction.Nothing', () => {
+      it('ignores the read model', async () => {
+        replace(config.provider.readModels, 'store', fake())
+        replace(config.provider.readModels, 'delete', fake())
+        replace(
+          ReadModelStore.prototype,
+          'reducerForProjection',
+          fake.returns(() => ReadModelAction.Nothing)
+        )
+        const readModelStore = new ReadModelStore(config, logger)
+
+        await readModelStore.project(anEntitySnapshot)
+        expect(config.provider.readModels.store).not.to.have.been.called
+        expect(config.provider.readModels.delete).not.to.have.been.called
       })
     })
 

--- a/packages/framework-integration-tests/integration/end-to-end/cart.integration.ts
+++ b/packages/framework-integration-tests/integration/end-to-end/cart.integration.ts
@@ -307,22 +307,12 @@ describe('Cart end-to-end tests', () => {
               `,
             })
           },
-          (result) => result?.data?.ProductReadModel?.deleted && result?.data?.ProductReadModel?.id === productId
+          () => true
         )
 
         const productData = queryResult.data.ProductReadModel
-        const expectedResult = {
-          __typename: 'ProductReadModel',
-          id: productId,
-          sku: '<DELETED>',
-          displayName: '',
-          description: '',
-          price: null,
-          availability: 0,
-          deleted: true,
-        }
 
-        expect(productData).to.be.deep.equal(expectedResult)
+        expect(productData).to.be.null
       })
     })
   })

--- a/packages/framework-integration-tests/integration/end-to-end/cart.integration.ts
+++ b/packages/framework-integration-tests/integration/end-to-end/cart.integration.ts
@@ -11,6 +11,7 @@ import { random, commerce, finance, lorem, internet } from 'faker'
 import { expect } from 'chai'
 import gql from 'graphql-tag'
 import { CartItem } from '../../src/common/cart-item'
+import { sleep } from '../../integration/providers/helpers'
 
 describe('Cart end-to-end tests', () => {
   let client: ApolloClient<NormalizedCacheObject>
@@ -283,6 +284,9 @@ describe('Cart end-to-end tests', () => {
             }
           `,
         })
+
+        console.log('Waiting 1 second for deletion to complete...')
+        await sleep(1000)
 
         client = await graphQLClient(userAuthInformation.accessToken)
         // Retrieve updated entity

--- a/packages/framework-integration-tests/integration/fixtures/read-models/CartReadModel.ts
+++ b/packages/framework-integration-tests/integration/fixtures/read-models/CartReadModel.ts
@@ -1,5 +1,5 @@
 import { ReadModel } from '@boostercloud/framework-core'
-import { UUID } from '@boostercloud/framework-types'
+import { UUID, ProjectionResult } from '@boostercloud/framework-types'
 
 @ReadModel({
   authorize: // Specify authorized roles here. Use 'all' to authorize anyone

--- a/packages/framework-integration-tests/integration/fixtures/read-models/CartReadModel.ts
+++ b/packages/framework-integration-tests/integration/fixtures/read-models/CartReadModel.ts
@@ -1,5 +1,5 @@
 import { ReadModel } from '@boostercloud/framework-core'
-import { UUID, ProjectionResult } from '@boostercloud/framework-types'
+import { UUID } from '@boostercloud/framework-types'
 
 @ReadModel({
   authorize: // Specify authorized roles here. Use 'all' to authorize anyone

--- a/packages/framework-integration-tests/integration/fixtures/read-models/CartWithFieldsReadModel.ts
+++ b/packages/framework-integration-tests/integration/fixtures/read-models/CartWithFieldsReadModel.ts
@@ -1,5 +1,5 @@
 import { ReadModel } from '@boostercloud/framework-core'
-import { UUID } from '@boostercloud/framework-types'
+import { UUID, ProjectionResult } from '@boostercloud/framework-types'
 
 @ReadModel({
   authorize: // Specify authorized roles here. Use 'all' to authorize anyone

--- a/packages/framework-integration-tests/integration/fixtures/read-models/CartWithFieldsReadModel.ts
+++ b/packages/framework-integration-tests/integration/fixtures/read-models/CartWithFieldsReadModel.ts
@@ -1,5 +1,5 @@
 import { ReadModel } from '@boostercloud/framework-core'
-import { UUID, ProjectionResult } from '@boostercloud/framework-types'
+import { UUID } from '@boostercloud/framework-types'
 
 @ReadModel({
   authorize: // Specify authorized roles here. Use 'all' to authorize anyone

--- a/packages/framework-integration-tests/integration/fixtures/read-models/CartWithProjectionReadModel.ts
+++ b/packages/framework-integration-tests/integration/fixtures/read-models/CartWithProjectionReadModel.ts
@@ -1,5 +1,5 @@
 import { ReadModel, Projects } from '@boostercloud/framework-core'
-import { ProjectionResult, UUID } from '@boostercloud/framework-types'
+import { UUID, ProjectionResult } from '@boostercloud/framework-types'
 import { Cart } from '../entities/Cart'
 
 @ReadModel({

--- a/packages/framework-integration-tests/integration/fixtures/read-models/CartWithProjectionReadModel.ts
+++ b/packages/framework-integration-tests/integration/fixtures/read-models/CartWithProjectionReadModel.ts
@@ -1,5 +1,5 @@
 import { ReadModel, Projects } from '@boostercloud/framework-core'
-import { UUID } from '@boostercloud/framework-types'
+import { ProjectionResult, UUID } from '@boostercloud/framework-types'
 import { Cart } from '../entities/Cart'
 
 @ReadModel({
@@ -12,7 +12,7 @@ export class CartWithProjectionReadModel {
   ) {}
 
   @Projects(Cart, "id")
-  public static projectCart(entity: Cart, currentCartWithProjectionReadModel?: CartWithProjectionReadModel): CartWithProjectionReadModel {
+  public static projectCart(entity: Cart, currentCartWithProjectionReadModel?: CartWithProjectionReadModel): ProjectionResult<CartWithProjectionReadModel> {
     return /* NEW CartWithProjectionReadModel HERE */
   }
 

--- a/packages/framework-integration-tests/src/read-models/cart-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/cart-read-model.ts
@@ -1,5 +1,5 @@
 import { ReadModel, Projects } from '@boostercloud/framework-core'
-import { UUID } from '@boostercloud/framework-types'
+import { ProjectionResult, UUID } from '@boostercloud/framework-types'
 import { CartItem } from '../common/cart-item'
 import { Address } from '../common/address'
 import { Cart } from '../entities/Cart'
@@ -17,12 +17,15 @@ export class CartReadModel {
   ) {}
 
   @Projects(Cart, 'id')
-  public static updateWithCart(cart: Cart, oldCartReadModel?: CartReadModel): CartReadModel {
+  public static updateWithCart(cart: Cart, oldCartReadModel?: CartReadModel): ProjectionResult<CartReadModel> {
     return new CartReadModel(cart.id, cart.cartItems, cart.shippingAddress, oldCartReadModel?.payment)
   }
 
   @Projects(Payment, 'cartId')
-  public static updateCartPaymentStatus(payment: Payment, oldCartReadModel?: CartReadModel): CartReadModel {
+  public static updateCartPaymentStatus(
+    payment: Payment,
+    oldCartReadModel?: CartReadModel
+  ): ProjectionResult<CartReadModel> {
     if (!oldCartReadModel) {
       return new CartReadModel(payment.cartId, [], undefined, payment)
     }

--- a/packages/framework-integration-tests/src/read-models/product-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/product-read-model.ts
@@ -1,6 +1,6 @@
-import { ReadModel, Projects } from '@boostercloud/framework-core'
+import { Projects, ReadModel } from '@boostercloud/framework-core'
 import { UserWithEmail } from '../roles'
-import { UUID } from '@boostercloud/framework-types'
+import { ProjectionResult, ReadModelAction, UUID } from '@boostercloud/framework-types'
 import { Product } from '../entities/Product'
 import { SKU } from '../common/sku'
 import { Money } from '../common/money'
@@ -21,10 +21,9 @@ export class ProductReadModel {
   ) {}
 
   @Projects(Product, 'id')
-  public static updateWithProduct(product: Product): ProductReadModel {
+  public static updateWithProduct(product: Product): ProjectionResult<ProductReadModel> {
     if (product.deleted) {
-      // TODO: Consider solutions to delete read models from the database (see BOOST-587)
-      return new ProductReadModel(product.id, '<DELETED>', '', '', 0, true)
+      return ReadModelAction.Delete
     } else {
       return new ProductReadModel(
         product.id,

--- a/packages/framework-integration-tests/src/read-models/product-updates-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/product-updates-read-model.ts
@@ -1,6 +1,6 @@
 import { ReadModel, Projects } from '@boostercloud/framework-core'
 import { Admin } from '../roles'
-import { UUID } from '@boostercloud/framework-types'
+import { ProjectionResult, UUID } from '@boostercloud/framework-types'
 import { Product } from '../entities/Product'
 
 // This is an example read model for a possible admin-exclusive report to show last and previous updates to products
@@ -16,7 +16,10 @@ export class ProductUpdatesReadModel {
   ) {}
 
   @Projects(Product, 'id')
-  public static updateWithProduct(product: Product, previous?: ProductUpdatesReadModel): ProductUpdatesReadModel {
+  public static updateWithProduct(
+    product: Product,
+    previous?: ProductUpdatesReadModel
+  ): ProjectionResult<ProductUpdatesReadModel> {
     return new ProductUpdatesReadModel(product.id, product.availability, new Date(), previous?.lastUpdate)
   }
 }

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
@@ -52,7 +52,9 @@ export const setupPermissions = (
 
   const tableArns = readModelTables.map((table): string => table.tableArn)
   if (tableArns.length > 0) {
-    eventsLambda.addToRolePolicy(createPolicyStatement(tableArns, ['dynamodb:Get*', 'dynamodb:Put*']))
+    eventsLambda.addToRolePolicy(
+      createPolicyStatement(tableArns, ['dynamodb:Get*', 'dynamodb:Put*', 'dynamodb:DeleteItem*'])
+    )
     graphQLLambda.addToRolePolicy(createPolicyStatement(tableArns, ['dynamodb:Query*', 'dynamodb:Scan*']))
   }
 }

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
@@ -192,7 +192,7 @@ describe('permissions', () => {
         it('should create read model permissions', () => {
           expect(createPolicyStatementStub).calledWithExactly(
             [mockReadModelTableArn],
-            ['dynamodb:Get*', 'dynamodb:Put*']
+            ['dynamodb:Get*', 'dynamodb:Put*', 'dynamodb:DeleteItem*']
           )
         })
       })

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -5,7 +5,12 @@ import {
   readEntityLatestSnapshot,
   readEntityEventsSince,
 } from './library/events-adapter'
-import { fetchReadModel, storeReadModel, rawReadModelEventsToEnvelopes } from './library/read-model-adapter'
+import {
+  fetchReadModel,
+  storeReadModel,
+  rawReadModelEventsToEnvelopes,
+  deleteReadModel,
+} from './library/read-model-adapter'
 import { rawGraphQLRequestToEnvelope } from './library/graphql-adapter'
 import { DynamoDB, CognitoIdentityServiceProvider } from 'aws-sdk'
 import { ProviderInfrastructure, ProviderLibrary } from '@boostercloud/framework-types'
@@ -42,6 +47,7 @@ export const Provider: ProviderLibrary = {
     fetch: fetchReadModel.bind(null, dynamoDB),
     search: searchReadModel.bind(null, dynamoDB),
     store: storeReadModel.bind(null, dynamoDB),
+    delete: deleteReadModel.bind(null, dynamoDB),
     subscribe: subscribeToReadModel.bind(null, dynamoDB),
     fetchSubscriptions: fetchSubscriptions.bind(null, dynamoDB),
     deleteSubscription: deleteSubscription.bind(null, dynamoDB),

--- a/packages/framework-provider-aws/src/library/read-model-adapter.ts
+++ b/packages/framework-provider-aws/src/library/read-model-adapter.ts
@@ -49,6 +49,22 @@ export async function storeReadModel(
   logger.debug('[ReadModelAdapter#storeReadModel] Read model stored')
 }
 
+export async function deleteReadModel(
+  db: DynamoDB.DocumentClient,
+  config: BoosterConfig,
+  logger: Logger,
+  readModelName: string,
+  readModel: ReadModelInterface
+): Promise<void> {
+  await db
+    .delete({
+      TableName: config.resourceNames.forReadModel(readModelName),
+      Key: { id: readModel.id },
+    })
+    .promise()
+  logger.debug('[ReadModelAdapter#deleteReadModel] Read model deleted')
+}
+
 function toReadModelEnvelope(config: BoosterConfig, record: DynamoDBRecord): ReadModelEnvelope {
   if (!record.dynamodb?.NewImage || !record.eventSourceARN) {
     throw new Error('Received a DynamoDB stream event without "eventSourceARN" or "NewImage" field. They are required')

--- a/packages/framework-provider-aws/src/library/read-model-adapter.ts
+++ b/packages/framework-provider-aws/src/library/read-model-adapter.ts
@@ -62,7 +62,7 @@ export async function deleteReadModel(
       Key: { id: readModel.id },
     })
     .promise()
-  logger.debug('[ReadModelAdapter#deleteReadModel] Read model deleted')
+  logger.debug(`[ReadModelAdapter#deleteReadModel] Read model deleted. ID = ${readModel.id}`)
 }
 
 function toReadModelEnvelope(config: BoosterConfig, record: DynamoDBRecord): ReadModelEnvelope {

--- a/packages/framework-provider-aws/test/library/read-model-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/read-model-adapter.test.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from '../expect'
 import { replace, fake } from 'sinon'
-import { fetchReadModel, storeReadModel, rawReadModelEventsToEnvelopes } from '../../src/library/read-model-adapter'
+import {
+  fetchReadModel,
+  storeReadModel,
+  rawReadModelEventsToEnvelopes,
+  deleteReadModel,
+} from '../../src/library/read-model-adapter'
 import { DynamoDB } from 'aws-sdk'
 import { BoosterConfig, Logger, ReadModelEnvelope } from '@boostercloud/framework-types'
 import { DynamoDBStreamEvent } from 'aws-lambda'
@@ -166,6 +171,29 @@ describe('the "storeReadModel" method', () => {
       Item: { id: 777, some: 'object' },
     })
     expect(something).not.to.be.null
+  })
+})
+
+describe('the "deleteReadModel"', () => {
+  it('deletes an existing read model', async () => {
+    const db: DynamoDB.DocumentClient = new DynamoDB.DocumentClient()
+    const config = new BoosterConfig('test')
+    replace(
+      db,
+      'delete',
+      fake.returns({
+        promise: fake.resolves({
+          $response: {},
+        }),
+      })
+    )
+
+    await deleteReadModel(db, config, logger, 'SomeReadModel', { id: 777, some: 'object' } as any)
+
+    expect(db.delete).to.have.been.calledOnceWithExactly({
+      TableName: 'new-booster-app-app-SomeReadModel',
+      Key: { id: 777 },
+    })
   })
 })
 

--- a/packages/framework-provider-azure/src/index.ts
+++ b/packages/framework-provider-azure/src/index.ts
@@ -34,6 +34,7 @@ export const Provider: ProviderLibrary = {
     rawToEnvelopes: undefined as any,
     fetchSubscriptions: undefined as any,
     store: storeReadModel.bind(null, cosmosClient),
+    delete: undefined as any,
     deleteSubscription: undefined as any,
     deleteAllSubscriptions: undefined as any,
   },

--- a/packages/framework-provider-kubernetes/src/index.ts
+++ b/packages/framework-provider-kubernetes/src/index.ts
@@ -15,6 +15,7 @@ export const Provider: ProviderLibrary = {
     fetch: undefined as any,
     search: undefined as any,
     store: undefined as any,
+    delete: undefined as any,
     subscribe: undefined as any,
     fetchSubscriptions: undefined as any,
     deleteSubscription: undefined as any,

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -36,8 +36,9 @@ export const Provider: ProviderLibrary = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     search: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     store: undefined as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subscribe: undefined as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/framework-provider-local/test/library/graphql-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/graphql-adapter.test.ts
@@ -40,6 +40,17 @@ describe('Local provider graphql-adapter', () => {
       restore()
     })
 
+    it('should call logger.debug', async () => {
+      await rawGraphQLRequestToEnvelope(mockRequest, logger)
+
+      expect(debugStub).to.have.been.calledOnceWith(
+        'Received GraphQL request: \n- Headers: ',
+        mockRequest.headers,
+        '\n- Body: ',
+        mockRequest.body
+      )
+    })
+
     it('should generate expected envelop', async () => {
       const result = await rawGraphQLRequestToEnvelope(mockRequest, logger)
 

--- a/packages/framework-types/src/concepts/projection-metadata.ts
+++ b/packages/framework-types/src/concepts/projection-metadata.ts
@@ -6,3 +6,10 @@ export interface ProjectionMetadata {
   methodName: string
   joinKey: string
 }
+
+export type ProjectionResult<TReadModel> = TReadModel | ReadModelAction
+
+export enum ReadModelAction {
+  Delete,
+  Nothing,
+}

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -50,6 +50,7 @@ export interface ProviderReadModelsLibrary {
     filters: Record<string, Filter<unknown>>
   ): Promise<Array<TReadModel>>
   store(config: BoosterConfig, logger: Logger, readModelName: string, readModel: ReadModelInterface): Promise<unknown>
+  delete(config: BoosterConfig, logger: Logger, readModelName: string, readModel: ReadModelInterface): Promise<any>
   subscribe(config: BoosterConfig, logger: Logger, subscriptionEnvelope: SubscriptionEnvelope): Promise<void>
   fetchSubscriptions(
     config: BoosterConfig,


### PR DESCRIPTION
**Note:** This is a copy from https://github.com/boostercloud/booster/pull/404, but fixing CLI integration tests
## Description
With this change, a developer will be able to delete their read models by returning the `deleteReadModel` type. Here's an example:
```
@ReadModel
export class UserReadModel {
  public constructor(readonly username: string, /* ...(other interesting fields from users)... */) {}
  
  @Projects(User, 'id')
  public static projectUser(entity: User, current?: UserReadModel): ProjectionResult<UserReadModel> {
    if (isReadModelDeletable()) {
        return deleteReadModel // This is a type from ProjectionResult
    }
    return new UserReadModel(...)
  }

  private isReadModelDeletable(): boolean {
    ...
  }
```

## Changes
1. Insert a `deleteReadModel` in the `read-model-store` flow, which ends up calling `read-model-adapter` and deleting a read model with a specific id
2. Changed the return value of projections from `TReadModel` to `ProjectionResult<TReadModel>`. This way we can set more values in the future if needed and we also don't return null, which is not that meaningful
3. Modified the `read-model` template to adapt it to the new `ProjectionResult` type
4. Added integration and unit testing
5. Updated the docs

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly

**Note2:** There is something going on on my local environment with integration tests, I'm going to run them here just to know where the issue is