### PR TITLE
Fix missing await in event handler

### DIFF
--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -78,10 +78,10 @@ export class BoosterEventDispatcher {
       return
     }
     await Promise.all(
-      eventHandlers.map((eventHandler: EventHandlerInterface) => {
+      eventHandlers.map(async (eventHandler: EventHandlerInterface) => {
         const register = new Register(eventEnvelope.requestID, eventEnvelope.currentUser)
         logger.debug('Calling "handle" method on event handler: ', eventHandler)
-        eventHandler.handle(eventEnvelope.value as EventInterface, register)
+        await eventHandler.handle(eventEnvelope.value as EventInterface, register)
         return RegisterHandler.handle(config, logger, register)
       })
     )

--- a/packages/framework-core/src/services/read-model-store.ts
+++ b/packages/framework-core/src/services/read-model-store.ts
@@ -43,7 +43,7 @@ export class ReadModelStore {
           entitySnapshotEnvelope,
           ' to build new state of read model ${readModelName} with ID ${readModelID}'
         )
-        const newReadModel = this.reducerForProjection(projectionMetadata)(entitySnapshot, readModel)
+        const newReadModel = this.projectionFunction(projectionMetadata)(entitySnapshot, readModel)
 
         if (newReadModel === ReadModelAction.Delete) {
           this.logger.debug(
@@ -58,7 +58,6 @@ export class ReadModelStore {
           )
           return
         }
-
         this.logger.debug(
           `[ReadModelStore#project] Storing new version of read model ${readModelName} with ID ${readModelID}:`,
           newReadModel
@@ -85,7 +84,7 @@ export class ReadModelStore {
     return joinKey
   }
 
-  public reducerForProjection(projectionMetadata: ProjectionMetadata): Function {
+  public projectionFunction(projectionMetadata: ProjectionMetadata): Function {
     try {
       return (projectionMetadata.class as any)[projectionMetadata.methodName]
     } catch {

--- a/packages/framework-core/test/decorators/event-handler.test.ts
+++ b/packages/framework-core/test/decorators/event-handler.test.ts
@@ -25,7 +25,9 @@ describe('the `EventHandler` decorator', () => {
 
     @EventHandler(SomeEvent)
     class SomeEventHandler {
-      public static handle(_event: SomeEvent, _register: Register): void {}
+      public static handle(_event: SomeEvent, _register: Register): Promise<void> {
+        return Promise.resolve()
+      }
     }
 
     const booster = Booster as any

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -103,7 +103,7 @@ describe('ReadModelStore', () => {
         replace(config.provider.readModels, 'delete', fake())
         replace(
           ReadModelStore.prototype,
-          'reducerForProjection',
+          'projectionFunction',
           fake.returns(() => ReadModelAction.Delete)
         )
         const readModelStore = new ReadModelStore(config, logger)
@@ -120,7 +120,7 @@ describe('ReadModelStore', () => {
         replace(config.provider.readModels, 'delete', fake())
         replace(
           ReadModelStore.prototype,
-          'reducerForProjection',
+          'projectionFunction',
           fake.returns(() => ReadModelAction.Nothing)
         )
         const readModelStore = new ReadModelStore(config, logger)

--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -66,11 +66,15 @@ describe('Project', () => {
     promptAnswers: Array<string> = [],
     flags: Array<string> = []
   ): Promise<string> => {
-    return new Promise<string>((resolve): void => {
+    return new Promise<string>((resolve, reject): void => {
       const childProcess = require('child_process').exec(
         `${cliPath} new:project ${projectName} ${flags.join(' ')}`,
-        (_error: ExecException | null, stdout: string) => {
+        (error: ExecException | null, stdout: string) => {
           childProcess.stdin.end()
+          if (error) {
+            reject(error)
+            return
+          }
           resolve(stdout)
         }
       )

--- a/packages/framework-integration-tests/integration/helper/fileHelper.ts
+++ b/packages/framework-integration-tests/integration/helper/fileHelper.ts
@@ -6,7 +6,7 @@ const rmdir = util.promisify(require('fs').rmdir)
 
 export const readFileContent = (filePath: string): string => fs.readFileSync(filePath, 'utf-8')
 
-export const writeFileContent = (filePath: string, data: unknown): void => fs.writeFileSync(filePath, data)
+export const writeFileContent = (filePath: string, data: string): void => fs.writeFileSync(filePath, data)
 
 export const removeFiles = (filePaths: Array<string>): Array<Promise<void>> =>
   filePaths.map((file: string) => unlink(file))

--- a/packages/framework-types/src/concepts/event-handler.ts
+++ b/packages/framework-types/src/concepts/event-handler.ts
@@ -2,5 +2,5 @@ import { EventInterface } from '../concepts/event'
 import { Register } from './register'
 
 export interface EventHandlerInterface {
-  handle(event: EventInterface, register: Register): void
+  handle(event: EventInterface, register: Register): Promise<void>
 }


### PR DESCRIPTION
## Description
We were calling the "handle" methods of event handlers without an `await`, what means that if the user included an async call in the handler, it won't work. This bug was found by @otoumas 

## Changes
Added the `await` keyword and a test to ensure it won't happen again

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly
 
