### PR TITLE
Export Booster.readModel() method

### DIFF
--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
@@ -62,8 +62,13 @@ export const setupPermissions = (
   const tableArns = readModelTables.map((table): string => table.tableArn)
   if (tableArns.length > 0) {
     eventsLambda.addToRolePolicy(
-      createPolicyStatement(tableArns, ['dynamodb:Get*', 'dynamodb:Put*', 'dynamodb:DeleteItem*'])
+      createPolicyStatement(tableArns, ['dynamodb:Get*', 'dynamodb:Scan*', 'dynamodb:Put*', 'dynamodb:DeleteItem*'])
     )
     graphQLLambda.addToRolePolicy(createPolicyStatement(tableArns, ['dynamodb:Query*', 'dynamodb:Scan*']))
+    if (scheduledCommandStack) {
+      scheduledCommandStack.scheduledLambda.addToRolePolicy(
+        createPolicyStatement(tableArns, ['dynamodb:Query*', 'dynamodb:Scan*'])
+      )
+    }
   }
 }

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
@@ -192,7 +192,7 @@ describe('permissions', () => {
         it('should create read model permissions', () => {
           expect(createPolicyStatementStub).calledWithExactly(
             [mockReadModelTableArn],
-            ['dynamodb:Get*', 'dynamodb:Put*', 'dynamodb:DeleteItem*']
+            ['dynamodb:Get*', 'dynamodb:Scan*', 'dynamodb:Put*', 'dynamodb:DeleteItem*']
           )
         })
       })

--- a/packages/framework-types/src/booster-app.ts
+++ b/packages/framework-types/src/booster-app.ts
@@ -1,4 +1,4 @@
-import { BoosterConfig, UUID, EntityInterface, Class } from '.'
+import { BoosterConfig, UUID, EntityInterface, Class, ReadModelInterface, Searcher } from '.'
 
 /**
  * `BoosterApp` is the interface of the user-facing functions that
@@ -12,5 +12,6 @@ export interface BoosterApp {
     entityName: Class<TEntity>,
     entityID: UUID
   ): Promise<TEntity | undefined>
+  readModel<TReadModel extends ReadModelInterface>(readModelClass: Class<TReadModel>): Searcher<TReadModel>
   configuredEnvironments: Set<string>
 }


### PR DESCRIPTION
## Description
This is a quick PR to export the function that allows to search read models from any handler. 
Note: `Booster.readModels` function is still undocumented and under a heavy refactor, expect breaking changes

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- ~[ ] Updated documentation accordingly~
 
