### PR TITLE
Local provider - Queries

### DIFF
--- a/packages/framework-integration-tests/package.json
+++ b/packages/framework-integration-tests/package.json
@@ -45,6 +45,7 @@
   "main": "dist/index.js",
   "repository": "boostercloud/booster",
   "scripts": {
+    "watch:local": "nodemon --watch ../framework-provider-local/dist --watch ../framework-provider-local-infrastructure --watch dist --exec \"../cli/bin/run start -e local\"",
     "lint:check": "eslint --ext '.js,.ts' **/*.ts",
     "lint:fix": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
     "compile": "tsc -b tsconfig.json",

--- a/packages/framework-provider-local/src/library/read-model-adapter.ts
+++ b/packages/framework-provider-local/src/library/read-model-adapter.ts
@@ -7,7 +7,7 @@ import {
   UUID,
 } from '@boostercloud/framework-types'
 import { ReadModelRegistry } from '../services/read-model-registry'
-import { QueryValue, filterToQuery } from './searcher-adapter'
+import { queryRecordFor, QueryValue } from './searcher-adapter'
 
 export async function rawReadModelEventsToEnvelopes(
   config: BoosterConfig,
@@ -56,15 +56,9 @@ export async function searchReadModel(
   filters: Record<string, Filter<QueryValue>>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<Array<any>> {
-  const queryFromFilters: Record<string, object> = {}
-  if (Object.keys(filters).length != 0) {
-    for (const key in filters) {
-      logger.info('Converting filter to query')
-      queryFromFilters[`value.${key}`] = filterToQuery(filters[key]) as object
-      logger.info('Got query ', queryFromFilters)
-    }
-  }
-  const query = { ...queryFromFilters, typeName: readModelName }
+  logger.info('Converting filter to query')
+  const query = queryRecordFor(readModelName, filters)
+  logger.info('Got query ', query)
   const result = await db.query(query)
   logger.debug('[ReadModelAdapter#searchReadModel] Search result: ', result)
   return result?.map((envelope) => envelope.value) ?? []

--- a/packages/framework-provider-local/src/library/read-model-adapter.ts
+++ b/packages/framework-provider-local/src/library/read-model-adapter.ts
@@ -7,6 +7,7 @@ import {
   UUID,
 } from '@boostercloud/framework-types'
 import { ReadModelRegistry } from '../services/read-model-registry'
+import { QueryValue, filterToQuery } from './searcher-adapter'
 
 export async function rawReadModelEventsToEnvelopes(
   config: BoosterConfig,
@@ -67,53 +68,4 @@ export async function searchReadModel(
   const result = await db.query(query)
   logger.debug('[ReadModelAdapter#searchReadModel] Search result: ', result)
   return result?.map((envelope) => envelope.value) ?? []
-}
-
-type QueryValue = number | string | boolean
-type QueryOperation<TValue> =
-  | TValue
-  | {
-      [TKey in '$lt' | '$lte' | '$gt' | '$gte' | '$ne']?: TValue
-    }
-  | {
-      [TKey in '$in' | '$nin']?: Array<TValue>
-    }
-  | {
-      [TKey in '$regex' | '$nin']?: RegExp
-    }
-
-const queryOperatorTable: Record<string, (vals: Array<QueryValue>) => QueryOperation<QueryValue>> = {
-  '=': (val) => val[0],
-  '!=': (val) => ({ $ne: val[0] }),
-  '<': (val) => ({ $lt: val[0] }),
-  '>': (val) => ({ $gt: val[0] }),
-  '<=': (val) => ({ $lte: val[0] }),
-  '>=': (val) => ({ $gte: val[0] }),
-  in: (val) => ({ $in: val }),
-  between: (val) => ({ $gt: val[0], $lte: val[1] }),
-  contains: buildRegexQuery.bind(null, 'contains'),
-  'not-contains': buildRegexQuery.bind(null, 'not-contains'),
-  'begins-with': buildRegexQuery.bind(null, 'begins-with'),
-}
-
-function buildRegexQuery(operation: string, vals: Array<QueryValue>): QueryOperation<QueryValue> {
-  let matcher = vals[0]
-  if (typeof matcher != 'string') {
-    throw new Error(`Attempted to perform a ${operation} operation on a non-string`)
-  }
-  if (operation === 'not-contains') {
-    throw new Error('not-contains not implemented yet')
-  }
-  if (operation === 'begins-with') {
-    matcher = `^${matcher}`
-  }
-  return { $regex: new RegExp(matcher) }
-}
-
-/**
- * Transforms a GraphQL Booster filter into an neDB query
- */
-function filterToQuery(filter: Filter<QueryValue>): QueryOperation<QueryValue> {
-  const query = queryOperatorTable[filter.operation]
-  return query(filter.values)
 }

--- a/packages/framework-provider-local/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-local/src/library/searcher-adapter.ts
@@ -68,15 +68,18 @@ const queryOperatorTable: Record<string, (values: Array<QueryValue>) => QueryOpe
  * Builds a regex out of string GraphQL queries
  */
 function buildRegexQuery(operation: string, values: Array<QueryValue>): QueryOperation<QueryValue> {
-  let matcher = values[0]
+  const matcher = values[0]
   if (typeof matcher != 'string') {
     throw new Error(`Attempted to perform a ${operation} operation on a non-string`)
   }
   if (operation === 'not-contains') {
-    throw new Error('not-contains not implemented yet')
+    // Matching on a string not containing something by using
+    // negative lookahead, which JS' regexes support.
+    // Check: https://stackoverflow.com/a/406408/3847023
+    return { $regex: new RegExp(`^((?!${matcher}).)*$`, 'gm') }
   }
   if (operation === 'begins-with') {
-    matcher = `^${matcher}`
+    return { $regex: new RegExp(`^${matcher}`) }
   }
   return { $regex: new RegExp(matcher) }
 }

--- a/packages/framework-provider-local/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-local/src/library/searcher-adapter.ts
@@ -1,0 +1,50 @@
+import { Filter } from '@boostercloud/framework-types'
+
+/**
+ * Transforms a GraphQL Booster filter into an neDB query
+ */
+export function filterToQuery(filter: Filter<QueryValue>): QueryOperation<QueryValue> {
+  const query = queryOperatorTable[filter.operation]
+  return query(filter.values)
+}
+
+export type QueryValue = number | string | boolean
+type QueryOperation<TValue> =
+  | TValue
+  | {
+      [TKey in '$lt' | '$lte' | '$gt' | '$gte' | '$ne']?: TValue
+    }
+  | {
+      [TKey in '$in' | '$nin']?: Array<TValue>
+    }
+  | {
+      [TKey in '$regex' | '$nin']?: RegExp
+    }
+
+const queryOperatorTable: Record<string, (vals: Array<QueryValue>) => QueryOperation<QueryValue>> = {
+  '=': (val) => val[0],
+  '!=': (val) => ({ $ne: val[0] }),
+  '<': (val) => ({ $lt: val[0] }),
+  '>': (val) => ({ $gt: val[0] }),
+  '<=': (val) => ({ $lte: val[0] }),
+  '>=': (val) => ({ $gte: val[0] }),
+  in: (val) => ({ $in: val }),
+  between: (val) => ({ $gt: val[0], $lte: val[1] }),
+  contains: buildRegexQuery.bind(null, 'contains'),
+  'not-contains': buildRegexQuery.bind(null, 'not-contains'),
+  'begins-with': buildRegexQuery.bind(null, 'begins-with'),
+}
+
+function buildRegexQuery(operation: string, vals: Array<QueryValue>): QueryOperation<QueryValue> {
+  let matcher = vals[0]
+  if (typeof matcher != 'string') {
+    throw new Error(`Attempted to perform a ${operation} operation on a non-string`)
+  }
+  if (operation === 'not-contains') {
+    throw new Error('not-contains not implemented yet')
+  }
+  if (operation === 'begins-with') {
+    matcher = `^${matcher}`
+  }
+  return { $regex: new RegExp(matcher) }
+}

--- a/packages/framework-provider-local/test/library/read-model-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/read-model-adapter.test.ts
@@ -76,16 +76,18 @@ describe('read-models-adapter', () => {
   })
 
   describe('searchReadModel', () => {
-    let mockReadModel: ReadModelEnvelope
-
-    beforeEach(async () => {
-      mockReadModel = createMockReadModelEnvelope()
-
+    it('should call read model registry store', async () => {
+      const mockReadModel = createMockReadModelEnvelope()
       await searchReadModel(mockReadModelRegistry, mockConfig, mockLogger, mockReadModel.typeName, {})
+      expect(queryStub).to.have.been.calledWithExactly({ typeName: mockReadModel.typeName })
     })
 
-    it('should call read model registry store', () => {
-      expect(queryStub).to.have.been.calledWithExactly({ typeName: mockReadModel.typeName })
+    it('should call read model registry store with the appropriate operation converted', async () => {
+      const mockReadModel = createMockReadModelEnvelope()
+      await searchReadModel(mockReadModelRegistry, mockConfig, mockLogger, mockReadModel.typeName, {
+        foo: { operation: '>', values: [1] },
+      })
+      expect(queryStub).to.have.been.calledWithExactly({ typeName: mockReadModel.typeName, 'value.foo': { $gt: 1 } })
     })
   })
 })

--- a/packages/framework-provider-local/test/library/searcher-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/searcher-adapter.test.ts
@@ -4,9 +4,13 @@ import { queryRecordFor } from '../../src/library/searcher-adapter'
 describe('searcher-adapter', () => {
   const typeName = 'SomeReadModel'
   describe('filter conversion for keys to NeDB queries', () => {
-    it('converts the "eq" operator', () => {
+    it('converts the "=" operator', () => {
       const result = queryRecordFor(typeName, { field: { operation: '=', values: ['one'] } })
       expect(result).to.deep.equal({ 'value.field': 'one', typeName })
+    })
+    it('converts the "!=" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: '!=', values: ['one'] } })
+      expect(result).to.deep.equal({ 'value.field': { $ne: 'one' }, typeName })
     })
   })
 })

--- a/packages/framework-provider-local/test/library/searcher-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/searcher-adapter.test.ts
@@ -1,0 +1,12 @@
+import { expect } from '../expect'
+import { queryRecordFor } from '../../src/library/searcher-adapter'
+
+describe('searcher-adapter', () => {
+  const typeName = 'SomeReadModel'
+  describe('filter conversion for keys to NeDB queries', () => {
+    it('converts the "eq" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: '=', values: ['one'] } })
+      expect(result).to.deep.equal({ 'value.field': 'one', typeName })
+    })
+  })
+})

--- a/packages/framework-provider-local/test/library/searcher-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/searcher-adapter.test.ts
@@ -3,7 +3,7 @@ import { queryRecordFor } from '../../src/library/searcher-adapter'
 
 describe('searcher-adapter', () => {
   const typeName = 'SomeReadModel'
-  describe('filter conversion for keys to NeDB queries', () => {
+  describe('converts simple operators', () => {
     it('converts the "=" operator', () => {
       const result = queryRecordFor(typeName, { field: { operation: '=', values: ['one'] } })
       expect(result).to.deep.equal({ 'value.field': 'one', typeName })
@@ -42,6 +42,22 @@ describe('searcher-adapter', () => {
     it('converts the "between" operator', () => {
       const result = queryRecordFor(typeName, { field: { operation: 'between', values: ['one', 'two'] } })
       expect(result).to.deep.equal({ 'value.field': { $gt: 'one', $lte: 'two' }, typeName })
+    })
+  })
+  describe('converts operators that rely on regexes', () => {
+    it('converts the "contains" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: 'contains', values: ['one'] } })
+      expect(result).to.deep.equal({ 'value.field': { $regex: new RegExp('one') }, typeName })
+    })
+
+    it('converts the "not-contains" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: 'not-contains', values: ['one'] } })
+      expect(result).to.deep.equal({ 'value.field': { $regex: new RegExp('^((?!one).)*$', 'gm') }, typeName })
+    })
+
+    it('converts the "begins-with" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: 'begins-with', values: ['one'] } })
+      expect(result).to.deep.equal({ 'value.field': { $regex: new RegExp('^one') }, typeName })
     })
   })
 })

--- a/packages/framework-provider-local/test/library/searcher-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/searcher-adapter.test.ts
@@ -8,9 +8,40 @@ describe('searcher-adapter', () => {
       const result = queryRecordFor(typeName, { field: { operation: '=', values: ['one'] } })
       expect(result).to.deep.equal({ 'value.field': 'one', typeName })
     })
+
     it('converts the "!=" operator', () => {
       const result = queryRecordFor(typeName, { field: { operation: '!=', values: ['one'] } })
       expect(result).to.deep.equal({ 'value.field': { $ne: 'one' }, typeName })
+    })
+
+    it('converts the "<" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: '<', values: ['one'] } })
+      expect(result).to.deep.equal({ 'value.field': { $lt: 'one' }, typeName })
+    })
+
+    it('converts the ">" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: '>', values: ['one'] } })
+      expect(result).to.deep.equal({ 'value.field': { $gt: 'one' }, typeName })
+    })
+
+    it('converts the "<=" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: '<=', values: ['one'] } })
+      expect(result).to.deep.equal({ 'value.field': { $lte: 'one' }, typeName })
+    })
+
+    it('converts the ">=" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: '>=', values: ['one'] } })
+      expect(result).to.deep.equal({ 'value.field': { $gte: 'one' }, typeName })
+    })
+
+    it('converts the "in" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: 'in', values: ['one'] } })
+      expect(result).to.deep.equal({ 'value.field': { $in: ['one'] }, typeName })
+    })
+
+    it('converts the "between" operator', () => {
+      const result = queryRecordFor(typeName, { field: { operation: 'between', values: ['one', 'two'] } })
+      expect(result).to.deep.equal({ 'value.field': { $gt: 'one', $lte: 'two' }, typeName })
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1834,7 +1834,7 @@
     chalk "^2.4.2"
     tslib "^1.9.3"
 
-"@oclif/plugin-help@^2":
+"@oclif/plugin-help@^2", "@oclif/plugin-help@^2.1.6":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-2.2.3.tgz#b993041e92047f0e1762668aab04d6738ac06767"
   integrity sha512-bGHUdo5e7DjPJ0vTeRBMIrfqTRDBfyR5w0MP41u0n3r7YG5p14lvMmiCXxi6WDaP2Hw5nqx3PnkAIntCKZZN7g==
@@ -6796,7 +6796,7 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.1, js-yaml@^3.8.1:
+js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.8.1, js-yaml@^3.9.1:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
@@ -10570,7 +10570,7 @@ umask@^1.1.0:
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
 
-"underscore@>= 1.3.1":
+"underscore@>= 1.3.1", underscore@^1.9.1:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.11.0.tgz#dd7c23a195db34267186044649870ff1bab5929e"
   integrity sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==


### PR DESCRIPTION
## Description
Adds the possibility of querying read models in the local provider, for example, by using queries like this:

```graphql
query{
  ProductReadModels(description: {operation: not_contains, values: ["hot"]}){
    id
    ...
  }
}
```

## Changes

Created a `searcher-adapter.ts` module that converts Booster GraphQL queries into query operations supported by NeDB.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly
 
## Additional information

It's missing the tests, but you can review for now.
