### PR TITLE
add scheduled commands func to cli tests

### DIFF
--- a/packages/cli/src/templates/project/index-ts.ts
+++ b/packages/cli/src/templates/project/index-ts.ts
@@ -5,6 +5,7 @@ export {
   boosterPreSignUpChecker,
   boosterServeGraphQL,
   boosterNotifySubscribers,
+  boosterTriggerScheduledCommand,
 } from '@boostercloud/framework-core'
 
 Booster.start()

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/src/index.ts
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/src/index.ts
@@ -5,6 +5,7 @@ export {
   boosterPreSignUpChecker,
   boosterServeGraphQL,
   boosterNotifySubscribers,
+  boosterTriggerScheduledCommand,
 } from '@boostercloud/framework-core'
 
 Booster.start()

--- a/scripts/check-all-the-things.sh
+++ b/scripts/check-all-the-things.sh
@@ -1,2 +1,9 @@
 #!/usr/bin/env sh
-lerna clean --yes && lerna run clean --stream && lerna bootstrap && lerna run compile --stream && lerna run lint:fix --stream && lerna run lint:check --stream && lerna run test --stream
+
+lerna clean --yes \
+&& lerna run clean --stream \
+&& lerna bootstrap \
+&& lerna run compile --stream \
+&& lerna run lint:fix --stream \
+&& lerna run lint:check --stream \
+&& lerna run test --stream


### PR DESCRIPTION
## Description
When `ScheduledCommands` were implemented, we spotted that there was an issue when creating the projects in the CLI tests, because it was trying to export a new booster function from an older version of the project, in which it didn't exist.

## Changes
Just added the `ScheduledCommands` booster function to the CLI tests.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- ~[ ] Updated documentation accordingly~ Not necessary
 
## Additional information
It passes all tests, including CLI except the ones that are failing now in master.