### PR TITLE
Fix/booster 503 remove real file operations from cli unit tests

### DIFF
--- a/packages/cli/resources/commands/new_package.json
+++ b/packages/cli/resources/commands/new_package.json
@@ -1,0 +1,44 @@
+{
+  "name": "test-project",
+  "description": "",
+  "version": "0.1.0",
+  "author": "",
+  "dependencies": {
+    "@boostercloud/framework-core": "^0.9.3",
+    "@boostercloud/framework-types": "^0.9.3",
+    "@boostercloud/framework-provider-aws": "*",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@boostercloud/cli": "^0.9.3",
+    "rimraf": "^3.0.1",
+    "@typescript-eslint/eslint-plugin": "^2.18.0",
+    "@typescript-eslint/parser": "^2.18.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "mocha": "^7.0.1",
+    "nyc": "^15.0.0",
+    "prettier": "^1.19.1",
+    "typescript": "^3.9.3",
+    "ts-node": "^8.6.2",
+    "@types/node": "^13.5.1",
+    "@boostercloud/framework-provider-aws-infrastructure": "*"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "homepage": "",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "repository": "",
+  "scripts": {
+    "lint:check": "eslint --ext '.js,.ts' **/*.ts",
+    "lint:fix": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
+    "compile": "tsc -b tsconfig.json",
+    "deploy": "boost deploy",
+    "clean": "rimraf ./dist tsconfig.tsbuildinfo",
+    "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
+  },
+  "types": "lib/index.d.ts"
+}

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -88,6 +88,26 @@ describe('new', (): void => {
           'index.ts',
         ],
       }
+      const expectFilesAndDirectoriesCreated = (projectName: string) => {
+        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/commands`)
+        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/events`)
+        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/entities`)
+        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/read-models`)
+        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/config`)
+        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/common`)
+        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/event-handlers`)
+        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/scheduled-commands`)
+        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/.eslintignore`)
+        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/.eslintrc.js`)
+        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/.gitignore`)
+        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/package.json`)
+        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/tsconfig.json`)
+        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/tsconfig.eslint.json`)
+        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/.prettierrc.yaml`)
+        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/src/config/config.ts`)
+        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/src/index.ts`)
+      }
+
       const defaultProjectInitializerConfig = {
         projectName: projectName,
         description: '',
@@ -120,36 +140,23 @@ describe('new', (): void => {
         await new Project.default([projectName], {} as IConfig).run()
 
         expect(childProcessPromise.exec).to.have.been.calledWithMatch('git init && git add -A && git commit -m "Initial commit"')
-        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/commands`)
-        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/events`)
-        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/entities`)
-        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/read-models`)
-        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/config`)
-        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/common`)
-        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/event-handlers`)
-        expect(fs.mkdirs).to.have.been.calledWithMatch(`${projectName}/src/scheduled-commands`)
-        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/.eslintignore`)
-        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/.eslintrc.js`)
-        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/.gitignore`)
-        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/package.json`)
-        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/tsconfig.json`)
-        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/tsconfig.eslint.json`)
-        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/.prettierrc.yaml`)
-        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/src/config/config.ts`)
-        expect(fs.outputFile).to.have.been.calledWithMatch(`${projectName}/src/index.ts`)
+        //expect(childProcessPromise.exec).to.have.been.calledWithMatch('npx yarn install')
+        expectFilesAndDirectoriesCreated(projectName)
       })
 
       it('generates all required files and folders without installing dependencies', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
         const installDependenciesSpy = spy(ProjectInitializer, 'installDependencies')
-        expect(fs.existsSync(projectDirectory)).to.be.false
+        replace(fs,'mkdirs', fake.resolves({}))
+        replace(fs,'outputFile', fake.resolves({}))
+        replace(childProcessPromise, 'exec', fake.resolves({}))
 
         await new Project.default([projectName, '--skipInstall'], {} as IConfig).run()
 
-        expect(fs.existsSync(projectDirectory)).to.be.true
         expect(installDependenciesSpy).to.have.not.been.calledOnce
-        expect(fs.readdirSync(projectDirectory)).to.have.all.members(expectedDirectoryContent.rootPath)
-        expect(fs.readdirSync(`${projectDirectory}/src`)).to.have.all.members(expectedDirectoryContent.src)
+        expect(childProcessPromise.exec).to.have.not.been.calledWithMatch('npx yarn install')
+        expect(childProcessPromise.exec).to.have.been.calledWithMatch('git init && git add -A && git commit -m "Initial commit"')
+        expectFilesAndDirectoriesCreated(projectName)
       })
 
       it('generates project with default parameters when using --default flag', async () => {

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -61,7 +61,6 @@ describe('new', (): void => {
   describe('project', () => {
     context('file generation', () => {
       const projectName = 'test-project'
-      const projectDirectory = `./${projectName}`
       const defaultProvider = '@boostercloud/framework-provider-aws'
 
       const expectFilesAndDirectoriesCreated = (projectName: string) => {
@@ -99,19 +98,19 @@ describe('new', (): void => {
         skipGit: false,
       } as ProjectInitializerConfig
 
+      beforeEach(() => {
+        replace(fs,'mkdirs', fake.resolves({}))
+        replace(fs,'outputFile', fake.resolves({}))
+        replace(childProcessPromise, 'exec', fake.resolves({}))
+      })
+
       afterEach(() => {
-        if (fs.existsSync(projectDirectory)) {
-          fs.rmdirSync(projectDirectory, { recursive: true })
-        }
         restore()
       })
 
       it('generates all required files and folders', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
         replace(ProjectInitializer, 'installDependencies', fake.returns({}))
-        replace(fs,'mkdirs', fake.resolves({}))
-        replace(fs,'outputFile', fake.resolves({}))
-        replace(childProcessPromise, 'exec', fake.resolves({}))
 
         await new Project.default([projectName], {} as IConfig).run()
 
@@ -123,9 +122,6 @@ describe('new', (): void => {
       it('generates all required files and folders without installing dependencies', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
         const installDependenciesSpy = spy(ProjectInitializer, 'installDependencies')
-        replace(fs,'mkdirs', fake.resolves({}))
-        replace(fs,'outputFile', fake.resolves({}))
-        replace(childProcessPromise, 'exec', fake.resolves({}))
 
         await new Project.default([projectName, '--skipInstall'], {} as IConfig).run()
 
@@ -138,10 +134,7 @@ describe('new', (): void => {
       it('generates project with default parameters when using --default flag', async () => {
         const parseConfigSpy = spy(Project, 'parseConfig')
         replace(ProjectInitializer, 'installDependencies', fake.returns({}))
-        replace(fs,'mkdirs', fake.resolves({}))
-        replace(fs,'outputFile', fake.resolves({}))
-        replace(childProcessPromise, 'exec', fake.resolves({}))
-        
+
         await new Project.default([projectName, '--default'], { version: '0.5.1' } as IConfig).run()
 
         expectFilesAndDirectoriesCreated(projectName)
@@ -158,9 +151,6 @@ describe('new', (): void => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
         replace(ProjectInitializer, 'installDependencies', fake.returns({}))
         const initializeGitSpy = spy(ProjectInitializer, 'initializeGit')
-        replace(fs,'mkdirs', fake.resolves({}))
-        replace(fs,'outputFile', fake.resolves({}))
-        replace(childProcessPromise, 'exec', fake.resolves({}))
 
         await new Project.default([projectName], {} as IConfig).run()
 
@@ -173,9 +163,6 @@ describe('new', (): void => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
         replace(ProjectInitializer, 'installDependencies', fake.returns({}))
         const initializeGitSpy = spy(ProjectInitializer, 'initializeGit')
-        replace(fs,'mkdirs', fake.resolves({}))
-        replace(fs,'outputFile', fake.resolves({}))
-        replace(childProcessPromise, 'exec', fake.resolves({}))
 
         await new Project.default([projectName, '--skipGit'], {} as IConfig).run()
 

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -1,11 +1,9 @@
 import * as ProjectChecker from '../../src/services/project-checker'
 import { restore, replace, fake, stub, spy } from 'sinon'
-import ErrnoException = NodeJS.ErrnoException
 import { ProjectInitializerConfig } from '../../src/services/project-initializer'
 import ReadModel from '../../src/commands/new/read-model'
 import { templates } from '../../src/templates'
 import Mustache = require('mustache')
-import * as fs_simple from 'fs'
 import * as fs from 'fs-extra'
 import * as childProcessPromise from 'child-process-promise'
 import { IConfig } from '@oclif/config'
@@ -16,19 +14,20 @@ import * as ProjectInitializer from '../../src/services/project-initializer'
 describe('new', (): void => {
   describe('Read model', () => {
     const readModel = 'example-read-model'
-    const readModelsRoot = './src/read-models/'
+    const readModelsRoot = 'src/read-models/'
     const readModelPath = `${readModelsRoot}${readModel}.ts`
+    
     afterEach(() => {
-      if (fs.existsSync(readModelPath)) {
-        fs_simple.rmdir(readModelsRoot, { recursive: true }, (err: ErrnoException | null) => console.log(err))
-      }
       restore()
     })
+    
     context('projections', () => {
       it('renders according to the template', async () => {
         stub(ProjectChecker, 'checkItIsABoosterProject').returnsThis()
+        replace(fs,'outputFile', fake.resolves({}))
+
         await new ReadModel([readModel, '--fields', 'title:string', '--projects', 'Post:id'], {} as IConfig).run()
-        const readModelFileContent = fs.readFileSync(readModelPath).toString()
+        
         const renderedReadModel = Mustache.render(templates.readModel, {
           imports: [
             {
@@ -54,13 +53,14 @@ describe('new', (): void => {
           ],
         })
 
-        expect(readModelFileContent).to.be.equal(renderedReadModel)
+        expect(fs.outputFile).to.have.been.calledWithMatch(readModelPath,renderedReadModel)
       })
     })
   })
+  
   describe('project', () => {
     context('file generation', () => {
-      const projectName = 'test-project'
+      const projectName = 'test-project'  
       const defaultProvider = '@boostercloud/framework-provider-aws'
 
       const expectFilesAndDirectoriesCreated = (projectName: string) => {


### PR DESCRIPTION
## Description
**CLI new** unit tests have been refactored to not write files on the file system, with the aim of run the test faster and without collateral effects. I mocked some **fs** methods and **init** function to avoid file creation during tests.

## Changes
- the test file has been refactored
- I added the **resources** folder to store assets used in our tests

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
## Additional information
