### PR TITLE
feat(cli): implement --skipInstall flag

### DIFF
--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -49,7 +49,7 @@ export default class Project extends Command {
       description: 'generates the project with default parameters (i.e. --license=MIT)',
       default: false,
     }),
-    'skip-install': flags.boolean({
+    skipInstall: flags.boolean({
       description: 'skip dependencies installation',
       default: false,
     }),
@@ -78,7 +78,7 @@ const run = async (flags: Partial<ProjectInitializerConfig>, boosterVersion: str
     .step('Creating project root', generateRootDirectory)
     .step('Generating config files', generateConfigFiles)
 
-  if (flags['skip-install']) {
+  if (flags.skipInstall) {
     return boostScript.info('Project generated!').done()
   }
 
@@ -135,7 +135,7 @@ export const parseConfig = async (
       repository: '',
       boosterVersion,
       default: flags.default,
-      'skip-install': false,
+      skipInstall: false,
     })
   }
 
@@ -169,6 +169,6 @@ export const parseConfig = async (
     repository,
     boosterVersion,
     default: false,
-    'skip-install': false,
+    skipInstall: false,
   })
 }

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -49,6 +49,10 @@ export default class Project extends Command {
       description: 'generates the project with default parameters (i.e. --license=MIT)',
       default: false,
     }),
+    'skip-install': flags.boolean({
+      description: 'skip dependencies installation',
+      default: false,
+    }),
   }
 
   public static args = [{ name: 'projectName' }]
@@ -69,13 +73,20 @@ export default class Project extends Command {
   }
 }
 
-const run = async (flags: Partial<ProjectInitializerConfig>, boosterVersion: string): Promise<void> =>
-  Script.init(`boost ${Brand.energize('new')} 🚧`, parseConfig(new Prompter(), flags, boosterVersion))
+const run = async (flags: Partial<ProjectInitializerConfig>, boosterVersion: string): Promise<void> => {
+  const boostScript = Script.init(`boost ${Brand.energize('new')} 🚧`, parseConfig(new Prompter(), flags, boosterVersion))
     .step('Creating project root', generateRootDirectory)
     .step('Generating config files', generateConfigFiles)
+
+  if (flags['skip-install']) {
+    return boostScript.info('Project generated!').done()
+  }
+
+  return boostScript
     .step('Installing dependencies', installDependencies)
     .info('Project generated!')
     .done()
+}
 
 const getSelectedProviderPackage = (provider: Provider): string => {
   switch (provider) {
@@ -124,6 +135,7 @@ export const parseConfig = async (
       repository: '',
       boosterVersion,
       default: flags.default,
+      'skip-install': false,
     })
   }
 
@@ -157,5 +169,6 @@ export const parseConfig = async (
     repository,
     boosterVersion,
     default: false,
+    'skip-install': false,
   })
 }

--- a/packages/cli/src/services/project-initializer.ts
+++ b/packages/cli/src/services/project-initializer.ts
@@ -51,7 +51,7 @@ export interface ProjectInitializerConfig {
   providerPackageName: string
   boosterVersion: string
   default: boolean
-  'skip-install': boolean
+  skipInstall: boolean
 }
 
 function renderToFile(templateData: ProjectInitializerConfig): (_: [Array<string>, string]) => Promise<void> {

--- a/packages/cli/src/services/project-initializer.ts
+++ b/packages/cli/src/services/project-initializer.ts
@@ -51,6 +51,7 @@ export interface ProjectInitializerConfig {
   providerPackageName: string
   boosterVersion: string
   default: boolean
+  'skip-install': boolean
 }
 
 function renderToFile(templateData: ProjectInitializerConfig): (_: [Array<string>, string]) => Promise<void> {

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -96,6 +96,7 @@ describe('new', (): void => {
         providerPackageName: defaultProvider,
         boosterVersion: '0.5.1',
         default: true,
+        'skip-install': false,
       } as ProjectInitializerConfig
 
       afterEach(() => {

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -96,7 +96,7 @@ describe('new', (): void => {
         providerPackageName: defaultProvider,
         boosterVersion: '0.5.1',
         default: true,
-        'skip-install': false,
+        skipInstall: false,
       } as ProjectInitializerConfig
 
       afterEach(() => {
@@ -112,6 +112,19 @@ describe('new', (): void => {
         await new Project.default([projectName], {} as IConfig).run()
 
         expect(fs.existsSync(projectDirectory)).to.be.true
+        expect(fs.readdirSync(projectDirectory)).to.have.all.members(expectedDirectoryContent.rootPath)
+        expect(fs.readdirSync(`${projectDirectory}/src`)).to.have.all.members(expectedDirectoryContent.src)
+      })
+
+      it('generates all required files and folders without installing dependencies', async () => {
+        replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
+        const installDependenciesSpy = spy(ProjectInitializer, 'installDependencies')
+        expect(fs.existsSync(projectDirectory)).to.be.false
+
+        await new Project.default([projectName, '--skipInstall'], {} as IConfig).run()
+
+        expect(fs.existsSync(projectDirectory)).to.be.true
+        expect(installDependenciesSpy).to.have.not.been.calledOnce
         expect(fs.readdirSync(projectDirectory)).to.have.all.members(expectedDirectoryContent.rootPath)
         expect(fs.readdirSync(`${projectDirectory}/src`)).to.have.all.members(expectedDirectoryContent.src)
       })


### PR DESCRIPTION
## Description
CLI flag to skip dependency installation. According to https://github.com/boostercloud/booster/issues/156#issuecomment-667982702 

## Changes

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
## Additional information
There is no documentation about CLI commands