### PR TITLE
Fix test failure when stack already exists

### DIFF
--- a/packages/framework-integration-tests/integration/providers/aws/deployment/deployment.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/deployment/deployment.integration.ts
@@ -10,7 +10,7 @@ describe('After deployment', () => {
       const stack = await appStack()
 
       expect(stack).not.to.be.null
-      expect(stack?.StackStatus).to.be.equal('CREATE_COMPLETE')
+      expect(stack?.StackStatus).to.be.oneOf(['CREATE_COMPLETE', 'UPDATE_COMPLETE'])
     })
   })
 })


### PR DESCRIPTION
## Description
When deploying a Booter app that already exists in AWS, it throws an error because a test is expecting a `CREATE_COMPLETED` message from `CloudFromation`. This error is commonly seen after a failed integration test.

## Changes
The tests expect now either a `CREATE_COMPLETED` or a `UPDATE_COMPLETED` message, which allows updating an existing stack without errors.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~- [ ] Updated documentation accordingly~ Not necessary 