### PR TITLE
Fix/event handlers promise all break

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4650,11 +4650,6 @@
 				"rxjs": "^6.4.0"
 			}
 		},
-		"@types/isomorphic-fetch": {
-			"version": "0.0.35",
-			"resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz",
-			"integrity": "sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw=="
-		},
 		"@types/js-yaml": {
 			"version": "3.12.6",
 			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.6.tgz",

--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -37,7 +37,7 @@ export class BoosterEventDispatcher {
         case 'event':
           logger.debug('[BoosterEventDispatcher#eventProcessor]: Started processing workflow for event:', eventEnvelope)
           // TODO: Separate into two independent processes the snapshotting/read-model generation process from the event handling process
-          await Promise.all([
+          await Promise.allSettled([
             BoosterEventDispatcher.snapshotAndUpdateReadModels(eventEnvelope, eventStore, readModelStore, logger),
             BoosterEventDispatcher.handleEvent(eventEnvelope, config, logger),
           ])

--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -87,6 +87,6 @@ export class BoosterEventDispatcher {
     )
     results
       .filter((result) => result.status === 'rejected')
-      .forEach((result) => logger.debug(`Event handlere execution failed: ${(result as PromiseRejectedResult).reason}`))
+      .forEach((result) => logger.debug(`Event handler execution failed: ${(result as PromiseRejectedResult).reason}`))
   }
 }

--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -77,7 +77,7 @@ export class BoosterEventDispatcher {
       )
       return
     }
-    await Promise.all(
+    const results = await Promise.allSettled(
       eventHandlers.map(async (eventHandler: EventHandlerInterface) => {
         const register = new Register(eventEnvelope.requestID, eventEnvelope.currentUser)
         logger.debug('Calling "handle" method on event handler: ', eventHandler)
@@ -85,5 +85,8 @@ export class BoosterEventDispatcher {
         return RegisterHandler.handle(config, logger, register)
       })
     )
+    results
+      .filter((result) => result.status === 'rejected')
+      .forEach((result) => logger.debug(`Event handlere execution failed: ${(result as PromiseRejectedResult).reason}`))
   }
 }

--- a/packages/framework-core/src/booster-subscribers-notifier.ts
+++ b/packages/framework-core/src/booster-subscribers-notifier.ts
@@ -40,7 +40,7 @@ export class BoosterSubscribersNotifier {
       )
 
       const pubSub = this.getPubSub(readModelEnvelopes)
-      await Promise.all(subscriptions.map(this.runSubscriptionAndNotify.bind(this, pubSub)))
+      await Promise.allSettled(subscriptions.map(this.runSubscriptionAndNotify.bind(this, pubSub)))
     } catch (e) {
       this.logger.error(e)
     }

--- a/packages/framework-provider-kubernetes-infrastructure/package.json
+++ b/packages/framework-provider-kubernetes-infrastructure/package.json
@@ -44,7 +44,6 @@
     "@types/cors": "^2.8.7",
     "@types/express": "4.17.2",
     "@types/faker": "5.1.5",
-    "@types/isomorphic-fetch": "0.0.35",
     "@types/mustache": "4.1.0",
     "@types/semver": "5.5.0",
     "archiver": "^4.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,10 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "lib": [
+      "ES2019",
+      "ES2020"
+    ]
   }
 }


### PR DESCRIPTION
## Description
When an event handler failed, the rest don't get to execute because of a `promise.all` wapper behavior.

## Changes
* Updated root TypeScript version to match the version of the rest of the packages.
* Remove an unnecessary dependency for k8s that had conflicts with TypeScript new version.
* Changed `booter-event-dispatcher.ts` to use `Promise.allSettled` to avoid stopping the execution of all of them when one fails. 

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
~- [] Updated documentation accordingly~ Not necessary 
