### PR TITLE
Add no admin by default note in auth docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1585,6 +1585,8 @@ By default, a Booster application has no roles defined, so the only allowed valu
 If you want to add user authorization, you first need to create the roles that are suitable for your application.
 Roles are classes annotated with the `@Role` decorator, where you can specify some attributes. We recommend that you define your roles in the file `src/roles.ts` or, if you have too many roles, put them in several files under the `src/roles` folder.
 
+_Note: There is not `Admin` user by default. In order to register one you need specify a sign-up method on `src/roles.ts`._
+
 In the following example we define two roles, `Admin` and `User`:
 
 ```typescript

--- a/docs/README.md
+++ b/docs/README.md
@@ -1585,7 +1585,7 @@ By default, a Booster application has no roles defined, so the only allowed valu
 If you want to add user authorization, you first need to create the roles that are suitable for your application.
 Roles are classes annotated with the `@Role` decorator, where you can specify some attributes. We recommend that you define your roles in the file `src/roles.ts` or, if you have too many roles, put them in several files under the `src/roles` folder.
 
-_Note: There is not `Admin` user by default. In order to register one you need specify a sign-up method on `src/roles.ts`._
+_Note: There is no `Admin` user by default. In order to register one you need to specify a sign-up method on `src/roles.ts`._
 
 In the following example we define two roles, `Admin` and `User`:
 


### PR DESCRIPTION
## Description
Just added a note clarification about that there is not Admin user by default.

## Changes
One line in the docs README. 

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
## Additional information
[It ain't much but it's honest work](https://en.meming.world/images/en/thumb/b/be/But_It%27s_Honest_Work.jpg/300px-But_It%27s_Honest_Work.jpg)