### PR TITLE
Reworked the way environments are managed by the CLI

### DIFF
--- a/packages/cli/src/commands/nuke.ts
+++ b/packages/cli/src/commands/nuke.ts
@@ -6,13 +6,13 @@ import { Script } from '../common/script'
 import Brand from '../common/brand'
 import Prompter from '../services/user-prompt'
 import { logger } from '../services/logger'
+import { currentEnvironment, initializeEnvironment } from '../common/environment'
 
 const runTasks = async (
-  environment: string,
   loader: Promise<BoosterConfig>,
   nuke: (config: BoosterConfig, logger: Logger) => Promise<void>
 ): Promise<void> =>
-  Script.init(`boost ${Brand.dangerize('nuke')} [${environment}] 🧨`, loader)
+  Script.init(`boost ${Brand.dangerize('nuke')} [${currentEnvironment()}] 🧨`, loader)
     .step('Removing', (config) => nuke(config, logger))
     .info('Removal complete!')
     .done()
@@ -54,15 +54,11 @@ export default class Nuke extends Command {
 
   public async run(): Promise<void> {
     const { flags } = this.parse(Nuke)
-    if (!flags.environment) {
-      console.log('Error: no environment name provided. Usage: `boost nuke -e <environment>`.')
-      return
+    if (initializeEnvironment(logger, flags.environment)) {
+      await runTasks(
+        askToConfirmRemoval(new Prompter(), flags.force, compileProjectAndLoadConfig()),
+        nukeCloudProviderResources
+      )
     }
-    process.env.BOOSTER_ENV = flags.environment
-    await runTasks(
-      flags.environment,
-      askToConfirmRemoval(new Prompter(), flags.force, compileProjectAndLoadConfig()),
-      nukeCloudProviderResources
-    )
   }
 }

--- a/packages/cli/src/common/environment.ts
+++ b/packages/cli/src/common/environment.ts
@@ -1,0 +1,20 @@
+import { Logger } from '@boostercloud/framework-types'
+
+export function initializeEnvironment(logger: Logger, environment?: string): boolean {
+  // We override the environment with the one passed via flags
+  if (environment) {
+    process.env.BOOSTER_ENV = environment
+  }
+  // If the resulting environment is not set, the user didn't provide an environment and it's not configured in the OS
+  if (!currentEnvironment()) {
+    logger.error(
+      'Error: No environment set. Use the flag `-e` or set the environment variable BOOSTER_ENV to set it before running this command. Example usage: `boost deploy -e <environment>`.'
+    )
+    return false
+  }
+  return true
+}
+
+export function currentEnvironment(): string | undefined {
+  return process.env.BOOSTER_ENV
+}

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { expect } from '../expect'
 import { fancy } from 'fancy-test'
-import { restore, fake } from 'sinon'
+import { restore, fake, replace } from 'sinon'
 import { ProviderLibrary, Logger } from '@boostercloud/framework-types'
 import { test } from '@oclif/test'
+import * as environment from '../../src/common/environment'
 
 // With this trick we can test non exported symbols
 const rewire = require('rewire')
@@ -24,8 +25,9 @@ describe('deploy', () => {
         const msg = 'weird exception'
         const fakeLoader = Promise.reject(new Error(msg))
         const fakeDeployer = fake()
+        replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks('test-env', fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })
@@ -35,8 +37,9 @@ describe('deploy', () => {
         const msg = 'An error when loading project'
         const fakeLoader = Promise.reject(new Error(msg))
         const fakeDeployer = fake()
+        replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks('test-env', fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })
@@ -56,7 +59,9 @@ describe('deploy', () => {
           logger.info('this is a progress update')
         })
 
-        await runTasks('test-env', fakeLoader, fakeDeployer)
+        replace(environment, 'currentEnvironment', fake.returns('test-env'))
+
+        await runTasks(fakeLoader, fakeDeployer)
 
         expect(ctx.stdout).to.include('Deployment complete')
 
@@ -71,7 +76,7 @@ describe('deploy', () => {
         .stdout()
         .command(['deploy'])
         .it('shows no environment provided error', (ctx) => {
-          expect(ctx.stdout).to.equal('Error: no environment name provided. Usage: `boost deploy -e <environment>`.\n')
+          expect(ctx.stdout).to.match(/No environment set/)
         })
     })
   })

--- a/packages/cli/test/commands/nuke.test.ts
+++ b/packages/cli/test/commands/nuke.test.ts
@@ -5,6 +5,7 @@ import { restore, replace, fake } from 'sinon'
 import Prompter from '../../src/services/user-prompt'
 import { ProviderLibrary, Logger } from '@boostercloud/framework-types'
 import { test } from '@oclif/test'
+import * as environment from '../../src/common/environment'
 
 const rewire = require('rewire')
 const nuke = rewire('../../src/commands/nuke')
@@ -22,8 +23,9 @@ describe('nuke', () => {
         const msg = 'weird exception'
         const fakeLoader = Promise.reject(new Error(msg))
         const fakeNuke = fake()
+        replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks('test-env', fakeLoader, fakeNuke)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(fakeLoader, fakeNuke)).to.eventually.be.rejectedWith(msg)
         expect(fakeNuke).not.to.have.been.called
       })
     })
@@ -45,9 +47,9 @@ describe('nuke', () => {
         const fakeNuke = fake()
         const errorMsg = 'Wrong app name, stopping nuke!'
 
-        await expect(runTasks('test-env', loader(prompter, false, fakeConfig), fakeNuke)).to.eventually.be.rejectedWith(
-          errorMsg
-        )
+        replace(environment, 'currentEnvironment', fake.returns('test-env'))
+
+        await expect(runTasks(loader(prompter, false, fakeConfig), fakeNuke)).to.eventually.be.rejectedWith(errorMsg)
         expect(fakeNuke).not.to.have.been.called
       })
     })
@@ -68,7 +70,9 @@ describe('nuke', () => {
         replace(prompter, 'defaultOrPrompt', fakePrompter)
         const fakeNuke = fake()
 
-        await expect(runTasks('test-env', loader(prompter, true, fakeConfig), fakeNuke)).to.eventually.be.fulfilled
+        replace(environment, 'currentEnvironment', fake.returns('test-env'))
+
+        await expect(runTasks(loader(prompter, true, fakeConfig), fakeNuke)).to.eventually.be.fulfilled
         expect(prompter.defaultOrPrompt).not.to.have.been.called
         expect(fakeNuke).to.have.been.calledOnce
       })
@@ -92,7 +96,9 @@ describe('nuke', () => {
           logger.info('this is a progress update')
         })
 
-        await runTasks('test-env', loader(prompter, false, fakeConfig), fakeNuke)
+        replace(environment, 'currentEnvironment', fake.returns('test-env'))
+
+        await runTasks(loader(prompter, false, fakeConfig), fakeNuke)
 
         expect(ctx.stdout).to.include('Removal complete!')
         expect(fakeNuke).to.have.been.calledOnce
@@ -106,7 +112,7 @@ describe('nuke', () => {
         .stdout()
         .command(['nuke'])
         .it('shows no environment provided error', (ctx) => {
-          expect(ctx.stdout).to.equal('Error: no environment name provided. Usage: `boost nuke -e <environment>`.\n')
+          expect(ctx.stdout).to.match(/No environment set/)
         })
     })
   })

--- a/packages/cli/test/commands/start.test.ts
+++ b/packages/cli/test/commands/start.test.ts
@@ -1,8 +1,9 @@
 import { expect } from '../expect'
-import { restore, fake } from 'sinon'
+import { restore, fake, replace } from 'sinon'
 import rewire = require('rewire')
 import { ProviderLibrary } from '@boostercloud/framework-types'
 import { test } from '@oclif/test'
+import * as environment from '../../src/common/environment'
 
 const start = rewire('../../src/commands/start')
 const runTasks = start.__get__('runTasks')
@@ -22,8 +23,9 @@ describe('start', () => {
 
       const fakeLoader = fake.resolves(fakeConfig)
       const fakeRunner = fake()
+      replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-      await runTasks('test-env', 3000, fakeLoader, fakeRunner)
+      await runTasks(3000, fakeLoader, fakeRunner)
 
       expect(fakeRunner).to.have.been.calledOnce
     })
@@ -35,7 +37,7 @@ describe('start', () => {
         .stdout()
         .command(['start'])
         .it('shows no environment provided error', (ctx) => {
-          expect(ctx.stdout).to.equal('Error: no environment name provided. Usage: `boost start -e <environment>`.\n')
+          expect(ctx.stdout).to.match(/No environment set/)
         })
     })
   })

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -1,28 +1,16 @@
-import { restore, SinonStub, stub } from 'sinon'
+import { fake, replace, restore, SinonStub, stub } from 'sinon'
 import * as projectChecker from '../../src/services/project-checker'
-import { compileProjectAndLoadConfig } from '../../src/services/config-service'
-import { BoosterApp, BoosterConfig } from '@boostercloud/framework-types'
+import { BoosterConfig } from '@boostercloud/framework-types'
 import { expect } from '../expect'
+import * as environment from '../../src/common/environment'
+
+const rewire = require('rewire')
+const configService = rewire('../../src/services/config-service')
 
 describe('configService', () => {
   beforeEach(() => {
     restore()
   })
-
-  const Module = require('module')
-
-  class BoosterMock {
-    constructor(public readonly config: BoosterConfig) {}
-    public configureCurrentEnv(configurator: (config: BoosterConfig) => void): void {
-      configurator(this.config)
-    }
-  }
-
-  class BoosterAppMock {
-    constructor(public readonly config: BoosterConfig) {}
-    // @ts-ignore
-    Booster: BoosterApp = new BoosterMock(this.config)
-  }
 
   describe('compileProjectAndLoadConfig', () => {
     let checkItIsABoosterProject: SinonStub
@@ -33,38 +21,79 @@ describe('configService', () => {
 
     it('loads the config when the selected environment exists', async () => {
       const config = new BoosterConfig('test')
-      config.addConfiguredEnvironment('test')
-      Module.prototype.require = function() {
-        return new BoosterAppMock(config)
-      }
 
-      await expect(compileProjectAndLoadConfig()).to.eventually.become(config)
+      const rewires = [
+        configService.__set__('compileProject', fake()),
+        configService.__set__(
+          'loadUserProject',
+          fake.returns({
+            Booster: {
+              config: config,
+              configuredEnvironments: new Set(['test']),
+              configureCurrentEnv: fake.yields(config),
+            },
+          })
+        ),
+      ]
+
+      replace(environment, 'currentEnvironment', fake.returns('test'))
+
+      await expect(configService.compileProjectAndLoadConfig()).to.eventually.become(config)
       expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly()
+
+      rewires.forEach((fn) => fn())
     })
 
     it('throws the right error when there are not configured environments', async () => {
       const config = new BoosterConfig('test')
-      Module.prototype.require = function() {
-        return new BoosterAppMock(config)
-      }
 
-      await expect(compileProjectAndLoadConfig()).to.eventually.be.rejectedWith(
+      const rewires = [
+        configService.__set__('compileProject', fake()),
+        configService.__set__(
+          'loadUserProject',
+          fake.returns({
+            Booster: {
+              config: config,
+              configuredEnvironments: new Set([]),
+              configureCurrentEnv: fake.yields(config),
+            },
+          })
+        ),
+      ]
+
+      await expect(configService.compileProjectAndLoadConfig()).to.eventually.be.rejectedWith(
         /You haven't configured any environment/
       )
       expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly()
+
+      rewires.forEach((fn) => fn())
     })
 
     it('throws the right error when the environment does not exist', async () => {
       const config = new BoosterConfig('test')
-      config.addConfiguredEnvironment('stage')
-      Module.prototype.require = function() {
-        return new BoosterAppMock(config)
-      }
 
-      await expect(compileProjectAndLoadConfig()).to.eventually.be.rejectedWith(
+      const rewires = [
+        configService.__set__('compileProject', fake()),
+        configService.__set__(
+          'loadUserProject',
+          fake.returns({
+            Booster: {
+              config: config,
+              configuredEnvironments: new Set(['another']),
+              configureCurrentEnv: fake.yields(config),
+            },
+          })
+        ),
+      ]
+
+      replace(environment, 'currentEnvironment', fake.returns('test'))
+
+      await expect(configService.compileProjectAndLoadConfig()).to.eventually.be.rejectedWith(
         /The environment 'test' does not match any of the environments/
       )
       expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly()
+
+      rewires.forEach((fn) => fn())
     })
   })
 })

--- a/packages/framework-core/src/booster.ts
+++ b/packages/framework-core/src/booster.ts
@@ -24,6 +24,7 @@ import { BoosterScheduledCommandDispatcher } from './booster-scheduled-command-d
  * - `region`: 'eu-west-1'
  */
 export class Booster {
+  public static readonly configuredEnvironments: Set<string> = new Set<string>()
   private static logger: Logger
   private static readonly config = new BoosterConfig(checkAndGetCurrentEnv())
   /**
@@ -42,7 +43,7 @@ export class Booster {
    * @param configurator A function that receives the configuration object to set the values
    */
   public static configure(environment: string, configurator: (config: BoosterConfig) => void): void {
-    this.config.addConfiguredEnvironment(environment)
+    this.configuredEnvironments.add(environment)
     if (this.config.environmentName === environment) {
       configurator(this.config)
     }

--- a/packages/framework-core/test/booster.test.ts
+++ b/packages/framework-core/test/booster.test.ts
@@ -30,8 +30,8 @@ describe('the `Booster` class', () => {
         config.appName = 'this-shouldnt-be-set'
       })
 
-      expect(booster.config.configuredEnvironments).to.have.lengthOf(2)
-      expect(booster.config.configuredEnvironments).to.include.keys(['test', 'another-environment'])
+      expect(booster.configuredEnvironments).to.have.lengthOf(2)
+      expect(booster.configuredEnvironments).to.include.keys(['test', 'another-environment'])
       expect(booster.config.appName).to.equal('test-app-name')
     })
   })

--- a/packages/framework-types/src/booster-app.ts
+++ b/packages/framework-types/src/booster-app.ts
@@ -12,4 +12,5 @@ export interface BoosterApp {
     entityName: Class<TEntity>,
     entityID: UUID
   ): Promise<TEntity | undefined>
+  configuredEnvironments: Set<string>
 }

--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -18,7 +18,6 @@ import { Level } from './logger'
  */
 export class BoosterConfig {
   public logLevel: Level = Level.debug
-  private readonly _configuredEnvironments: Set<string> = new Set<string>()
   private _provider?: ProviderLibrary
   public appName = 'new-booster-app'
   public readonly subscriptions = {
@@ -109,14 +108,6 @@ export class BoosterConfig {
       throw new Error(`Missing environment variable '${varName}'`)
     }
     return value
-  }
-
-  public addConfiguredEnvironment(environmentName: string): void {
-    this._configuredEnvironments.add(environmentName)
-  }
-
-  public get configuredEnvironments(): Set<string> {
-    return this._configuredEnvironments
   }
 
   private validateAllMigrations(): void {


### PR DESCRIPTION
## Description
This is a minor refactor. I noticed some details that the environment management in configuration that made me think that the way we were managing them was a bit fragile:

* We were dealing with system environment variables from the cli scripts
* We had a list of available environments in the config that was only used by the CLI to display them when there were errors. The config is the config for a specific environment, so it doesn't make sense that it has getters and setters for things that are unrelated.
* The tests were rewriting `require`

## Changes
* Created a new `environment` module with higher-level functions to write and read the current environment
* Moved the `configuredEnvironments` list from `BoosterConfig` to `BoosterApp`
* Fixed (and improved a little) the tests

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~~Updated documentation accordingly~~ (not needed)
 
## Additional information
