### PR TITLE
GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,16 @@
+## Bug Report
+
+## Current Behavior
+A clear and concise description of the behavior.
+
+## Expected behavior
+A clear and concise description of what you expected to happen (or code).
+
+## Possible Solution
+<!--- Only if you have suggestions on a fix for the bug -->
+
+## Additional information
+
+#### Environment
+- Node/npm version: [e.g. Node 8/npm 5]
+- OS: [e.g. OSX 10.13.4, Windows 10]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,16 +6,21 @@ about: Use this template for reporting a bug.
 ## Bug Report
 
 ## Current Behavior
+
 A clear and concise description of the behavior.
 
 ## Expected behavior
+
 A clear and concise description of what you expected to happen (or code).
 
 ## Possible Solution
+
 <!--- Only if you have suggestions on a fix for the bug -->
 
 ## Additional information
 
 #### Environment
+
+- Booster version: [e.g. 0.8.2] <!--- You can check this with `boost version` -->
 - Node/npm version: [e.g. Node 8/npm 5]
 - OS: [e.g. OSX 10.13.4, Windows 10]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,8 @@
+---
+name: Bug Report
+about: Use this template for reporting a bug.
+---
+
 ## Bug Report
 
 ## Current Behavior

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -6,4 +6,5 @@ about: Use this template for reporting issue or improvements for documentation.
 ## Documentation bug, improvement
 
 ## Description
+
 <-- Description of the documentation issue -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,3 +1,8 @@
+---
+name: Documentation issue
+about: Use this template for reporting issue or improvements for documentation.
+---
+
 ## Documentation bug, improvement
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,4 @@
+## Documentation bug, improvement
+
+## Description
+<-- Description of the documentation issue -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,8 @@
+---
+name: Feature request
+about: Use this template to suggest an idea for this project
+---
+
 ## Feature Request
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,9 @@
+## Feature Request
+
+## Description
+<!--- Description of the feature you want to be implemented -->
+
+## Possible Solution
+<!--- Only if you have suggestions on a implementation -->
+
+## Additional information

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,9 +6,11 @@ about: Use this template to suggest an idea for this project
 ## Feature Request
 
 ## Description
+
 <!--- Description of the feature you want to be implemented -->
 
 ## Possible Solution
+
 <!--- Only if you have suggestions on a implementation -->
 
 ## Additional information


### PR DESCRIPTION
## Description
When I opened issue for git initialization with CLI `--no-git` flag I saw blank issue and didn't know how to write what I wanted to add. This PR will allow users to add new issue for `bug report` / `documentation bug(improvement)` / `feature request` templates. They can be improved to collect more information from user, or separated for each package `cli feature` or `cli bug` for example.