### PR TITLE
Reverted changes to prune devDependencies using `yarn install --production`

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -6,16 +6,15 @@ import { Script } from '../common/script'
 import Brand from '../common/brand'
 import { logger } from '../services/logger'
 import { currentEnvironment, initializeEnvironment } from '../services/environment'
-import { installAllDependencies } from '../services/dependencies'
+import { installDependencies } from '../services/dependencies'
 
 const runTasks = async (
-  skipRestoreDependencies: boolean,
   compileAndLoad: Promise<BoosterConfig>,
   deployer: (config: BoosterConfig, logger: Logger) => Promise<void>
 ): Promise<void> =>
   Script.init(`boost ${Brand.dangerize('deploy')} [${currentEnvironment()}] 🚀`, compileAndLoad)
+    .step('Installing dependencies', async () => await installDependencies())
     .step('Deploying', (config) => deployer(config, logger))
-    .optionalStep(skipRestoreDependencies, 'Reinstalling dev dependencies', async () => await installAllDependencies())
     .info('Deployment complete!')
     .done()
 
@@ -28,21 +27,13 @@ export default class Deploy extends Command {
       char: 'e',
       description: 'environment configuration to run',
     }),
-    skipRestoreDependencies: flags.boolean({
-      char: 's',
-      description: 'skips restoring dependencies after deployment',
-    }),
   }
 
   public async run(): Promise<void> {
     const { flags } = this.parse(Deploy)
 
     if (initializeEnvironment(logger, flags.environment)) {
-      await runTasks(
-        flags.skipRestoreDependencies,
-        compileProjectAndLoadConfig({ production: true }),
-        deployToCloudProvider
-      )
+      await runTasks(compileProjectAndLoadConfig(), deployToCloudProvider)
     }
   }
 }

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -5,12 +5,12 @@ import {
   generateConfigFiles,
   generateRootDirectory,
   initializeGit,
-  installDependencies,
   ProjectInitializerConfig,
 } from '../../services/project-initializer'
 import Prompter from '../../services/user-prompt'
 import { assertNameIsCorrect } from '../../services/provider-service'
 import { Provider } from '../../common/provider'
+import { installDependencies } from '../../services/dependencies'
 
 export default class Project extends Command {
   public static description = 'create a new project from scratch'
@@ -81,7 +81,9 @@ const run = async (flags: Partial<ProjectInitializerConfig>, boosterVersion: str
   Script.init(`boost ${Brand.energize('new')} 🚧`, parseConfig(new Prompter(), flags, boosterVersion))
     .step('Creating project root', generateRootDirectory)
     .step('Generating config files', generateConfigFiles)
-    .optionalStep(Boolean(flags.skipInstall), 'Installing dependencies', installDependencies)
+    .optionalStep(Boolean(flags.skipInstall), 'Installing dependencies', (config) =>
+      installDependencies(config.projectName)
+    )
     .optionalStep(Boolean(flags.skipGit), 'Initializing git repository', initializeGit)
     .info('Project generated!')
     .done()

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -4,18 +4,10 @@ import { exec } from 'child-process-promise'
 import { wrapExecError } from '../common/errors'
 import { checkItIsABoosterProject } from './project-checker'
 import { currentEnvironment } from './environment'
-import { pruneDevDependencies } from './dependencies'
 
-type CompileAndLoadOptions = {
-  production: boolean
-}
-
-export async function compileProjectAndLoadConfig(opts?: CompileAndLoadOptions): Promise<BoosterConfig> {
+export async function compileProjectAndLoadConfig(): Promise<BoosterConfig> {
   const userProjectPath = process.cwd()
   await checkItIsABoosterProject()
-  if (opts?.production) {
-    await pruneDevDependencies()
-  }
   await compileProject(userProjectPath)
   return readProjectConfig(userProjectPath)
 }

--- a/packages/cli/src/services/dependencies.ts
+++ b/packages/cli/src/services/dependencies.ts
@@ -1,15 +1,7 @@
 import { exec } from 'child-process-promise'
 import { wrapExecError } from '../common/errors'
 
-export async function pruneDevDependencies(): Promise<void> {
-  try {
-    await exec('npx yarn install --production --no-bin-links')
-  } catch (e) {
-    throw wrapExecError(e, 'Could not prune dev dependencies')
-  }
-}
-
-export async function installAllDependencies(path?: string): Promise<void> {
+export async function installDependencies(path?: string): Promise<void> {
   try {
     await exec('npx yarn install', { cwd: path ?? process.cwd() })
   } catch (e) {

--- a/packages/cli/src/services/project-initializer.ts
+++ b/packages/cli/src/services/project-initializer.ts
@@ -12,14 +12,9 @@ import * as configTs from '../templates/project/config-ts'
 import * as indexTs from '../templates/project/index-ts'
 import * as prettierRc from '../templates/project/prettierrc-yaml'
 import { wrapExecError } from '../common/errors'
-import { installAllDependencies } from './dependencies'
 
 export async function generateConfigFiles(config: ProjectInitializerConfig): Promise<void> {
   await Promise.all(filesToGenerate.map(renderToFile(config)))
-}
-
-export async function installDependencies(config: ProjectInitializerConfig): Promise<void> {
-  return installAllDependencies(projectDir(config))
 }
 
 export async function generateRootDirectory(config: ProjectInitializerConfig): Promise<void> {

--- a/packages/cli/src/templates/project/package-json.ts
+++ b/packages/cli/src/templates/project/package-json.ts
@@ -9,11 +9,9 @@ export const template = `{
   "dependencies": {
     "@boostercloud/framework-core": "^${VERSION}",
     "@boostercloud/framework-types": "^${VERSION}",
-    "{{{providerPackageName}}}": "*",
-    "tslib": "^2.0.3"
+    "{{{providerPackageName}}}": "*"
   },
   "devDependencies": {
-    "@boostercloud/cli": "^${VERSION}",
     "rimraf": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -23,89 +23,60 @@ describe('deploy', () => {
   describe('runTasks function', () => {
     context('when an unexpected problem happens', () => {
       fancy.stdout().it('fails gracefully showing the error message', async () => {
+        replace(dependencies, 'installDependencies', fake())
         const msg = 'weird exception'
         const fakeLoader = Promise.reject(new Error(msg))
         const fakeDeployer = fake()
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks(false, fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })
 
     context('when index.ts structure is not correct', () => {
       fancy.stdout().it('fails gracefully', async () => {
+        replace(dependencies, 'installDependencies', fake())
         const msg = 'An error when loading project'
         const fakeLoader = Promise.reject(new Error(msg))
         const fakeDeployer = fake()
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks(false, fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })
 
-    context('when the `skipRestoreDependencies` flag is set to "false"', () => {
-      fancy.stdout().it('reinstalls dev dependencies after deploy', async (ctx) => {
-        const fakeReinstallDependencies = fake()
-        replace(dependencies, 'installAllDependencies', fakeReinstallDependencies)
+    fancy.stdout().it('installs dependencies before deploy', async (ctx) => {
+      const fakeInstallDependencies = fake()
+      replace(dependencies, 'installDependencies', fakeInstallDependencies)
 
-        const fakeProvider = {} as ProviderLibrary
+      const fakeProvider = {} as ProviderLibrary
 
-        const fakeLoader = fake.resolves({
-          provider: fakeProvider,
-          appName: 'fake app',
-          region: 'tunte',
-          entities: {},
-        })
-
-        const fakeDeployer = fake((_config: unknown, logger: Logger) => {
-          logger.info('this is a progress update')
-        })
-
-        replace(environment, 'currentEnvironment', fake.returns('test-env'))
-
-        await runTasks(false, fakeLoader, fakeDeployer)
-
-        expect(fakeReinstallDependencies).to.have.been.called
-
-        expect(ctx.stdout).to.include('Deployment complete')
-        expect(fakeDeployer).to.have.been.calledOnce
+      const fakeLoader = fake.resolves({
+        provider: fakeProvider,
+        appName: 'fake app',
+        region: 'tunte',
+        entities: {},
       })
-    })
 
-    context('when `skipRestoreDependencies` flag is set to "true"', () => {
-      fancy.stdout().it('does not reinstall dependencies after deployment', async (ctx) => {
-        const fakeReinstallDependencies = fake()
-        replace(dependencies, 'installAllDependencies', fakeReinstallDependencies)
-
-        const fakeProvider = {} as ProviderLibrary
-
-        const fakeLoader = fake.resolves({
-          provider: fakeProvider,
-          appName: 'fake app',
-          region: 'tunte',
-          entities: {},
-        })
-
-        const fakeDeployer = fake((_config: unknown, logger: Logger) => {
-          logger.info('this is a progress update')
-        })
-
-        replace(environment, 'currentEnvironment', fake.returns('test-env'))
-
-        await runTasks(true, fakeLoader, fakeDeployer)
-
-        expect(fakeReinstallDependencies).not.to.have.been.called
-
-        expect(ctx.stdout).to.include('Deployment complete')
-        expect(fakeDeployer).to.have.been.calledOnce
+      const fakeDeployer = fake((_config: unknown, logger: Logger) => {
+        logger.info('this is a progress update')
       })
+
+      replace(environment, 'currentEnvironment', fake.returns('test-env'))
+
+      await runTasks(fakeLoader, fakeDeployer)
+
+      expect(fakeInstallDependencies).to.have.been.called
+
+      expect(ctx.stdout).to.include('Deployment complete')
+      expect(fakeDeployer).to.have.been.calledOnce
     })
 
     context('when there is a valid index.ts', () => {
       fancy.stdout().it('Starts deployment', async (ctx) => {
-        replace(dependencies, 'installAllDependencies', fake())
+        replace(dependencies, 'installDependencies', fake())
 
         const fakeProvider = {} as ProviderLibrary
 
@@ -122,7 +93,7 @@ describe('deploy', () => {
 
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await runTasks(false, fakeLoader, fakeDeployer)
+        await runTasks(fakeLoader, fakeDeployer)
 
         expect(ctx.stdout).to.include('Deployment complete')
 

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -10,6 +10,7 @@ import { IConfig } from '@oclif/config'
 import { expect } from '../expect'
 import * as Project from '../../src/commands/new/project'
 import * as ProjectInitializer from '../../src/services/project-initializer'
+import * as dependencies from '../../src/services/dependencies'
 
 describe('new', (): void => {
   describe('Read model', () => {
@@ -108,7 +109,7 @@ describe('new', (): void => {
 
       it('generates all required files and folders', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
-        replace(ProjectInitializer, 'installDependencies', fake.returns({}))
+        replace(dependencies, 'installDependencies', fake.returns({}))
         expect(fs.existsSync(projectDirectory)).to.be.false
 
         await new Project.default([projectName], {} as IConfig).run()
@@ -120,7 +121,7 @@ describe('new', (): void => {
 
       it('generates all required files and folders without installing dependencies', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
-        const installDependenciesSpy = spy(ProjectInitializer, 'installDependencies')
+        const installDependenciesSpy = spy(dependencies, 'installDependencies')
         expect(fs.existsSync(projectDirectory)).to.be.false
 
         await new Project.default([projectName, '--skipInstall'], {} as IConfig).run()
@@ -133,7 +134,7 @@ describe('new', (): void => {
 
       it('generates project with default parameters when using --default flag', async () => {
         const parseConfigSpy = spy(Project, 'parseConfig')
-        replace(ProjectInitializer, 'installDependencies', fake.returns({}))
+        replace(dependencies, 'installDependencies', fake.returns({}))
         expect(fs.existsSync(projectDirectory)).to.be.false
 
         await new Project.default([projectName, '--default'], { version: '0.5.1' } as IConfig).run()
@@ -157,7 +158,7 @@ describe('new', (): void => {
 
       it('initializes git repository', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
-        replace(ProjectInitializer, 'installDependencies', fake.returns({}))
+        replace(dependencies, 'installDependencies', fake.returns({}))
         const initializeGitSpy = spy(ProjectInitializer, 'initializeGit')
 
         await new Project.default([projectName], {} as IConfig).run()
@@ -169,7 +170,7 @@ describe('new', (): void => {
 
       it('skips git repository initialization', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
-        replace(ProjectInitializer, 'installDependencies', fake.returns({}))
+        replace(dependencies, 'installDependencies', fake.returns({}))
         const initializeGitSpy = spy(ProjectInitializer, 'initializeGit')
 
         await new Project.default([projectName, '--skipGit'], {} as IConfig).run()

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -3,7 +3,6 @@ import * as projectChecker from '../../src/services/project-checker'
 import { BoosterConfig } from '@boostercloud/framework-types'
 import { expect } from '../expect'
 import * as environment from '../../src/services/environment'
-import * as dependencies from '../../src/services/dependencies'
 
 const rewire = require('rewire')
 const configService = rewire('../../src/services/config-service')
@@ -38,71 +37,11 @@ describe('configService', () => {
       ]
 
       replace(environment, 'currentEnvironment', fake.returns('test'))
-      replace(dependencies, 'pruneDevDependencies', fake())
 
       await expect(configService.compileProjectAndLoadConfig()).to.eventually.become(config)
-      expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly()
-      expect(dependencies.pruneDevDependencies).not.to.have.been.called
+      expect(checkItIsABoosterProject).to.have.been.calledOnce
 
       rewires.forEach((fn) => fn())
-    })
-
-    context('when the production option is set to `false`', () => {
-      it('does not prune devDependencies', async () => {
-        const config = new BoosterConfig('test')
-
-        const rewires = [
-          configService.__set__('compileProject', fake()),
-          configService.__set__(
-            'loadUserProject',
-            fake.returns({
-              Booster: {
-                config: config,
-                configuredEnvironments: new Set(['test']),
-                configureCurrentEnv: fake.yields(config),
-              },
-            })
-          ),
-        ]
-
-        replace(environment, 'currentEnvironment', fake.returns('test'))
-        replace(dependencies, 'pruneDevDependencies', fake())
-
-        await expect(configService.compileProjectAndLoadConfig({ prduction: true })).to.eventually.become(config)
-
-        expect(dependencies.pruneDevDependencies).not.to.have.been.called
-
-        rewires.forEach((fn) => fn())
-      })
-    })
-
-    context('when the production option is set to `true`', () => {
-      it('prunes devDependencies', async () => {
-        const config = new BoosterConfig('test')
-
-        const rewires = [
-          configService.__set__('compileProject', fake()),
-          configService.__set__(
-            'loadUserProject',
-            fake.returns({
-              Booster: {
-                config: config,
-                configuredEnvironments: new Set(['test']),
-                configureCurrentEnv: fake.yields(config),
-              },
-            })
-          ),
-        ]
-
-        replace(environment, 'currentEnvironment', fake.returns('test'))
-        replace(dependencies, 'pruneDevDependencies', fake())
-
-        await expect(configService.compileProjectAndLoadConfig({ production: true })).to.eventually.become(config)
-
-        expect(dependencies.pruneDevDependencies).to.have.been.calledOnce
-
-        rewires.forEach((fn) => fn())
-      })
     })
 
     it('throws the right error when there are not configured environments', async () => {

--- a/packages/cli/test/services/dependencies.test.ts
+++ b/packages/cli/test/services/dependencies.test.ts
@@ -1,6 +1,6 @@
 import * as childProcessPromise from 'child-process-promise'
 import { fake, replace, restore } from 'sinon'
-import { installAllDependencies, pruneDevDependencies } from '../../src/services/dependencies'
+import { installDependencies } from '../../src/services/dependencies'
 import { expect } from '../expect'
 
 describe('dependencies service', () => {
@@ -8,30 +8,12 @@ describe('dependencies service', () => {
     restore()
   })
 
-  describe('pruneDevDependencies', () => {
-    it('installs dependencies in production mode', async () => {
-      replace(childProcessPromise, 'exec', fake.resolves({}))
-
-      await expect(pruneDevDependencies()).to.eventually.be.fulfilled
-
-      expect(childProcessPromise.exec).to.have.been.calledWithMatch('npx yarn install --production --no-bin-links')
-    })
-
-    it('wraps the exec error', async () => {
-      const error = new Error('something wrong happened')
-
-      replace(childProcessPromise, 'exec', fake.rejects(error))
-
-      await expect(pruneDevDependencies()).to.eventually.be.rejectedWith(/Could not prune dev dependencies/)
-    })
-  })
-
-  describe('installAllDependencies', () => {
+  describe('installDependencies', () => {
     context('without passing a path', () => {
       it('installs dependencies in dev mode in the current directory', async () => {
         replace(childProcessPromise, 'exec', fake.resolves({}))
 
-        await expect(installAllDependencies()).to.eventually.be.fulfilled
+        await expect(installDependencies()).to.eventually.be.fulfilled
 
         expect(childProcessPromise.exec).to.have.been.calledWithMatch('npx yarn install', { cwd: process.cwd() })
       })
@@ -41,7 +23,7 @@ describe('dependencies service', () => {
       it('installs dependencies in dev mode in the passed path', async () => {
         replace(childProcessPromise, 'exec', fake.resolves({}))
 
-        await expect(installAllDependencies('somewhere')).to.eventually.be.fulfilled
+        await expect(installDependencies('somewhere')).to.eventually.be.fulfilled
 
         expect(childProcessPromise.exec).to.have.been.calledWithMatch('npx yarn install', { cwd: 'somewhere' })
       })
@@ -52,7 +34,7 @@ describe('dependencies service', () => {
 
       replace(childProcessPromise, 'exec', fake.rejects(error))
 
-      await expect(installAllDependencies()).to.eventually.be.rejectedWith(/Could not install dependencies/)
+      await expect(installDependencies()).to.eventually.be.rejectedWith(/Could not install dependencies/)
     })
   })
 })

--- a/packages/framework-integration-tests/integration/cli/cli.command.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.command.integration.ts
@@ -15,7 +15,7 @@ describe('Command', () => {
   let commandSandboxDir: string
 
   before(async () => {
-    commandSandboxDir = createSandboxProject('command')
+    commandSandboxDir = await createSandboxProject('command')
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.entity.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.entity.integration.ts
@@ -16,7 +16,7 @@ describe('Entity', () => {
   let entitySandboxDir: string
 
   before(async () => {
-    entitySandboxDir = createSandboxProject('entity')
+    entitySandboxDir = await createSandboxProject('entity')
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.event-handler.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.event-handler.integration.ts
@@ -7,7 +7,7 @@ describe('Event handler', () => {
   let eventHandlerSandboxDir: string
 
   before(async () => {
-    eventHandlerSandboxDir = createSandboxProject('event-handler')
+    eventHandlerSandboxDir = await createSandboxProject('event-handler')
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.event.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.event.integration.ts
@@ -15,7 +15,7 @@ describe('Event', () => {
   let eventSandboxDir: string
 
   before(async () => {
-    eventSandboxDir = createSandboxProject('event')
+    eventSandboxDir = await createSandboxProject('event')
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -219,7 +219,6 @@ describe('Project', () => {
     const cartDemoPackageJsonObject = JSON.parse(cartDemoPackageJsonContent)
     expect(cartDemoPackageJsonObject['dependencies']['@boostercloud/framework-core']).to.equal(`^${BOOSTER_VERSION}`)
     expect(cartDemoPackageJsonObject['dependencies']['@boostercloud/framework-types']).to.equal(`^${BOOSTER_VERSION}`)
-    expect(cartDemoPackageJsonObject['devDependencies']['@boostercloud/cli']).to.equal(`^${BOOSTER_VERSION}`)
 
     const expectedCartDemoTsConfigEslint = loadFixture('cart-demo/tsconfig.eslint.json')
     const cartDemoTsConfigEslintContent = fileContents('tsconfig.eslint.json')

--- a/packages/framework-integration-tests/integration/cli/cli.readmodel.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.readmodel.integration.ts
@@ -16,7 +16,7 @@ describe('Read model', () => {
   let readModelSandboxDir: string
 
   before(async () => {
-    readModelSandboxDir = createSandboxProject('read-model')
+    readModelSandboxDir = await createSandboxProject('read-model')
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.scheduled-command.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.scheduled-command.integration.ts
@@ -7,7 +7,7 @@ describe('Scheduled Command', () => {
   let scheduledCommandSandboxDir: string
 
   before(async () => {
-    scheduledCommandSandboxDir = createSandboxProject('scheduled-command')
+    scheduledCommandSandboxDir = await createSandboxProject('scheduled-command')
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.type.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.type.integration.ts
@@ -7,7 +7,7 @@ describe('Type', () => {
   let typeSandboxDir: string
 
   before(async () => {
-    typeSandboxDir = createSandboxProject('type')
+    typeSandboxDir = await createSandboxProject('type')
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/expect.ts
+++ b/packages/framework-integration-tests/integration/expect.ts
@@ -1,0 +1,6 @@
+import * as chai from 'chai'
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+
+export const expect = chai.expect

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/package.json
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/package.json
@@ -9,7 +9,6 @@
     "@boostercloud/framework-provider-aws": "whatever"
   },
   "devDependencies": {
-    "@boostercloud/cli": "whatever",
     "rimraf": "whatever",
     "@typescript-eslint/eslint-plugin": "whatever",
     "@typescript-eslint/parser": "whatever",

--- a/packages/framework-integration-tests/integration/helper/depsHelper.ts
+++ b/packages/framework-integration-tests/integration/helper/depsHelper.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child-process-promise'
 import * as path from 'path'
+import { runCommand } from './runCommand'
 
 function deBoosterize(packageName: string, projectPath: string): string {
   const folderName = packageName.replace('@boostercloud/', '')
@@ -27,4 +28,8 @@ export async function symLinkBoosterDependencies(projectPath: string): Promise<v
 
 export async function forceLernaRebuild(): Promise<void> {
   await exec('lerna clean --yes && lerna bootstrap && lerna run clean && lerna run compile')
+}
+
+export async function installBoosterPackage(packageName: string): Promise<void> {
+  await runCommand(path.join('..', packageName), 'npx yarn global add file:$PWD')
 }

--- a/packages/framework-integration-tests/integration/helper/depsHelper.ts
+++ b/packages/framework-integration-tests/integration/helper/depsHelper.ts
@@ -12,13 +12,13 @@ export async function symLinkBoosterDependencies(projectPath: string): Promise<v
   // by the versions under development.
   for (const packageName in packageJSON.dependencies) {
     if (/@boostercloud/.test(packageName)) {
-      await exec(`npx yarn add link:${deBoosterize(packageName, projectPath)}`, { cwd: projectPath })
+      await exec(`npx yarn add file:${deBoosterize(packageName, projectPath)}`, { cwd: projectPath })
     }
   }
 
   for (const packageName in packageJSON.devDependencies) {
     if (/@boostercloud/.test(packageName)) {
-      await exec(`npx yarn add link:${deBoosterize(packageName, projectPath)}`, {
+      await exec(`npx yarn add file:${deBoosterize(packageName, projectPath)}`, {
         cwd: projectPath,
       })
     }

--- a/packages/framework-integration-tests/integration/helper/fileHelper.ts
+++ b/packages/framework-integration-tests/integration/helper/fileHelper.ts
@@ -9,6 +9,7 @@ import {
   copyFileSync,
 } from 'fs'
 import * as path from 'path'
+import { symLinkBoosterDependencies } from './depsHelper'
 
 export const loadFixture = (fixturePath: string, replacements?: Array<Array<string>>): string => {
   const template = readFileContent(`integration/fixtures/${fixturePath}`)
@@ -61,7 +62,7 @@ const copyFolder = (origin: string, destiny: string): void => {
 
 const sandboxPathFor = (sandboxName: string): string => sandboxName + '-integration-sandbox' // Add the suffix to make sure this folder is gitignored
 
-export const createSandboxProject = (sandboxName: string): string => {
+export const createSandboxProject = async (sandboxName: string): Promise<string> => {
   const sandboxPath = sandboxPathFor(sandboxName)
 
   rmdirSync(sandboxPath, { recursive: true })
@@ -70,6 +71,11 @@ export const createSandboxProject = (sandboxName: string): string => {
 
   const projectFiles = ['.eslintignore', 'package.json', 'tsconfig.eslint.json', 'tsconfig.json']
   projectFiles.forEach((file: string) => copyFileSync(file, path.join(sandboxPath, file)))
+
+  copyFileSync(path.join('..', '..', 'yarn.lock'), path.join(sandboxPath, 'yarn.lock'))
+
+  // Make sure all booster dependencies come from the versions under development
+  await symLinkBoosterDependencies(sandboxPath)
 
   return sandboxPath
 }

--- a/packages/framework-integration-tests/integration/providers/aws/deploy.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/deploy.ts
@@ -1,15 +1,18 @@
 import * as path from 'path'
+import { installBoosterPackage } from '../../helper/depsHelper'
 import { runCommand } from '../../helper/runCommand'
 
 // Path to the CLI binary compiled by lerna
 const cliBinaryPath = path.join('..', '..', 'cli', 'bin', 'run')
 
 export async function deploy(projectPath: string, environmentName = 'production'): Promise<void> {
+  await installBoosterPackage('framework-provider-aws-infrastructure')
   // Production dependencies are installed by the deploy command
   await runCommand(projectPath, `${cliBinaryPath} deploy -e ${environmentName}`)
 }
 
 export async function nuke(projectPath: string, environmentName = 'production'): Promise<void> {
+  await installBoosterPackage('framework-provider-aws-infrastructure')
   // Dependencies should be installed before running the nuke command
   await runCommand(projectPath, 'npx yarn install')
   await runCommand(projectPath, `${cliBinaryPath} nuke -e ${environmentName} --force`)

--- a/packages/framework-integration-tests/integration/providers/aws/deployment/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/deployment/setup.ts
@@ -5,7 +5,7 @@ import { createSandboxProject } from '../../../helper/fileHelper'
 
 before(async () => {
   await setEnv()
-  const sandboxedProject = createSandboxProject('deploy')
+  const sandboxedProject = await createSandboxProject('deploy')
   await checkConfigAnd(deploy.bind(null, sandboxedProject))
   console.log('Waiting 30 seconds after deployment to let the stack finish its initialization...')
   await sleep(30000)

--- a/packages/framework-integration-tests/integration/providers/aws/functionality/auth.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/functionality/auth.integration.ts
@@ -16,14 +16,11 @@ import {
   graphQLClient,
 } from '../utils'
 import gql from 'graphql-tag'
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from '../../../expect'
 import { random, internet, finance, lorem, phone } from 'faker'
 import fetch from 'cross-fetch'
 import { ApolloClient } from 'apollo-client'
 import { NormalizedCacheObject } from 'apollo-cache-inmemory'
-
-chai.use(require('chai-as-promised'))
 
 describe('With the auth API', () => {
   let mockProductId: string
@@ -39,11 +36,11 @@ describe('With the auth API', () => {
   context('an internet rando', () => {
     let client: DisconnectableApolloClient
 
-    before(async () => {
+    beforeEach(async () => {
       client = await graphQLClientWithSubscriptions()
     })
 
-    after(() => {
+    afterEach(() => {
       client.disconnect()
     })
 

--- a/packages/framework-integration-tests/integration/providers/aws/functionality/cors.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/functionality/cors.integration.ts
@@ -1,7 +1,7 @@
 import { authClientID, createPassword, signInURL, signOutURL, signUpURL } from '../utils'
 import { internet } from 'faker'
 import fetch from 'cross-fetch'
-import { expect } from '@boostercloud/framework-provider-aws/test/expect'
+import { expect } from '../../../expect'
 
 describe('Given the Authentication API', () => {
   let clientId: string
@@ -84,7 +84,6 @@ describe('Given the Authentication API', () => {
       })
 
       context('POST', () => {
-
         it('should return the Access-Control-Allow-Origin header for 200 responses', async () => {
           const response = await fetch(signInUrl, {
             method: 'POST',

--- a/packages/framework-integration-tests/integration/providers/aws/nuke/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/nuke/setup.ts
@@ -4,7 +4,7 @@ import { setEnv, checkConfigAnd } from '../utils'
 
 before(async () => {
   await setEnv()
-  const sandboxedProject = createSandboxProject('deploy')
+  const sandboxedProject = await createSandboxProject('deploy')
   await checkConfigAnd(nuke.bind(null, sandboxedProject))
   removeSandboxProject('deploy')
 })

--- a/packages/framework-integration-tests/integration/providers/local/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/local/setup.ts
@@ -2,7 +2,7 @@ import { start } from './utils'
 import { sleep } from '../../helper/sleep'
 import { ChildProcess } from 'child_process'
 import { createSandboxProject, removeFolders } from '../../helper/fileHelper'
-import { symLinkBoosterDependencies } from '../../helper/depsHelper'
+import { installBoosterPackage } from '../../helper/depsHelper'
 import { sandboxName } from './constants'
 import { runCommand } from '../../helper/runCommand'
 
@@ -10,14 +10,14 @@ let serverProcess: ChildProcess
 let sandboxPath: string
 
 before(async () => {
+  console.log('Installing the infrastructure package in the global scope')
+  await installBoosterPackage('framework-provider-local-infrastructure')
+
   console.log('preparing sandboxed project...')
-  sandboxPath = createSandboxProject(sandboxName)
+  sandboxPath = await createSandboxProject(sandboxName)
 
   console.log('installing dependencies...')
   await runCommand(sandboxPath, 'npx yarn install')
-
-  console.log('symlinking booster dependencies...')
-  await symLinkBoosterDependencies(sandboxPath)
 
   console.log(`starting local server in ${sandboxPath}...`)
   serverProcess = start('local', sandboxPath)

--- a/packages/framework-integration-tests/package.json
+++ b/packages/framework-integration-tests/package.json
@@ -13,8 +13,7 @@
     "@boostercloud/framework-core": "^0.9.3",
     "@boostercloud/framework-provider-aws": "^0.9.3",
     "@boostercloud/framework-provider-local": "^0.9.3",
-    "@boostercloud/framework-types": "^0.9.3",
-    "tslib": "^2.0.3"
+    "@boostercloud/framework-types": "^0.9.3"
   },
   "devDependencies": {
     "@boostercloud/framework-provider-aws-infrastructure": "^0.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10511,7 +10511,7 @@ tslib@^1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3:
+tslib@^2.0.0, tslib@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==


### PR DESCRIPTION
The deployment process was running `yarn install --production` under the hoods with the intention of removing the devDependencies, but it also unexpectedly removed secondary dependencies (dependencies of our dependencies), making lambdas fail once deployed, and forcing us to explicitly add missing dependencies as direct project dependencies.

By doing this, we're bringing back the lambda size issues, so we won't generate a version when merging this PR. Users are currently using a workaround that consists of adding the infra package as a project dependency and use yarn, which seems to produce smaller packages.

I'm currently working on PR #524 to change the way infrastructure dependency is loaded, which should allow us to remove the dependencies related to infrastructure from user projects.

This change's main goal is to make integration tests pass in currently blocked PRs.

## Checks
- [x] Project Builds
- [ ] Project passes tests and checks
- [x] Updated documentation accordingly