### PR TITLE
Removed the dynamic require of the infrastructure package through the provider library to load it directly from the cli

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2784,19 +2784,20 @@ In `mountStack` you will receive an initialized AWS CDK stack that you can use t
 
 The application stack, including the resources added by your rocket are automatically nuked along with the application stack, but there are some situations on which it's convenient to delete or move the contents of the resources created by you. In the appl `unmountStack` you'll have the opportunity to run any code before deleting the stack. This function receives an `utils` object with the same tools that Booster uses to perform common actions like emptying the contents of an S3 bucket (Non-empty buckets are kept by default when a stack is deleted).
 
-Notice that infrastructure rockets should not be included from within the application code to avoid including the CDK and other non-used dependencies in the lambdas, as there are some hard restrictions on code size in most platforms. That's why infrastructure rockets are loaded dynamically by Booster passing the packet names as strings in the application config file:
+Notice that infrastructure rockets should not be included among the application dependencies, because they're plugins for the CLI that are only used during the deploy process. Booster will check that the rockets are installed and load them dynamically during infrastructure operations. You'll need to set the package names and their configuration in the application config as follows:
 
 _src/config/production.ts:_
 
 ```typescript
 Booster.configure('development', (config: BoosterConfig): void => {
   config.appName = 'my-store'
-  config.provider = AWSProvider([{
+  config.provider = AWSProvider
+  config.rockets = [{
     packageName: 'rocket-your-rocket-name-aws-infrastructure', // The name of your infrastructure rocket package
     parameters: { // An arbitrary object with the parameters required by your infrastructure rocket initializator
       hello: 'world'
     }
-  }])
+  }]
 })
 ```
 

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -6,7 +6,7 @@ import { checkItIsABoosterProject } from './project-checker'
 import { currentEnvironment } from './environment'
 import { createSandboxProject, removeSandboxProject } from '../common/sandbox'
 import { installProductionDependencies } from './dependencies'
-import { dynamicLoad } from './dynamic-loader'
+import { dynamicLoadFile } from './dynamic-loader'
 
 export const DEPLOYMENT_SANDBOX = '.deploy'
 
@@ -37,7 +37,7 @@ async function compileProject(projectPath: string): Promise<void> {
 
 async function readProjectConfig(userProjectPath: string): Promise<BoosterConfig> {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const userProject: { Booster: BoosterApp } = await dynamicLoad(path.join(userProjectPath, 'dist', 'index.js'))
+  const userProject: { Booster: BoosterApp } = await dynamicLoadFile(path.join(userProjectPath, 'dist', 'index.js'))
   return new Promise((resolve): void => {
     const app: BoosterApp = userProject.Booster
     app.configureCurrentEnv((config: BoosterConfig): void => {

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -6,6 +6,7 @@ import { checkItIsABoosterProject } from './project-checker'
 import { currentEnvironment } from './environment'
 import { createSandboxProject, removeSandboxProject } from '../common/sandbox'
 import { installProductionDependencies } from './dependencies'
+import { dynamicLoad } from './dynamic-loader'
 
 export const DEPLOYMENT_SANDBOX = '.deploy'
 
@@ -34,9 +35,9 @@ async function compileProject(projectPath: string): Promise<void> {
   }
 }
 
-function readProjectConfig(userProjectPath: string): Promise<BoosterConfig> {
+async function readProjectConfig(userProjectPath: string): Promise<BoosterConfig> {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const userProject = loadUserProject(userProjectPath)
+  const userProject: { Booster: BoosterApp } = await dynamicLoad(path.join(userProjectPath, 'dist', 'index.js'))
   return new Promise((resolve): void => {
     const app: BoosterApp = userProject.Booster
     app.configureCurrentEnv((config: BoosterConfig): void => {
@@ -44,11 +45,6 @@ function readProjectConfig(userProjectPath: string): Promise<BoosterConfig> {
       resolve(config)
     })
   })
-}
-
-function loadUserProject(userProjectPath: string): { Booster: BoosterApp } {
-  const projectIndexJSPath = path.resolve(path.join(userProjectPath, 'dist', 'index.js'))
-  return require(projectIndexJSPath)
 }
 
 function checkEnvironmentWasConfigured(app: BoosterApp): void {

--- a/packages/cli/src/services/dynamic-loader.ts
+++ b/packages/cli/src/services/dynamic-loader.ts
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export async function dynamicLoad(module: string): Promise<any> {
+  // We wrap the call to import here to ease testing dynamic module loading
+  // The `import` expression returns a promise that will be rejected when the module is not found
+  return import(module)
+}

--- a/packages/cli/src/services/dynamic-loader.ts
+++ b/packages/cli/src/services/dynamic-loader.ts
@@ -1,6 +1,12 @@
+import * as path from 'path'
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export async function dynamicLoad(module: string): Promise<any> {
-  // We wrap the call to import here to ease testing dynamic module loading
+export async function dynamicLoadFile(filePath: string): Promise<any> {
+  // Import is always relative to current file, so we need to "relativize" the path
+  return dynamicLoadModule(path.relative(__dirname, filePath))
+}
+
+export async function dynamicLoadModule(packageName: string): Promise<any> {
   // The `import` expression returns a promise that will be rejected when the module is not found
-  return import(module)
+  return import(packageName)
 }

--- a/packages/cli/src/services/project-checker.ts
+++ b/packages/cli/src/services/project-checker.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra'
 import * as path from 'path'
-import { dynamicLoad } from './dynamic-loader'
+import { dynamicLoadFile } from './dynamic-loader'
 
 function checkIndexFileIsBooster(indexFilePath: string): void {
   const contents = fs.readFileSync(indexFilePath)
@@ -18,7 +18,7 @@ export async function checkCurrentDirIsABoosterProject(): Promise<void> {
 export async function checkItIsABoosterProject(projectPath: string): Promise<void> {
   const projectAbsolutePath = path.resolve(projectPath)
   try {
-    const tsConfigJsonContents = await dynamicLoad(path.join(projectAbsolutePath, 'tsconfig.json'))
+    const tsConfigJsonContents = await dynamicLoadFile(path.join(projectAbsolutePath, 'tsconfig.json'))
     const indexFilePath = path.normalize(
       path.join(projectAbsolutePath, tsConfigJsonContents.compilerOptions.rootDir, 'index.ts')
     )

--- a/packages/cli/src/services/project-checker.ts
+++ b/packages/cli/src/services/project-checker.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra'
 import * as path from 'path'
+import { dynamicLoad } from './dynamic-loader'
 
 function checkIndexFileIsBooster(indexFilePath: string): void {
   const contents = fs.readFileSync(indexFilePath)
@@ -17,7 +18,7 @@ export async function checkCurrentDirIsABoosterProject(): Promise<void> {
 export async function checkItIsABoosterProject(projectPath: string): Promise<void> {
   const projectAbsolutePath = path.resolve(projectPath)
   try {
-    const tsConfigJsonContents = require(path.join(projectAbsolutePath, 'tsconfig.json'))
+    const tsConfigJsonContents = await dynamicLoad(path.join(projectAbsolutePath, 'tsconfig.json'))
     const indexFilePath = path.normalize(
       path.join(projectAbsolutePath, tsConfigJsonContents.compilerOptions.rootDir, 'index.ts')
     )

--- a/packages/cli/src/services/provider-service.ts
+++ b/packages/cli/src/services/provider-service.ts
@@ -1,5 +1,5 @@
 import { BoosterConfig, Logger, ProviderInfrastructure } from '@boostercloud/framework-types'
-import { dynamicLoad } from './dynamic-loader'
+import { dynamicLoadModule } from './dynamic-loader'
 
 export function assertNameIsCorrect(name: string): void {
   // Current characters max length: 37
@@ -34,7 +34,7 @@ function validateConfig(config: BoosterConfig): void {
  */
 async function loadInfrastructure(config: BoosterConfig): Promise<ProviderInfrastructure> {
   const packageDescription = config.provider.packageDescription()
-  const { Infrastructure } = await dynamicLoad(packageDescription.name + '-infrastructure')
+  const { Infrastructure } = await dynamicLoadModule(packageDescription.name + '-infrastructure')
   return Infrastructure(config.rockets)
 }
 

--- a/packages/cli/src/templates/project/config-ts.ts
+++ b/packages/cli/src/templates/project/config-ts.ts
@@ -4,6 +4,6 @@ import { Provider } from '{{{providerPackageName}}}'
 
 Booster.configure('production', (config: BoosterConfig): void => {
   config.appName = '{{{ projectName }}}'
-  config.provider = Provider()
+  config.provider = Provider
 })
 `

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -34,7 +34,7 @@ describe('configService', () => {
 
       replace(
         dynamicLoader,
-        'dynamicLoad',
+        'dynamicLoadModule',
         fake.resolves({
           Booster: {
             config: config,
@@ -58,7 +58,7 @@ describe('configService', () => {
 
       replace(
         dynamicLoader,
-        'dynamicLoad',
+        'dynamicLoadModule',
         fake.resolves({
           Booster: {
             config: config,
@@ -84,7 +84,7 @@ describe('configService', () => {
 
       replace(
         dynamicLoader,
-        'dynamicLoad',
+        'dynamicLoadModule',
         fake.resolves({
           Booster: {
             config: config,

--- a/packages/cli/test/services/dynamic-loader.test.ts
+++ b/packages/cli/test/services/dynamic-loader.test.ts
@@ -1,0 +1,23 @@
+import * as DynamicLoader from '../../src/services/dynamic-loader'
+import { expect } from '../expect'
+import { restore } from 'sinon'
+
+describe('dynamic-loader service', () => {
+  afterEach(() => {
+    restore()
+  })
+
+  describe('dynamicLoad', () => {
+    it('can load a specific file using a relative path', async () => {
+      const packageJson = await DynamicLoader.dynamicLoad('../../package.json')
+
+      expect(packageJson.name).to.equal('@boostercloud/cli')
+    })
+
+    it('can load a package', async () => {
+      const packageJson = await DynamicLoader.dynamicLoad('@boostercloud/framework-types')
+
+      expect(packageJson.BoosterConfig).not.to.be.null
+    })
+  })
+})

--- a/packages/cli/test/services/dynamic-loader.test.ts
+++ b/packages/cli/test/services/dynamic-loader.test.ts
@@ -7,15 +7,15 @@ describe('dynamic-loader service', () => {
     restore()
   })
 
-  describe('dynamicLoad', () => {
+  describe('dynamicLoadModule', () => {
     it('can load a specific file using a relative path', async () => {
-      const packageJson = await DynamicLoader.dynamicLoad('../../package.json')
+      const packageJson = await DynamicLoader.dynamicLoadModule('../../package.json')
 
       expect(packageJson.name).to.equal('@boostercloud/cli')
     })
 
     it('can load a package', async () => {
-      const packageJson = await DynamicLoader.dynamicLoad('@boostercloud/framework-types')
+      const packageJson = await DynamicLoader.dynamicLoadModule('@boostercloud/framework-types')
 
       expect(packageJson.BoosterConfig).not.to.be.null
     })

--- a/packages/cli/test/services/provider-service.test.ts
+++ b/packages/cli/test/services/provider-service.test.ts
@@ -62,7 +62,7 @@ describe('providerService', () => {
             Infrastructure: fake.returns({ deploy: fakeDeploy }),
           }
 
-          replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+          replace(dynamicLoader, 'dynamicLoadModule', fake.resolves(fakeInfrastructure))
 
           const fakeProvider = {
             packageDescription: fake.returns(fakeProviderDescription),
@@ -78,7 +78,7 @@ describe('providerService', () => {
           await providerService.deployToCloudProvider(fakeConfig, logger)
 
           expect(fakeProvider.packageDescription).to.have.been.calledOnce
-          expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+          expect(dynamicLoader.dynamicLoadModule).to.have.been.calledWith('some-provider-package-infrastructure')
           expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith([])
           expect(fakeDeploy).to.have.been.calledOnceWith(fakeConfig, logger)
         })
@@ -96,7 +96,7 @@ describe('providerService', () => {
             Infrastructure: fake.returns({ deploy: fakeDeploy }),
           }
 
-          replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+          replace(dynamicLoader, 'dynamicLoadModule', fake.resolves(fakeInfrastructure))
 
           const fakeProvider = {
             packageDescription: fake.returns(fakeProviderDescription),
@@ -119,7 +119,7 @@ describe('providerService', () => {
           await providerService.deployToCloudProvider(fakeConfig, logger)
 
           expect(fakeProvider.packageDescription).to.have.been.calledOnce
-          expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+          expect(dynamicLoader.dynamicLoadModule).to.have.been.calledWith('some-provider-package-infrastructure')
           expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith(fakeRockets)
           expect(fakeDeploy).to.have.been.calledOnceWith(fakeConfig, logger)
         })
@@ -137,7 +137,7 @@ describe('providerService', () => {
           Infrastructure: fake.returns({}),
         }
 
-        replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+        replace(dynamicLoader, 'dynamicLoadModule', fake.resolves(fakeInfrastructure))
 
         const fakeProvider = {
           packageDescription: fake.returns(fakeProviderDescription),
@@ -155,7 +155,7 @@ describe('providerService', () => {
         )
 
         expect(fakeProvider.packageDescription).to.have.been.calledOnce
-        expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+        expect(dynamicLoader.dynamicLoadModule).to.have.been.calledWith('some-provider-package-infrastructure')
         expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith([])
       })
     })
@@ -175,7 +175,7 @@ describe('providerService', () => {
             Infrastructure: fake.returns({ nuke: fakeNuke }),
           }
 
-          replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+          replace(dynamicLoader, 'dynamicLoadModule', fake.resolves(fakeInfrastructure))
 
           const fakeProvider = {
             packageDescription: fake.returns(fakeProviderDescription),
@@ -191,7 +191,7 @@ describe('providerService', () => {
           await providerService.nukeCloudProviderResources(fakeConfig, logger)
 
           expect(fakeProvider.packageDescription).to.have.been.calledOnce
-          expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+          expect(dynamicLoader.dynamicLoadModule).to.have.been.calledWith('some-provider-package-infrastructure')
           expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith([])
           expect(fakeNuke).to.have.been.calledOnceWith(fakeConfig, logger)
         })
@@ -209,7 +209,7 @@ describe('providerService', () => {
             Infrastructure: fake.returns({ nuke: fakeNuke }),
           }
 
-          replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+          replace(dynamicLoader, 'dynamicLoadModule', fake.resolves(fakeInfrastructure))
 
           const fakeProvider = {
             packageDescription: fake.returns(fakeProviderDescription),
@@ -232,7 +232,7 @@ describe('providerService', () => {
           await providerService.nukeCloudProviderResources(fakeConfig, logger)
 
           expect(fakeProvider.packageDescription).to.have.been.calledOnce
-          expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+          expect(dynamicLoader.dynamicLoadModule).to.have.been.calledWith('some-provider-package-infrastructure')
           expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith(fakeRockets)
           expect(fakeNuke).to.have.been.calledOnceWith(fakeConfig, logger)
         })
@@ -250,7 +250,7 @@ describe('providerService', () => {
           Infrastructure: fake.returns({}),
         }
 
-        replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+        replace(dynamicLoader, 'dynamicLoadModule', fake.resolves(fakeInfrastructure))
 
         const fakeProvider = {
           packageDescription: fake.returns(fakeProviderDescription),
@@ -268,7 +268,7 @@ describe('providerService', () => {
         )
 
         expect(fakeProvider.packageDescription).to.have.been.calledOnce
-        expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+        expect(dynamicLoader.dynamicLoadModule).to.have.been.calledWith('some-provider-package-infrastructure')
         expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith([])
       })
     })
@@ -287,7 +287,7 @@ describe('providerService', () => {
           Infrastructure: fake.returns({ start: fakeStart }),
         }
 
-        replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+        replace(dynamicLoader, 'dynamicLoadModule', fake.resolves(fakeInfrastructure))
 
         const fakeProvider = {
           packageDescription: fake.returns(fakeProviderDescription),
@@ -302,7 +302,7 @@ describe('providerService', () => {
         await providerService.startProvider(3000, fakeConfig)
 
         expect(fakeProvider.packageDescription).to.have.been.calledOnce
-        expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+        expect(dynamicLoader.dynamicLoadModule).to.have.been.calledWith('some-provider-package-infrastructure')
         expect(fakeStart).to.have.been.calledOnceWith(fakeConfig, 3000)
       })
     })
@@ -318,7 +318,7 @@ describe('providerService', () => {
           Infrastructure: fake.returns({}),
         }
 
-        replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+        replace(dynamicLoader, 'dynamicLoadModule', fake.resolves(fakeInfrastructure))
 
         const fakeProvider = {
           packageDescription: fake.returns(fakeProviderDescription),
@@ -335,7 +335,7 @@ describe('providerService', () => {
         )
 
         expect(fakeProvider.packageDescription).to.have.been.calledOnce
-        expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+        expect(dynamicLoader.dynamicLoadModule).to.have.been.calledWith('some-provider-package-infrastructure')
       })
     })
   })

--- a/packages/cli/test/services/provider-service.test.ts
+++ b/packages/cli/test/services/provider-service.test.ts
@@ -1,9 +1,18 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { afterEach, describe } from 'mocha'
 import * as providerService from '../../src/services/provider-service'
-import { restore, fake } from 'sinon'
+import { restore, fake, replace } from 'sinon'
 import { expect } from '../expect'
 import { lorem, random } from 'faker'
+import * as dynamicLoader from '../../src/services/dynamic-loader'
+
+import { Logger } from '@boostercloud/framework-types'
+
+const logger: Logger = {
+  debug: fake(),
+  info: fake(),
+  error: fake(),
+}
 
 describe('providerService', () => {
   afterEach(() => {
@@ -39,17 +48,249 @@ describe('providerService', () => {
     })
   })
 
-  describe.skip('deployToCloudProvider', () => {})
+  describe('deployToCloudProvider', () => {
+    context('when the configured provider implements the `deploy` function', () => {
+      context('with no rockets', () => {
+        it('loads and initializes the infrastructure module and calls the `deploy` method', async () => {
+          const fakeProviderDescription = {
+            name: 'some-provider-package',
+            version: '3.14.16',
+          }
+          const fakeDeploy = fake()
 
-  describe('startProvider', () => {
-    context('when the configured provider implements the run function', () => {
-      it('calls the provider start method', async () => {
-        const fakeInfrastructure = {
-          start: fake(),
+          const fakeInfrastructure = {
+            Infrastructure: fake.returns({ deploy: fakeDeploy }),
+          }
+
+          replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+
+          const fakeProvider = {
+            packageDescription: fake.returns(fakeProviderDescription),
+          }
+
+          const fakeConfig = {
+            appName: 'lolapp',
+            provider: fakeProvider,
+            rockets: [],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any
+
+          await providerService.deployToCloudProvider(fakeConfig, logger)
+
+          expect(fakeProvider.packageDescription).to.have.been.calledOnce
+          expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+          expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith([])
+          expect(fakeDeploy).to.have.been.calledOnceWith(fakeConfig, logger)
+        })
+      })
+
+      context('with rockets', () => {
+        it('loads and initializes the infrastructure module with the rockets and calls the `deploy` method', async () => {
+          const fakeProviderDescription = {
+            name: 'some-provider-package',
+            version: '3.14.16',
+          }
+          const fakeDeploy = fake()
+
+          const fakeInfrastructure = {
+            Infrastructure: fake.returns({ deploy: fakeDeploy }),
+          }
+
+          replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+
+          const fakeProvider = {
+            packageDescription: fake.returns(fakeProviderDescription),
+          }
+
+          const fakeRockets = [
+            {
+              packageName: 'rocket-package',
+              parameters: { some: 'parameter' },
+            },
+          ]
+
+          const fakeConfig = {
+            appName: 'lolapp',
+            provider: fakeProvider,
+            rockets: fakeRockets,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any
+
+          await providerService.deployToCloudProvider(fakeConfig, logger)
+
+          expect(fakeProvider.packageDescription).to.have.been.calledOnce
+          expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+          expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith(fakeRockets)
+          expect(fakeDeploy).to.have.been.calledOnceWith(fakeConfig, logger)
+        })
+      })
+    })
+
+    context('when the configured provider does not implement the `deploy` function', () => {
+      it('throws an error', async () => {
+        const fakeProviderDescription = {
+          name: 'some-provider-package',
+          version: '3.14.16',
         }
 
+        const fakeInfrastructure = {
+          Infrastructure: fake.returns({}),
+        }
+
+        replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+
         const fakeProvider = {
-          infrastructure: fake.returns(fakeInfrastructure),
+          packageDescription: fake.returns(fakeProviderDescription),
+        }
+
+        const fakeConfig = {
+          appName: 'lolapp',
+          provider: fakeProvider,
+          rockets: [],
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any
+
+        await expect(providerService.deployToCloudProvider(fakeConfig, logger)).to.eventually.be.rejectedWith(
+          "Attempted to perform the 'deploy' operation with a provider that does not support this feature, please check your environment configuration."
+        )
+
+        expect(fakeProvider.packageDescription).to.have.been.calledOnce
+        expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+        expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith([])
+      })
+    })
+  })
+
+  describe('nukeCloudProviderResources', () => {
+    context('when the configured provider implements the `nuke` function', () => {
+      context('with no rockets', () => {
+        it('loads and initializes the infrastructure module and calls the `nuke` method', async () => {
+          const fakeProviderDescription = {
+            name: 'some-provider-package',
+            version: '3.14.16',
+          }
+          const fakeNuke = fake()
+
+          const fakeInfrastructure = {
+            Infrastructure: fake.returns({ nuke: fakeNuke }),
+          }
+
+          replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+
+          const fakeProvider = {
+            packageDescription: fake.returns(fakeProviderDescription),
+          }
+
+          const fakeConfig = {
+            appName: 'lolapp',
+            provider: fakeProvider,
+            rockets: [],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any
+
+          await providerService.nukeCloudProviderResources(fakeConfig, logger)
+
+          expect(fakeProvider.packageDescription).to.have.been.calledOnce
+          expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+          expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith([])
+          expect(fakeNuke).to.have.been.calledOnceWith(fakeConfig, logger)
+        })
+      })
+
+      context('with rockets', () => {
+        it('loads and initializes the infrastructure module with the rockets and calls the `nuke` method', async () => {
+          const fakeProviderDescription = {
+            name: 'some-provider-package',
+            version: '3.14.16',
+          }
+          const fakeNuke = fake()
+
+          const fakeInfrastructure = {
+            Infrastructure: fake.returns({ nuke: fakeNuke }),
+          }
+
+          replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+
+          const fakeProvider = {
+            packageDescription: fake.returns(fakeProviderDescription),
+          }
+
+          const fakeRockets = [
+            {
+              packageName: 'rocket-package',
+              parameters: { some: 'parameter' },
+            },
+          ]
+
+          const fakeConfig = {
+            appName: 'lolapp',
+            provider: fakeProvider,
+            rockets: fakeRockets,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any
+
+          await providerService.nukeCloudProviderResources(fakeConfig, logger)
+
+          expect(fakeProvider.packageDescription).to.have.been.calledOnce
+          expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+          expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith(fakeRockets)
+          expect(fakeNuke).to.have.been.calledOnceWith(fakeConfig, logger)
+        })
+      })
+    })
+
+    context('when the configured provider does not implement the `nuke` function', () => {
+      it('throws an error', async () => {
+        const fakeProviderDescription = {
+          name: 'some-provider-package',
+          version: '3.14.16',
+        }
+
+        const fakeInfrastructure = {
+          Infrastructure: fake.returns({}),
+        }
+
+        replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+
+        const fakeProvider = {
+          packageDescription: fake.returns(fakeProviderDescription),
+        }
+
+        const fakeConfig = {
+          appName: 'lolapp',
+          provider: fakeProvider,
+          rockets: [],
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any
+
+        await expect(providerService.nukeCloudProviderResources(fakeConfig, logger)).to.be.eventually.rejectedWith(
+          "Attempted to perform the 'nuke' operation with a provider that does not support this feature, please check your environment configuration."
+        )
+
+        expect(fakeProvider.packageDescription).to.have.been.calledOnce
+        expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+        expect(fakeInfrastructure.Infrastructure).to.have.been.calledWith([])
+      })
+    })
+  })
+
+  describe('startProvider', () => {
+    context('when the configured provider implements the `start` function', () => {
+      it('calls the provider start method', async () => {
+        const fakeProviderDescription = {
+          name: 'some-provider-package',
+          version: '3.14.16',
+        }
+        const fakeStart = fake()
+
+        const fakeInfrastructure = {
+          Infrastructure: fake.returns({ start: fakeStart }),
+        }
+
+        replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+
+        const fakeProvider = {
+          packageDescription: fake.returns(fakeProviderDescription),
         }
 
         const fakeConfig = {
@@ -60,14 +301,27 @@ describe('providerService', () => {
 
         await providerService.startProvider(3000, fakeConfig)
 
-        expect(fakeInfrastructure.start).to.have.been.calledOnceWith(fakeConfig)
+        expect(fakeProvider.packageDescription).to.have.been.calledOnce
+        expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
+        expect(fakeStart).to.have.been.calledOnceWith(fakeConfig, 3000)
       })
     })
 
-    context('when the configured provider does not implement the start function', () => {
+    context('when the configured provider does not implement the `start` function', () => {
       it('throws an error', async () => {
+        const fakeProviderDescription = {
+          name: 'some-provider-package',
+          version: '3.14.16',
+        }
+
+        const fakeInfrastructure = {
+          Infrastructure: fake.returns({}),
+        }
+
+        replace(dynamicLoader, 'dynamicLoad', fake.resolves(fakeInfrastructure))
+
         const fakeProvider = {
-          infrastructure: fake.returns({}),
+          packageDescription: fake.returns(fakeProviderDescription),
         }
 
         const fakeConfig = {
@@ -76,12 +330,13 @@ describe('providerService', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any
 
-        await expect(providerService.startProvider(3000, fakeConfig)).to.eventually.be.rejectedWith(
-          `Attempted to perform the 'start' operation with a provider that does not support this feature, please check your environment configuration.`
+        await expect(providerService.startProvider(3000, fakeConfig)).to.be.eventually.rejectedWith(
+          "Attempted to perform the 'start' operation with a provider that does not support this feature, please check your environment configuration."
         )
+
+        expect(fakeProvider.packageDescription).to.have.been.calledOnce
+        expect(dynamicLoader.dynamicLoad).to.have.been.calledWith('some-provider-package-infrastructure')
       })
     })
   })
-
-  describe.skip('nukeCloudProviderResources', () => {})
 })

--- a/packages/framework-core/src/decorators/metadata.ts
+++ b/packages/framework-core/src/decorators/metadata.ts
@@ -4,8 +4,8 @@ import 'reflect-metadata'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getPropertiesMetadata(classType: Class<any>): Array<PropertyMetadata> {
   const propertyNames = Object.getOwnPropertyNames(new classType())
-  const propertyTypes = Reflect.getMetadata('design:paramtypes', classType)
-  if (propertyNames.length != propertyTypes.length) {
+  const propertyTypes = Reflect.getMetadata('design:paramtypes', classType) ?? []
+  if (propertyNames.length !== propertyTypes.length) {
     // eslint-disable-next-line prettier/prettier
     throw new Error(`Could not get proper metadata information of ${classType.name}. While inspecting the class, the following properties were found:
 > ${propertyNames.join(', ')}

--- a/packages/framework-core/test/booster-command-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-command-dispatcher.test.ts
@@ -1,23 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { Booster } from '../src/booster'
-import { fake, replace, restore } from 'sinon'
+import { fake, replace, restore, match, spy } from 'sinon'
 import { expect } from './expect'
 import { BoosterCommandDispatcher } from '../src/booster-command-dispatcher'
-import { Logger, Register } from '@boostercloud/framework-types'
-import { Command } from '../src/decorators'
+import { BoosterConfig, Logger, Register, UUID } from '@boostercloud/framework-types'
 import { RegisterHandler } from '../src/booster-register-handler'
-import { random } from 'faker'
 
 describe('the `BoosterCommandsDispatcher`', () => {
   afterEach(() => {
     restore()
-    Booster.configure('test', (config) => {
-      config.appName = ''
-      for (const propName in config.commandHandlers) {
-        delete config.commandHandlers[propName]
-      }
-    })
   })
 
   const logger: Logger = {
@@ -26,172 +17,182 @@ describe('the `BoosterCommandsDispatcher`', () => {
     error() {},
   }
 
-  describe('the `dispatchCommand` method', () => {
-    it('fails if the command "version" is not sent', () => {
-      const command = {
-        typeName: 'PostComment',
-        value: { comment: 'This comment is pointless' },
-      }
-      Booster.configure('test', async (config) => {
+  describe('private methods', () => {
+    describe('the `dispatchCommand` method', () => {
+      it('fails if the current user is not authorized', async () => {
+        class Thor {}
+
+        const config = {
+          commandHandlers: {
+            UnauthorizedCommand: {
+              authorizedRoles: [Thor],
+            },
+          },
+        }
+
+        const commandEnvelope = {
+          typeName: 'UnauthorizedCommand',
+          version: 'π', // JS doesn't care, and π is a number after all xD...
+          currentUser: {
+            role: 'Loki',
+          },
+        }
+
+        await expect(
+          new BoosterCommandDispatcher(config as any, logger).dispatchCommand(commandEnvelope as any)
+        ).to.be.eventually.rejectedWith("Access denied for command 'UnauthorizedCommand'")
+      })
+
+      it('calls the handler method of a registered command and handles the result', async () => {
+        class PostComment {
+          public constructor(readonly comment: string) {}
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          public static async handle(_command: PostComment, _register: Register): Promise<void> {
+            throw new Error('Not implemented')
+          }
+        }
+
+        const config = new BoosterConfig('test') as any
+        config.commandHandlers = {
+          PostComment: {
+            class: PostComment,
+            properties: { name: 'comment', type: String },
+            authorizedRoles: 'all',
+          },
+        }
+
+        const fakeHandler = fake()
+        replace(PostComment, 'handle', fakeHandler)
+        replace(RegisterHandler, 'handle', fake())
+
+        const command = new PostComment('This test is good!')
+
+        await new BoosterCommandDispatcher(config, logger).dispatchCommand({
+          requestID: '1234',
+          version: 1,
+          typeName: 'PostComment',
+          value: command,
+        })
+
+        expect(fakeHandler).to.have.been.calledOnceWith(command)
+        expect(RegisterHandler.handle).to.have.been.calledOnceWith(config, logger, match.instanceOf(Register))
+      })
+
+      it('properly handle the registered events', async () => {
+        class SomethingHappened {
+          public constructor(readonly when: string) {}
+          public entityID() {
+            return UUID.generate()
+          }
+        }
+
+        const event = new SomethingHappened('right now!')
+
+        const fakeHandler = fake((_command: any, register: Register) => {
+          register.events(event)
+        })
+
+        class ProperlyHandledCommand {
+          public static handle() {}
+        }
+
+        replace(ProperlyHandledCommand, 'handle', fakeHandler)
+        replace(RegisterHandler, 'handle', fake())
+
+        const config = {
+          commandHandlers: {
+            ProperlyHandledCommand: {
+              authorizedRoles: 'all',
+              class: ProperlyHandledCommand,
+            },
+          },
+        }
+        const commandValue = {
+          something: 'to handle',
+        }
+
+        const commandEnvelope = {
+          typeName: 'ProperlyHandledCommand',
+          version: 'π', // JS doesn't care, and π is a number after all xD...
+          currentUser: {
+            role: 'Loki',
+          },
+          value: commandValue,
+          requestID: '42',
+        }
+
+        await new BoosterCommandDispatcher(config as any, logger).dispatchCommand(commandEnvelope as any)
+
+        expect(fakeHandler).to.have.been.calledWithMatch(commandValue)
+        expect(RegisterHandler.handle).to.have.been.calledWithMatch(config, logger, {
+          requestID: '42',
+          currentUser: commandEnvelope.currentUser,
+          eventList: [event],
+        })
+      })
+
+      it('waits for the handler method of a registered command to finish any async operation', async () => {
+        let asyncOperationFinished = false
+        class PostComment {
+          public constructor(readonly comment: string) {}
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          public static async handle(command: PostComment, _register: Register): Promise<void> {
+            await new Promise((resolve) => setTimeout(resolve, 100))
+            asyncOperationFinished = true
+          }
+        }
+
+        const config = new BoosterConfig('test') as any
+        config.commandHandlers = {
+          PostComment: {
+            class: PostComment,
+            properties: { name: 'comment', type: String },
+            authorizedRoles: 'all',
+          },
+        }
+
+        const handlerSpy = spy(PostComment, 'handle')
+        replace(RegisterHandler, 'handle', fake())
+
+        const command = new PostComment('This test is good!')
+
+        await new BoosterCommandDispatcher(config, logger).dispatchCommand({
+          requestID: '1234',
+          version: 1,
+          typeName: 'PostComment',
+          value: command,
+        })
+
+        expect(handlerSpy).to.have.been.calledOnceWith(command)
+        expect(asyncOperationFinished).to.be.true
+      })
+
+      it('fails if the command "version" is not sent', async () => {
+        const command = {
+          typeName: 'PostComment',
+          value: { comment: 'This comment is pointless' },
+        }
+
+        const config = new BoosterConfig('test')
+
         await expect(
           new BoosterCommandDispatcher(config, logger).dispatchCommand(command as any)
-        ).to.be.eventually.rejectedWith('The required command "version" was not present')
+        ).to.eventually.be.rejectedWith('The required command "version" was not present')
       })
-    })
 
-    it('fails if the command is not registered', () => {
-      const command = {
-        version: 1,
-        typeName: 'PostComment',
-        value: { comment: 'This comment is pointless' },
-      }
-      Booster.configure('test', async (config) => {
+      it('fails if the command is not registered', async () => {
+        const command = {
+          version: 1,
+          typeName: 'PostComment',
+          value: { comment: 'This comment is pointless' },
+        }
+
+        const config = new BoosterConfig('test')
+
         await expect(
           new BoosterCommandDispatcher(config, logger).dispatchCommand(command as any)
-        ).to.be.eventually.rejectedWith('Could not find a proper handler for PostComment')
+        ).to.eventually.be.rejectedWith('Could not find a proper handler for PostComment')
       })
-    })
-
-    it('fails if the current user is not authorized', async () => {
-      class Thor {}
-
-      const config = {
-        commandHandlers: {
-          UnauthorizedCommand: {
-            authorizedRoles: [Thor],
-          },
-        },
-      }
-
-      const commandEnvelope = {
-        typeName: 'UnauthorizedCommand',
-        version: 'π', // JS doesn't care, and π is a number after all xD...
-        currentUser: {
-          role: 'Loki',
-        },
-      }
-
-      await expect(
-        new BoosterCommandDispatcher(config as any, logger).dispatchCommand(commandEnvelope as any)
-      ).to.be.eventually.rejectedWith("Access denied for command 'UnauthorizedCommand'")
-    })
-
-    it('calls the handler method of a registered command', async () => {
-      const fakeHandler = fake()
-      class ProperlyHandledCommand {
-        public static handle() {}
-      }
-
-      replace(ProperlyHandledCommand, 'handle', fakeHandler)
-      replace(RegisterHandler, 'handle', fake())
-
-      const config = {
-        commandHandlers: {
-          ProperlyHandledCommand: {
-            authorizedRoles: 'all',
-            class: ProperlyHandledCommand,
-          },
-        },
-      }
-      const commandValue = {
-        something: 'to handle',
-      }
-
-      const commandEnvelope = {
-        typeName: 'ProperlyHandledCommand',
-        version: 'π', // JS doesn't care, and π is a number after all xD...
-        currentUser: {
-          role: 'Loki',
-        },
-        value: commandValue,
-        requestID: '42',
-      }
-
-      await new BoosterCommandDispatcher(config as any, logger).dispatchCommand(commandEnvelope as any)
-
-      expect(fakeHandler).to.have.been.calledWithMatch(commandValue)
-    })
-
-    it('properly handle the registered events', async () => {
-      class SomethingHappened {
-        public constructor(readonly when: string) {}
-        public entityID() {
-          return random.uuid()
-        }
-      }
-
-      const event = new SomethingHappened('right now!')
-
-      const fakeHandler = fake((_command: any, register: Register) => {
-        register.events(event)
-      })
-
-      class ProperlyHandledCommand {
-        public static handle() {}
-      }
-
-      replace(ProperlyHandledCommand, 'handle', fakeHandler)
-      replace(RegisterHandler, 'handle', fake())
-
-      const config = {
-        commandHandlers: {
-          ProperlyHandledCommand: {
-            authorizedRoles: 'all',
-            class: ProperlyHandledCommand,
-          },
-        },
-      }
-      const commandValue = {
-        something: 'to handle',
-      }
-
-      const commandEnvelope = {
-        typeName: 'ProperlyHandledCommand',
-        version: 'π', // JS doesn't care, and π is a number after all xD...
-        currentUser: {
-          role: 'Loki',
-        },
-        value: commandValue,
-        requestID: '42',
-      }
-
-      await new BoosterCommandDispatcher(config as any, logger).dispatchCommand(commandEnvelope as any)
-
-      expect(fakeHandler).to.have.been.calledWithMatch(commandValue)
-      expect(RegisterHandler.handle).to.have.been.calledWithMatch(config, logger, {
-        requestID: '42',
-        currentUser: commandEnvelope.currentUser,
-        eventList: [event],
-      })
-    })
-
-    it('waits for the handler method of a registered command to finish any async operation', async () => {
-      let asyncOperationFinished = false
-      @Command({ authorize: 'all' })
-      class PostComment {
-        public constructor(readonly comment: string) {}
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        public static async handle(command: PostComment, _register: Register): Promise<void> {
-          await new Promise((resolve) => setTimeout(resolve, 100))
-          asyncOperationFinished = true
-        }
-      }
-
-      const command = new PostComment('This test is good!')
-      replace(RegisterHandler, 'handle', fake())
-
-      let boosterConfig: any
-      Booster.configure('test', (config) => {
-        boosterConfig = config
-      })
-
-      await new BoosterCommandDispatcher(boosterConfig, logger).dispatchCommand({
-        requestID: '1234',
-        version: 1,
-        typeName: 'PostComment',
-        value: command,
-      })
-      expect(asyncOperationFinished).to.be.true
     })
   })
 })

--- a/packages/framework-integration-tests/integration/cli/.mocharc.yml
+++ b/packages/framework-integration-tests/integration/cli/.mocharc.yml
@@ -9,4 +9,4 @@ timeout: 600000
 file:
   - './integration/cli/setup.ts'
 full-trace: true
-# bail: true -- This option makes the test suite stop after the first failure. Might make sense to enable once tests are stable
+bail: true

--- a/packages/framework-integration-tests/integration/end-to-end/.mocharc.yml
+++ b/packages/framework-integration-tests/integration/end-to-end/.mocharc.yml
@@ -9,4 +9,4 @@ timeout: 600000
 file:
   - './integration/end-to-end/setup.ts'
 full-trace: true
-# bail: true -- This option makes the test suite stop after the first failure. Might make sense to enable once tests are stable
+bail: true

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/src/config/config.ts
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/src/config/config.ts
@@ -4,5 +4,5 @@ import { Provider } from '@boostercloud/framework-provider-aws'
 
 Booster.configure('production', (config: BoosterConfig): void => {
   config.appName = 'project_name_placeholder'
-  config.provider = Provider()
+  config.provider = Provider
 })

--- a/packages/framework-integration-tests/integration/helper/depsHelper.ts
+++ b/packages/framework-integration-tests/integration/helper/depsHelper.ts
@@ -1,13 +1,22 @@
-import { exec } from 'child-process-promise'
 import * as path from 'path'
 import * as fs from 'fs'
+import { runCommand } from './runCommand'
 
 export async function overrideWithBoosterLocalDependencies(projectPath: string): Promise<void> {
   const projectRelativePath = path.relative(__dirname, projectPath)
   const packageJSON = require(path.join(projectRelativePath, 'package.json'))
   // To compile the project with the current version we need to replace all Booster dependencies
   // by the versions under development.
-  for (const packageName in packageJSON.dependencies) {
+  await overrideBoosterPackages(packageJSON, 'dependencies')
+  await overrideBoosterPackages(packageJSON, 'devDependencies')
+  fs.writeFileSync(path.join(projectPath, 'package.json'), JSON.stringify(packageJSON, undefined, 2))
+}
+
+async function overrideBoosterPackages(
+  packageJSON: { dependencies: Record<string, string>; devDependencies: Record<string, string> },
+  dependenciesEntry: 'dependencies' | 'devDependencies'
+): Promise<void> {
+  for (const packageName in packageJSON[dependenciesEntry]) {
     if (/@boostercloud/.test(packageName)) {
       const dependencyName = packageName.replace('@boostercloud/', '')
 
@@ -16,20 +25,18 @@ export async function overrideWithBoosterLocalDependencies(projectPath: string):
         fs.mkdirSync(dotBooster)
       }
 
-      const execution = await exec(`npm pack ${path.join('..', '..', dependencyName)}`, { cwd: dotBooster })
+      const execution = await runCommand(dotBooster, `npm pack ${path.join('..', '..', dependencyName)}`)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const packedDependencyFileName = execution.stdout
         ?.trim()
         ?.split('\n')
         ?.pop()!
       const dotBoosterAbsolutePath = path.resolve(dotBooster)
-      // Now override the packageJSON dependencies with the path to the packed dependency
-      packageJSON.dependencies[packageName] = `file:${path.join(dotBoosterAbsolutePath, packedDependencyFileName)}`
+      // Now override the dependency with the path to the packed dependency
+      packageJSON[dependenciesEntry][packageName] = `file:${path.join(
+        dotBoosterAbsolutePath,
+        packedDependencyFileName
+      )}`
     }
   }
-  fs.writeFileSync(path.join(projectPath, 'package.json'), JSON.stringify(packageJSON, undefined, 2))
-}
-
-export async function forceLernaRebuild(): Promise<void> {
-  await exec('lerna clean --yes && lerna bootstrap && lerna run clean && lerna run compile')
 }

--- a/packages/framework-integration-tests/integration/providers/aws/functionality/.mocharc.yml
+++ b/packages/framework-integration-tests/integration/providers/aws/functionality/.mocharc.yml
@@ -9,4 +9,4 @@ timeout: 1500000
 file:
   - './integration/providers/aws/functionality/setup.ts'
 full-trace: true
-# bail: true -- This option makes the test suite stop after the first failure. Might make sense to enable once tests are stable
+bail: true

--- a/packages/framework-integration-tests/integration/providers/local/utils.ts
+++ b/packages/framework-integration-tests/integration/providers/local/utils.ts
@@ -8,10 +8,10 @@ import { runCommand } from '../../helper/runCommand'
 import path = require('path')
 import { ChildProcess } from 'child_process'
 
-const cliBinaryPath = path.join('..', 'cli', 'bin', 'run')
+const cliBinaryPath = path.join('..', '..', 'cli', 'bin', 'run')
 
 export function start(environmentName = 'local', path: string): ChildProcess {
-  return runCommand(path, `../${cliBinaryPath} start -e ${environmentName}`).childProcess
+  return runCommand(path, `${cliBinaryPath} start -e ${environmentName}`).childProcess
 }
 
 // --- Auth helpers ---

--- a/packages/framework-integration-tests/src/config/config.ts
+++ b/packages/framework-integration-tests/src/config/config.ts
@@ -8,14 +8,14 @@ if (process.env.BOOSTER_ENV === 'local') {
 
   Booster.configure('local', (config: BoosterConfig): void => {
     config.appName = 'my-store'
-    config.provider = Local.Provider()
+    config.provider = Local.Provider
   })
 }
 
 Booster.configure('development', (config: BoosterConfig): void => {
   config.appName = 'my-store'
-  config.provider = AWS.Provider()
   config.assets = ['assets', 'assetFile.txt']
+  config.provider = AWS.Provider
 })
 
 Booster.configure('production', (config: BoosterConfig): void => {
@@ -28,6 +28,6 @@ Booster.configure('production', (config: BoosterConfig): void => {
   config.env['BOOSTER_APP_SUFFIX'] = appNameSuffix
 
   config.appName = 'my-store-' + appNameSuffix
-  config.provider = AWS.Provider()
   config.assets = ['assets', 'assetFile.txt']
+  config.provider = AWS.Provider
 })

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -13,7 +13,7 @@ import {
 } from './library/read-model-adapter'
 import { rawGraphQLRequestToEnvelope } from './library/graphql-adapter'
 import { DynamoDB, CognitoIdentityServiceProvider } from 'aws-sdk'
-import { ProviderInfrastructure, ProviderLibrary, RocketDescriptor } from '@boostercloud/framework-types'
+import { ProviderLibrary } from '@boostercloud/framework-types'
 import { requestFailed, requestSucceeded } from './library/api-gateway-io'
 import { searchReadModel } from './library/searcher-adapter'
 import {
@@ -34,84 +34,62 @@ import { rawScheduledInputToEnvelope } from './library/scheduled-adapter'
 const dynamoDB: DynamoDB.DocumentClient = new DynamoDB.DocumentClient()
 const userPool = new CognitoIdentityServiceProvider()
 
-/* We load the infrastructure package dynamically here to avoid including it in the
- * dependences that are deployed in the lambda functions. The infrastructure
- * package is only used during the deploy.
- * Notice that this is done in a separate function to ease testing
- */
-function loadInfrastructurePackage(
-  packageName: string
-): { Infrastructure: (rockets?: RocketDescriptor[]) => ProviderInfrastructure } {
-  return require(packageName)
-}
-
 /**
- * `Provider` is a function that accepts a list of rocket names and returns an
- * object compatible with the `ProviderLibrary` defined in the `framework-types` package.
- * The rocket names are passed to the infrastructure package, which loads them dynamically
- * to extend the AWS functionality. Rockets are typically distributed in separate node packages.
+ * `Provider` is an implementation of `ProviderLibrary` defined in the `framework-types` package.
  */
-export const Provider = (rockets?: RocketDescriptor[]): ProviderLibrary => {
-  return {
-    // ProviderEventsLibrary
-    events: {
-      rawToEnvelopes: rawEventsToEnvelopes,
-      forEntitySince: readEntityEventsSince.bind(null, dynamoDB),
-      latestEntitySnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
-      store: storeEvents.bind(null, dynamoDB),
-    },
-    // ProviderReadModelsLibrary
-    readModels: {
-      rawToEnvelopes: rawReadModelEventsToEnvelopes,
-      fetch: fetchReadModel.bind(null, dynamoDB),
-      search: searchReadModel.bind(null, dynamoDB),
-      store: storeReadModel.bind(null, dynamoDB),
-      delete: deleteReadModel.bind(null, dynamoDB),
-      subscribe: subscribeToReadModel.bind(null, dynamoDB),
-      fetchSubscriptions: fetchSubscriptions.bind(null, dynamoDB),
-      deleteSubscription: deleteSubscription.bind(null, dynamoDB),
-      deleteAllSubscriptions: deleteAllSubscriptions.bind(null, dynamoDB),
-    },
-    // ProviderGraphQLLibrary
-    graphQL: {
-      rawToEnvelope: rawGraphQLRequestToEnvelope,
-      handleResult: requestSucceeded,
-    },
-    // ProviderAuthLibrary
-    auth: {
-      rawToEnvelope: rawSignUpDataToUserEnvelope,
-      fromAuthToken: userEnvelopeFromAuthToken.bind(null, userPool),
-      handleSignUpResult: handleSignUpResult,
-    },
-    // ProviderAPIHandling
-    api: {
-      requestSucceeded,
-      requestFailed,
-    },
-    connections: {
-      storeData: storeConnectionData.bind(null, dynamoDB),
-      fetchData: fetchConnectionData.bind(null, dynamoDB),
-      deleteData: deleteConnectionData.bind(null, dynamoDB),
-      sendMessage: sendMessageToConnection,
-    },
-    // ScheduledCommandsLibrary
-    scheduled: {
-      rawToEnvelope: rawScheduledInputToEnvelope,
-    },
-    // ProviderInfrastructureGetter
-    infrastructure: () => {
-      const infrastructurePackageName = require('../package.json').name + '-infrastructure'
-      try {
-        return loadInfrastructurePackage(infrastructurePackageName).Infrastructure(rockets)
-      } catch (e) {
-        throw new Error(
-          'The AWS infrastructure package could not be loaded. Please ensure that one of the following actions has been done:\n' +
-            `  - It has been specified in your "devDependencies" section of your "package.json" file. You can do so by running 'npm install --save-dev ${infrastructurePackageName}'\n` +
-            `  - Or it has been installed globally. You can do so by running 'npm install -g ${infrastructurePackageName}'`
-        )
-      }
-    },
-  }
+export const Provider: ProviderLibrary = {
+  // ProviderEventsLibrary
+  events: {
+    rawToEnvelopes: rawEventsToEnvelopes,
+    forEntitySince: readEntityEventsSince.bind(null, dynamoDB),
+    latestEntitySnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
+    store: storeEvents.bind(null, dynamoDB),
+  },
+  // ProviderReadModelsLibrary
+  readModels: {
+    rawToEnvelopes: rawReadModelEventsToEnvelopes,
+    fetch: fetchReadModel.bind(null, dynamoDB),
+    search: searchReadModel.bind(null, dynamoDB),
+    store: storeReadModel.bind(null, dynamoDB),
+    delete: deleteReadModel.bind(null, dynamoDB),
+    subscribe: subscribeToReadModel.bind(null, dynamoDB),
+    fetchSubscriptions: fetchSubscriptions.bind(null, dynamoDB),
+    deleteSubscription: deleteSubscription.bind(null, dynamoDB),
+    deleteAllSubscriptions: deleteAllSubscriptions.bind(null, dynamoDB),
+  },
+  // ProviderGraphQLLibrary
+  graphQL: {
+    rawToEnvelope: rawGraphQLRequestToEnvelope,
+    handleResult: requestSucceeded,
+  },
+  // ProviderAuthLibrary
+  auth: {
+    rawToEnvelope: rawSignUpDataToUserEnvelope,
+    fromAuthToken: userEnvelopeFromAuthToken.bind(null, userPool),
+    handleSignUpResult: handleSignUpResult,
+  },
+  // ProviderAPIHandling
+  api: {
+    requestSucceeded,
+    requestFailed,
+  },
+  connections: {
+    storeData: storeConnectionData.bind(null, dynamoDB),
+    fetchData: fetchConnectionData.bind(null, dynamoDB),
+    deleteData: deleteConnectionData.bind(null, dynamoDB),
+    sendMessage: sendMessageToConnection,
+  },
+  // ScheduledCommandsLibrary
+  scheduled: {
+    rawToEnvelope: rawScheduledInputToEnvelope,
+  },
+  packageDescription: () => {
+    const { name, version } = require('../package.json')
+    return {
+      name,
+      version,
+    }
+  },
 }
 
 export * from './constants'

--- a/packages/framework-provider-aws/test/index.test.ts
+++ b/packages/framework-provider-aws/test/index.test.ts
@@ -1,13 +1,7 @@
 import { ProviderLibrary } from '@boostercloud/framework-types'
 import { expect } from '../test/expect'
-import { fake, restore } from 'sinon'
-
-const rewire = require('rewire')
-const providerPackage = rewire('../src/index')
-const fakeInfrastructure = fake.returns({})
-providerPackage.__set__('loadInfrastructurePackage', () => ({
-  Infrastructure: fakeInfrastructure,
-}))
+import { restore } from 'sinon'
+import * as providerPackage from '../src/index'
 
 describe('the `framework-provider-aws` package', () => {
   afterEach(() => {
@@ -15,58 +9,25 @@ describe('the `framework-provider-aws` package', () => {
   })
 
   describe('the `Provider` function', () => {
-    context('with no rockets', () => {
-      const providerLibrary: ProviderLibrary = providerPackage.Provider()
+    const providerLibrary: ProviderLibrary = providerPackage.Provider
 
-      it('returns a `ProviderLibrary` object', () => {
-        expect(providerLibrary).to.be.an('object')
-        expect(providerLibrary.api).to.be.an('object')
-        expect(providerLibrary.auth).to.be.an('object')
-        expect(providerLibrary.connections).to.be.an('object')
-        expect(providerLibrary.events).to.be.an('object')
-        expect(providerLibrary.graphQL).to.be.an('object')
-        expect(providerLibrary.infrastructure).to.be.a('function')
-        expect(providerLibrary.readModels).to.be.an('object')
-      })
-
-      describe('infrastructure', () => {
-        it('is loaded with no parameters', () => {
-          providerLibrary.infrastructure()
-
-          expect(fakeInfrastructure).to.have.been.calledWith()
-        })
-      })
+    it('returns a `ProviderLibrary` object', () => {
+      expect(providerLibrary).to.be.an('object')
+      expect(providerLibrary.api).to.be.an('object')
+      expect(providerLibrary.auth).to.be.an('object')
+      expect(providerLibrary.connections).to.be.an('object')
+      expect(providerLibrary.events).to.be.an('object')
+      expect(providerLibrary.graphQL).to.be.an('object')
+      expect(providerLibrary.readModels).to.be.an('object')
+      expect(providerLibrary.packageDescription).to.be.a('function')
     })
 
-    context('with a list of rockets', () => {
-      const rockets = [
-        {
-          packageName: 'some-package-name',
-          parameters: {
-            whatever: true,
-          },
-        },
-      ]
+    describe('packageDescription', () => {
+      it('provides info about ', () => {
+        const packageDescription = providerLibrary.packageDescription()
 
-      const providerLibrary: ProviderLibrary = providerPackage.Provider(rockets)
-
-      it('returns a `ProviderLibrary` object', () => {
-        expect(providerLibrary).to.be.an('object')
-        expect(providerLibrary.api).to.be.an('object')
-        expect(providerLibrary.auth).to.be.an('object')
-        expect(providerLibrary.connections).to.be.an('object')
-        expect(providerLibrary.events).to.be.an('object')
-        expect(providerLibrary.graphQL).to.be.an('object')
-        expect(providerLibrary.infrastructure).to.be.a('function')
-        expect(providerLibrary.readModels).to.be.an('object')
-      })
-
-      describe('infrastructure', () => {
-        it('is loaded with a list of rockets', () => {
-          providerLibrary.infrastructure()
-
-          expect(fakeInfrastructure).to.have.been.calledWith(rockets)
-        })
+        expect(packageDescription.name).to.be.equal('@boostercloud/framework-provider-aws')
+        expect(packageDescription.version).to.be.equal(require('../package.json').version)
       })
     })
   })

--- a/packages/framework-provider-azure-infrastructure/src/index.ts
+++ b/packages/framework-provider-azure-infrastructure/src/index.ts
@@ -1,6 +1,9 @@
 import { deploy, nuke } from './infrastructure'
+import { ProviderInfrastructure } from '@boostercloud/framework-types'
 
-export const Infrastructure = {
-  deploy,
-  nuke,
+export const Infrastructure = (): ProviderInfrastructure => {
+  return {
+    deploy,
+    nuke,
+  }
 }

--- a/packages/framework-provider-azure/src/index.ts
+++ b/packages/framework-provider-azure/src/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ProviderInfrastructure, ProviderLibrary } from '@boostercloud/framework-types'
+import { ProviderLibrary } from '@boostercloud/framework-types'
 import { requestFailed, requestSucceeded } from './library/api-adapter'
 import { rawGraphQLRequestToEnvelope } from './library/graphql-adapter'
 import {
@@ -18,7 +18,7 @@ if (typeof process.env[environmentVarNames.cosmosDbConnectionString] === 'undefi
 }
 const cosmosClient = new CosmosClient(process.env[environmentVarNames.cosmosDbConnectionString] as string)
 
-export const Provider = (): ProviderLibrary => ({
+export const Provider: ProviderLibrary = {
   // ProviderEventsLibrary
   events: {
     rawToEnvelopes: rawEventsToEnvelopes,
@@ -64,10 +64,14 @@ export const Provider = (): ProviderLibrary => ({
   scheduled: {
     rawToEnvelope: undefined as any,
   },
-  // ProviderInfrastructureGetter
-  infrastructure: () =>
-    require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure,
-})
+  packageDescription: () => {
+    const { name, version } = require('../package.json')
+    return {
+      name,
+      version,
+    }
+  },
+}
 
 function notImplemented(): void {}
 

--- a/packages/framework-provider-kubernetes-infrastructure/src/index.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/index.ts
@@ -1,6 +1,9 @@
+import { ProviderInfrastructure } from '@boostercloud/framework-types'
 import { deploy, nuke } from './infrastructure'
 
-export const Infrastructure = {
-  deploy,
-  nuke,
+export const Infrastructure = (): ProviderInfrastructure => {
+  return {
+    deploy,
+    nuke,
+  }
 }

--- a/packages/framework-provider-kubernetes/src/index.ts
+++ b/packages/framework-provider-kubernetes/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ProviderInfrastructure, ProviderLibrary } from '@boostercloud/framework-types'
+import { ProviderLibrary } from '@boostercloud/framework-types'
 
-export const Provider = (): ProviderLibrary => ({
+export const Provider: ProviderLibrary = {
   // ProviderEventsLibrary
   events: {
     rawToEnvelopes: undefined as any,
@@ -47,9 +47,13 @@ export const Provider = (): ProviderLibrary => ({
   scheduled: {
     rawToEnvelope: undefined as any,
   },
-  // ProviderInfrastructureGetter
-  infrastructure: () =>
-    require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure,
-})
+  packageDescription: () => {
+    const { name, version } = require('../package.json')
+    return {
+      name,
+      version,
+    }
+  },
+}
 
 function notImplemented(): void {}

--- a/packages/framework-provider-local-infrastructure/src/index.ts
+++ b/packages/framework-provider-local-infrastructure/src/index.ts
@@ -1,7 +1,7 @@
 import * as express from 'express'
 import { GraphQLService, UserRegistry } from '@boostercloud/framework-provider-local'
 import { AuthController } from './controllers/auth'
-import { BoosterConfig } from '@boostercloud/framework-types'
+import { BoosterConfig, ProviderInfrastructure } from '@boostercloud/framework-types'
 import * as path from 'path'
 import { requestFailed } from './http'
 import { GraphQLController } from './controllers/graphql'
@@ -25,25 +25,27 @@ async function defaultErrorHandler(
   await requestFailed(err, res)
 }
 
-export const Infrastructure = {
-  /**
-   * `run` serves as the entry point for the local provider. It starts the required infrastructure
-   * locally, which is running an `express` server.
-   *
-   * @param config The user's project config
-   * @param port Port on which the express server will listen
-   */
-  start: (config: BoosterConfig, port: number): void => {
-    const expressServer = express()
-    const router = express.Router()
-    const userProject: UserApp = require(path.join(process.cwd(), 'dist', 'index.js'))
-    const userRegistry = new UserRegistry()
-    const graphQLService = new GraphQLService(userProject)
-    router.use('/auth', new AuthController(port, userRegistry, userProject).router)
-    router.use('/graphql', new GraphQLController(graphQLService).router)
-    expressServer.use(express.json())
-    expressServer.use(router)
-    expressServer.use(defaultErrorHandler)
-    expressServer.listen(port)
-  },
+export const Infrastructure = (): ProviderInfrastructure => {
+  return {
+    /**
+     * `run` serves as the entry point for the local provider. It starts the required infrastructure
+     * locally, which is running an `express` server.
+     *
+     * @param config The user's project config
+     * @param port Port on which the express server will listen
+     */
+    start: (config: BoosterConfig, port: number): void => {
+      const expressServer = express()
+      const router = express.Router()
+      const userProject: UserApp = require(path.join(process.cwd(), 'dist', 'index.js'))
+      const userRegistry = new UserRegistry()
+      const graphQLService = new GraphQLService(userProject)
+      router.use('/auth', new AuthController(port, userRegistry, userProject).router)
+      router.use('/graphql', new GraphQLController(graphQLService).router)
+      expressServer.use(express.json())
+      expressServer.use(router)
+      expressServer.use(defaultErrorHandler)
+      expressServer.listen(port)
+    },
+  }
 }

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -1,4 +1,4 @@
-import { ProviderLibrary, ProviderInfrastructure } from '@boostercloud/framework-types'
+import { ProviderLibrary } from '@boostercloud/framework-types'
 import { rawSignUpDataToUserEnvelope } from './library/auth-adapter'
 import {
   rawEventsToEnvelopes,
@@ -22,7 +22,7 @@ const eventRegistry = new EventRegistry()
 const readModelRegistry = new ReadModelRegistry()
 const userApp: UserApp = require(path.join(process.cwd(), 'dist', 'index.js'))
 
-export const Provider = (): ProviderLibrary => ({
+export const Provider: ProviderLibrary = {
   // ProviderEventsLibrary
   events: {
     rawToEnvelopes: rawEventsToEnvelopes,
@@ -78,11 +78,16 @@ export const Provider = (): ProviderLibrary => ({
   },
   // ScheduledCommandsLibrary
   scheduled: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     rawToEnvelope: undefined as any,
   },
-  // ProviderInfrastructureGetter
-  infrastructure: () =>
-    require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure,
-})
+  packageDescription: () => {
+    const { name, version } = require('../package.json')
+    return {
+      name,
+      version,
+    }
+  },
+}
 
 function notImplemented(): void {}

--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -12,6 +12,7 @@ import {
 import { ProviderLibrary } from './provider'
 import { Level } from './logger'
 import * as path from 'path'
+import { RocketDescriptor } from './rocket-descriptor'
 
 /**
  * Class used by external packages that needs to get a representation of
@@ -46,6 +47,9 @@ export class BoosterConfig {
   public readonly roles: Record<RoleName, RoleMetadata> = {}
   public readonly migrations: Record<ConceptName, Map<Version, MigrationMetadata>> = {}
   public readonly scheduledCommandHandlers: Record<ScheduledCommandName, ScheduledCommandMetadata> = {}
+
+  /** List of rockets to be used in the project */
+  public readonly rockets: RocketDescriptor[] = []
 
   /** Environment variables set at deployment time on the target lambda functions */
   public readonly env: Record<string, string> = {}

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -13,6 +13,11 @@ import { Logger } from './logger'
 import { ReadModelInterface, UUID } from './concepts'
 import { Filter } from './searcher'
 
+type ProviderPackageDescription = {
+  name: string
+  version: string
+}
+
 export interface ProviderLibrary {
   events: ProviderEventsLibrary
   readModels: ProviderReadModelsLibrary
@@ -21,7 +26,7 @@ export interface ProviderLibrary {
   api: ProviderAPIHandling
   connections: ProviderConnectionsLibrary
   scheduled: ScheduledCommandsLibrary
-  infrastructure: () => ProviderInfrastructure
+  packageDescription: () => ProviderPackageDescription
 }
 
 export interface ProviderEventsLibrary {
@@ -91,12 +96,12 @@ export interface ProviderAPIHandling {
   requestFailed(error: Error): Promise<unknown>
 }
 
+export interface ScheduledCommandsLibrary {
+  rawToEnvelope(rawMessage: unknown, logger: Logger): Promise<ScheduledCommandEnvelope>
+}
+
 export interface ProviderInfrastructure {
   deploy?: (configuration: BoosterConfig, logger: Logger) => Promise<void>
   nuke?: (configuration: BoosterConfig, logger: Logger) => Promise<void>
-  start?: (configuration: BoosterConfig, port: number) => Promise<void>
-}
-
-export interface ScheduledCommandsLibrary {
-  rawToEnvelope(rawMessage: unknown, logger: Logger): Promise<ScheduledCommandEnvelope>
+  start?: (configuration: BoosterConfig, port: number) => void
 }

--- a/packages/rocket-static-sites-aws-infrastructure/README.md
+++ b/packages/rocket-static-sites-aws-infrastructure/README.md
@@ -4,13 +4,13 @@ This package is a configurable Booster rocket to add static site deployment to y
 
 ## Usage
 
-Install this package as a dev dependency in your Booster project (It's a dev dependency because it's only used during deployment, but we don't want this code to be uploaded to the project lambdas)
+Install this package as a general dependency in your machine to allow the Booster CLI load it dynamically.
 
 ```sh
-npm install --save-dev @boostercloud/rocket-static-sites-aws-infrastructure
+npm install -g @boostercloud/rocket-static-sites-aws-infrastructure
 ```
 
-In your Booster config file, pass a `RocketDescriptor` array to the AWS' `Provider` initializer configuring the static site rocket:
+In your Booster config file, add a `RocketDescriptor` to the `config.rockets` configuration option with the configuration of the static site rocket as follows:
 
 ```typescript
 import { Booster } from '@boostercloud/framework-core'
@@ -19,7 +19,8 @@ import * as AWS from '@boostercloud/framework-provider-aws'
 
 Booster.configure('development', (config: BoosterConfig): void => {
   config.appName = 'my-store'
-  config.provider = Provider([{
+  config.provider = Provider
+  config.rockets = [{
     packageName: '@boostercloud/rocket-static-sites-aws-infrastructure', 
     parameters: {
       bucketName: 'test-bucket-name', // Required
@@ -27,6 +28,6 @@ Booster.configure('development', (config: BoosterConfig): void => {
       indexFile: 'main.html', // File to render when users access the CLoudFormation URL. Defaults to index.html
       errorFile: 'error.html', // File to render when there's an error. Defaults to 404.html
     }
-  }])
+  }]
 })
 ```

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "lib": [
       "ES2019",
       "ES2020"


### PR DESCRIPTION
## Description

In this PR I've removed the `infrastructure` function from the `ProviderLibrary` type and replaced it by a `packageDescriptor` function that returns an object with the name and version of the provider library.

With this change, the `framework-provider-*-infrastructure` packages are independent of the `framework-provider-*` packages, hopefully avoiding dependency issues when the infrastructure packages were not defined in the user project's `package.json` file.

This is the first step towards the changes proposed in #517 to fully decouple the runtime from the infrastructure code.

## Changes
- [x] Removed the `infrastructure` function from `ProviderLibrary`.
- [x] Added a new `rockets` option to `BoosterConfig` to set up the rockets instead of passing them as a parameter to the provider library initialization (This changes slightly the way you configure rockets, see the doc changes)
- [x] Unified all dynamic requires in the `cli` module in a single `dynamicLoad` service.
- [ ] Checks that packages loaded dynamically are installed and that the version matches before trying to execute them
- [x] Fixed unit tests
- [ ] Fixed integration tests 

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 