### PR TITLE
fix cli integration tests

### DIFF
--- a/packages/cli/src/templates/project/index-ts.ts
+++ b/packages/cli/src/templates/project/index-ts.ts
@@ -5,7 +5,6 @@ export {
   boosterPreSignUpChecker,
   boosterServeGraphQL,
   boosterNotifySubscribers,
-  boosterTriggerScheduledCommand,
 } from '@boostercloud/framework-core'
 
 Booster.start()

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/src/index.ts
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/src/index.ts
@@ -5,7 +5,6 @@ export {
   boosterPreSignUpChecker,
   boosterServeGraphQL,
   boosterNotifySubscribers,
-  boosterTriggerScheduledCommand,
 } from '@boostercloud/framework-core'
 
 Booster.start()


### PR DESCRIPTION
## Description
CLI integration tests are failing and the new version with the `ScheduledCommands` functionality can't be built. This was happening because the CLI tests were trying to export the new `boosterTriggerScheduledCommand` function from the core, but it didn't exist because it was installing the previous version of Booster `v8.1`. 

## Changes
This fix removes the export of that function, allowing the CLI tests to use the previous version, once this is merged I'll submit some changes to the `ScheduledCommands`, including the usage of these functions in the tests.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
