### PR TITLE
Feature/535 cli add validations duplicated fields and empty types

### DIFF
--- a/packages/cli/src/services/generator/target/parsing.ts
+++ b/packages/cli/src/services/generator/target/parsing.ts
@@ -27,7 +27,7 @@ export const parseProjections = (fields: Array<string>): Promise<HasProjections>
 
 async function parseProjection(rawProjection: string): Promise<Projection> {
   const splitInput = rawProjection.split(':')
-  if (splitInput.length != 2) {
+  if (splitInput.length != 2 || splitInput[0].length === 0 || splitInput[1].length === 0) {
     throw projectionParsingError(rawProjection)
   } else {
     return {

--- a/packages/cli/src/services/generator/target/parsing.ts
+++ b/packages/cli/src/services/generator/target/parsing.ts
@@ -12,7 +12,7 @@ export const parseFields = (fields: Array<string>): Promise<HasFields> =>
 
 function parseField(rawField: string): Promise<Field> {
   const splitInput = rawField.split(':')
-  if (splitInput.length != 2) {
+  if (splitInput.length != 2 || splitInput[0].length === 0 || splitInput[1].length === 0) {
     return Promise.reject(fieldParsingError(rawField))
   } else {
     return Promise.resolve({

--- a/packages/cli/test/commands/new/command.test.ts
+++ b/packages/cli/test/commands/new/command.test.ts
@@ -152,23 +152,20 @@ describe('new', (): void => {
         expect(exceptionMessage).to.contain('Error: Error parsing field title:. Fields must be in the form of <field name>:<field type>')
         expect(fs.outputFile).to.have.not.been.calledWithMatch(commandPath)
       })
-    })
 
-    xdescribe('should display an error but is not currently being validated', () => {
       it('with repeated fields', async () => {
-        await new Command([command, '--fields', 'title:string', 'title:string', 'quantity:number'], {} as IConfig).run()
-        const renderedCommand = Mustache.render(templates.command, {
-          imports: defaultCommandImports,
-          name: command,
-          fields: [
-            { name: 'title', type: 'string' },
-            { name: 'title', type: 'string' },
-            { name: 'quantity', type: 'number' },
-          ],
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(commandPath, renderedCommand)
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new Command([command, '--fields', 'title:string', 'title:string', 'quantity:number'], {} as IConfig).run()
+        } catch(e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain('Error: Error parsing field title. Fields cannot be duplicated')
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(commandPath)
       })
-
     })
   })
 })

--- a/packages/cli/test/commands/new/command.test.ts
+++ b/packages/cli/test/commands/new/command.test.ts
@@ -138,6 +138,20 @@ describe('new', (): void => {
           'Error: Error parsing field title. Fields must be in the form of <field name>:<field type>'
         )
       })
+
+      it('with no field type after :', async () => {
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new Command([command, '--fields', 'title:'], {} as IConfig).run()
+        } catch(e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain('Error: Error parsing field title:. Fields must be in the form of <field name>:<field type>')
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(commandPath)
+      })
     })
 
     xdescribe('should display an error but is not currently being validated', () => {
@@ -155,15 +169,6 @@ describe('new', (): void => {
         expect(fs.outputFile).to.have.been.calledWithMatch(commandPath, renderedCommand)
       })
 
-      it('with no field type after :', async () => {
-        await new Command([command, '--fields', 'title:'], {} as IConfig).run()
-        const renderedCommand = Mustache.render(templates.command, {
-          imports: defaultCommandImports,
-          name: command,
-          fields: [{ name: 'title', type: '' }],
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(commandPath, renderedCommand)
-      })
     })
   })
 })

--- a/packages/cli/test/commands/new/entity.test.ts
+++ b/packages/cli/test/commands/new/entity.test.ts
@@ -281,26 +281,23 @@ describe('new', (): void => {
         expect(fs.outputFile).to.have.not.been.calledWithMatch(entityPath)
       })
 
-    })
-
-    xdescribe('should display an error but is not currently being validated', () => {
       it('with repeated fields', async () => {
-        await new Entity(
-          [entityName, '--fields', 'title:string', 'title:string', 'quantity:number'],
-          {} as IConfig
-        ).run()
-        const renderedEntity = Mustache.render(templates.entity, {
-          imports: defaultEntityImports,
-          name: entityName,
-          fields: [
-            { name: 'title', type: 'string' },
-            { name: 'title', type: 'string' },
-            { name: 'quantity', type: 'number' },
-          ],
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(entityPath, renderedEntity)
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new Entity(
+            [entityName, '--fields', 'title:string', 'title:string', 'quantity:number'],
+            {} as IConfig
+          ).run()
+        } catch(e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain('Error: Error parsing field title. Fields cannot be duplicated')
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(entityPath)
       })
-
     })
+
   })
 })

--- a/packages/cli/test/commands/new/entity.test.ts
+++ b/packages/cli/test/commands/new/entity.test.ts
@@ -266,7 +266,23 @@ describe('new', (): void => {
           'Error: Error parsing field title. Fields must be in the form of <field name>:<field type>'
         )
       })
+
+      it('with no field type after :', async () => {
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new Entity([entityName, '--fields', 'title:'], {} as IConfig).run()
+        } catch(e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain('Error: Error parsing field title:. Fields must be in the form of <field name>:<field type>')
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(entityPath)
+      })
+
     })
+
     xdescribe('should display an error but is not currently being validated', () => {
       it('with repeated fields', async () => {
         await new Entity(
@@ -285,15 +301,6 @@ describe('new', (): void => {
         expect(fs.outputFile).to.have.been.calledWithMatch(entityPath, renderedEntity)
       })
 
-      it('with no field type after :', async () => {
-        await new Entity([entityName, '--fields', 'title:'], {} as IConfig).run()
-        const renderedEntity = Mustache.render(templates.entity, {
-          imports: defaultEntityImports,
-          name: entityName,
-          fields: [{ name: 'title', type: '' }],
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(entityPath, renderedEntity)
-      })
     })
   })
 })

--- a/packages/cli/test/commands/new/event.test.ts
+++ b/packages/cli/test/commands/new/event.test.ts
@@ -132,18 +132,20 @@ describe('new', (): void => {
         expect(fs.outputFile).to.have.not.been.calledWithMatch(eventPath)
       })
       
-    })
-
-    describe('should display an error but is not currently being validated', () => {
       it('with repeated fields', async () => {
-        await new Event([eventName, '--fields', 'title:string','title:string','quantity:number'], {} as IConfig).run()
-        const renderedEvent = Mustache.render(templates.event, {
-          imports: defaultEventImports,
-          name: eventName,
-          fields: [{ name: 'title', type: 'string' },{ name: 'title', type: 'string' },{ name: 'quantity', type: 'number' }]
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(eventPath,renderedEvent)
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new Event([eventName, '--fields', 'title:string','title:string','quantity:number'], {} as IConfig).run()
+        } catch(e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain('Error: Error parsing field title. Fields cannot be duplicated')
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(eventPath)
       })
     })
+
   })
 })

--- a/packages/cli/test/commands/new/event.test.ts
+++ b/packages/cli/test/commands/new/event.test.ts
@@ -117,6 +117,21 @@ describe('new', (): void => {
         expect(exceptionThrown).to.be.equal(true)
         expect(exceptionMessage).to.contain('Error: Error parsing field title. Fields must be in the form of <field name>:<field type>')
       })
+
+      it('with no field type after :', async () => {
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new Event([eventName, '--fields','title:'], {} as IConfig).run()
+        } catch(e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain('Error: Error parsing field title:. Fields must be in the form of <field name>:<field type>')
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(eventPath)
+      })
+      
     })
 
     describe('should display an error but is not currently being validated', () => {
@@ -126,16 +141,6 @@ describe('new', (): void => {
           imports: defaultEventImports,
           name: eventName,
           fields: [{ name: 'title', type: 'string' },{ name: 'title', type: 'string' },{ name: 'quantity', type: 'number' }]
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(eventPath,renderedEvent)
-      })
-
-      it('with no field type after :', async () => {
-        await new Event([eventName, '--fields', 'title:'], {} as IConfig).run()
-        const renderedEvent = Mustache.render(templates.event, {
-          imports: defaultEventImports,
-          name: eventName,
-          fields: [{ name: 'title', type: '' }]
         })
         expect(fs.outputFile).to.have.been.calledWithMatch(eventPath,renderedEvent)
       })

--- a/packages/cli/test/commands/new/read-model.test.ts
+++ b/packages/cli/test/commands/new/read-model.test.ts
@@ -303,8 +303,42 @@ describe('new', (): void => {
         expect(exceptionMessage).to.contain(
           'Error parsing projection Post. Projections must be in the form of <entity name>:<entity id>'
         )
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(readModelPath)
+      })
+
+      it('with projection with empty entity id', async () => {
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new ReadModel([readModelName, '--fields', 'title:string', '--projects', 'Post:'], {} as IConfig).run()
+        } catch (e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain(
+          'Error parsing projection Post:. Projections must be in the form of <entity name>:<entity id>'
+        )
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(readModelPath)
+      })
+
+      it('with projection with empty entity name', async () => {
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new ReadModel([readModelName, '--fields', 'title:string', '--projects', ':id'], {} as IConfig).run()
+        } catch (e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain(
+          'Error parsing projection :id. Projections must be in the form of <entity name>:<entity id>'
+        )
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(readModelPath)
       })
     })
+
     xdescribe('should display an error but is not currently being validated', () => {
       it('with repeated fields', async () => {
         await new ReadModel(
@@ -323,16 +357,6 @@ describe('new', (): void => {
         expect(fs.outputFile).to.have.been.calledWithMatch(readModelPath, renderedReadModel)
       })
 
-      it('with no entity id after :', async () => {
-        await new ReadModel([readModelName, '--fields', 'title:string', '--projects', 'Post:'], {} as IConfig).run()
-        const renderedReadModel = Mustache.render(templates.readModel, {
-          imports: projectingReadModelImports,
-          name: readModelName,
-          fields: [{ name: 'title', type: 'string' }],
-          projections: [{ entityName: 'Post', entityId: '' }],
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(readModelPath, renderedReadModel)
-      })
     })
   })
 })

--- a/packages/cli/test/commands/new/read-model.test.ts
+++ b/packages/cli/test/commands/new/read-model.test.ts
@@ -276,6 +276,20 @@ describe('new', (): void => {
         )
       })
 
+      it('with no field type after :', async () => {
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new ReadModel([readModelName, '--fields', 'title:'], {} as IConfig).run()
+        } catch(e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain('Error: Error parsing field title:. Fields must be in the form of <field name>:<field type>')
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(readModelPath)
+      })
+
       it('with projection with no entity id', async () => {
         let exceptionThrown = false
         let exceptionMessage = ''
@@ -305,16 +319,6 @@ describe('new', (): void => {
             { name: 'title', type: 'string' },
             { name: 'quantity', type: 'number' },
           ],
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(readModelPath, renderedReadModel)
-      })
-
-      it('with no field type after :', async () => {
-        await new ReadModel([readModelName, '--fields', 'title:'], {} as IConfig).run()
-        const renderedReadModel = Mustache.render(templates.readModel, {
-          imports: defaultReadModelImports,
-          name: readModelName,
-          fields: [{ name: 'title', type: '' }],
         })
         expect(fs.outputFile).to.have.been.calledWithMatch(readModelPath, renderedReadModel)
       })

--- a/packages/cli/test/commands/new/read-model.test.ts
+++ b/packages/cli/test/commands/new/read-model.test.ts
@@ -337,26 +337,24 @@ describe('new', (): void => {
         )
         expect(fs.outputFile).to.have.not.been.calledWithMatch(readModelPath)
       })
-    })
 
-    xdescribe('should display an error but is not currently being validated', () => {
       it('with repeated fields', async () => {
-        await new ReadModel(
-          [readModelName, '--fields', 'title:string', 'title:string', 'quantity:number'],
-          {} as IConfig
-        ).run()
-        const renderedReadModel = Mustache.render(templates.readModel, {
-          imports: defaultReadModelImports,
-          name: readModelName,
-          fields: [
-            { name: 'title', type: 'string' },
-            { name: 'title', type: 'string' },
-            { name: 'quantity', type: 'number' },
-          ],
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(readModelPath, renderedReadModel)
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new ReadModel(
+            [readModelName, '--fields', 'title:string', 'title:string', 'quantity:number'],
+            {} as IConfig
+          ).run()
+        } catch(e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain('Error: Error parsing field title. Fields cannot be duplicated')
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(readModelPath)
       })
-
     })
+
   })
 })

--- a/packages/cli/test/commands/new/type.test.ts
+++ b/packages/cli/test/commands/new/type.test.ts
@@ -153,21 +153,18 @@ describe('new', (): void => {
         expect(fs.outputFile).to.have.not.been.calledWithMatch(typePath)
       })
 
-    })
-
-    xdescribe('should display an error but is not currently being validated', () => {
       it('with repeated fields', async () => {
-        await new Type([typeName, '--fields', 'title:string', 'title:string', 'quantity:number'], {} as IConfig).run()
-        const renderedType = Mustache.render(templates.type, {
-          imports: defaultTypeImports,
-          name: typeName,
-          fields: [
-            { name: 'title', type: 'string' },
-            { name: 'title', type: 'string' },
-            { name: 'quantity', type: 'number' },
-          ],
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(typePath, renderedType)
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new Type([typeName, '--fields', 'title:string', 'title:string', 'quantity:number'], {} as IConfig).run()
+        } catch(e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain('Error: Error parsing field title. Fields cannot be duplicated')
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(typePath)
       })
     })
   })

--- a/packages/cli/test/commands/new/type.test.ts
+++ b/packages/cli/test/commands/new/type.test.ts
@@ -138,6 +138,21 @@ describe('new', (): void => {
           'Error: Error parsing field title. Fields must be in the form of <field name>:<field type>'
         )
       })
+
+      it('with no field type after :', async () => {
+        let exceptionThrown = false
+        let exceptionMessage = ''
+        try {
+          await new Type([typeName, '--fields', 'title:'], {} as IConfig).run()
+        } catch(e) {
+          exceptionThrown = true
+          exceptionMessage = e.message
+        }
+        expect(exceptionThrown).to.be.equal(true)
+        expect(exceptionMessage).to.contain('Error: Error parsing field title:. Fields must be in the form of <field name>:<field type>')
+        expect(fs.outputFile).to.have.not.been.calledWithMatch(typePath)
+      })
+
     })
 
     xdescribe('should display an error but is not currently being validated', () => {
@@ -151,16 +166,6 @@ describe('new', (): void => {
             { name: 'title', type: 'string' },
             { name: 'quantity', type: 'number' },
           ],
-        })
-        expect(fs.outputFile).to.have.been.calledWithMatch(typePath, renderedType)
-      })
-
-      it('with no field type after :', async () => {
-        await new Type([typeName, '--fields', 'title:'], {} as IConfig).run()
-        const renderedType = Mustache.render(templates.type, {
-          imports: defaultTypeImports,
-          name: typeName,
-          fields: [{ name: 'title', type: '' }],
         })
         expect(fs.outputFile).to.have.been.calledWithMatch(typePath, renderedType)
       })

--- a/packages/cli/test/services/generator/target/parsing.test.ts
+++ b/packages/cli/test/services/generator/target/parsing.test.ts
@@ -112,6 +112,51 @@ describe('parsing',() => {
                 'Error parsing field :string. Fields must be in the form of <field name>:<field type>'
             )
         })
+
+        it('duplicated fields', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseFields(['title:string','content:string','title:number'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing field title. Fields cannot be duplicated'
+            )
+        })
+
+        it('field without type and duplicated fields', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseFields(['title:string','content','title:number'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing field content. Fields must be in the form of <field name>:<field type>'
+            )
+        })
+
+        it('duplicated fields and a field without type', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseFields(['title:string','content:string','title:number','category'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing field category. Fields must be in the form of <field name>:<field type>'
+            )
+        })
     })
 
     describe('parseProjections', () => {

--- a/packages/cli/test/services/generator/target/parsing.test.ts
+++ b/packages/cli/test/services/generator/target/parsing.test.ts
@@ -1,4 +1,4 @@
-import { parseFields } from '../../../../src/services/generator/target/parsing'
+import { parseFields, parseProjections } from '../../../../src/services/generator/target/parsing'
 import { expect } from '../../../expect'
 
 describe('parsing',() => {
@@ -114,4 +114,113 @@ describe('parsing',() => {
         })
     })
 
+    describe('parseProjections', () => {
+
+        it('one correct entity and id', async () => {
+            const projections = await parseProjections(['Post:id'])
+            expect(projections.projections).to.have.lengthOf(1)
+            expect(projections.projections[0].entityName).to.equal('Post')
+            expect(projections.projections[0].entityId).to.equal('id')
+        })
+
+        it('many correct entities and ids', async () => {
+            const projections = await parseProjections(['Post:id','Comment:id'])
+            expect(projections.projections).to.have.lengthOf(2)
+            expect(projections.projections[0].entityName).to.equal('Post')
+            expect(projections.projections[0].entityId).to.equal('id')
+            expect(projections.projections[1].entityName).to.equal('Comment')
+            expect(projections.projections[1].entityId).to.equal('id')
+        })
+
+        it('one entity without id', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseProjections(['Post'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing projection Post. Projections must be in the form of <entity name>:<entity id>'
+            )
+        })
+
+        it('many entities without id', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseProjections(['Post:id','Comment'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing projection Comment. Projections must be in the form of <entity name>:<entity id>'
+            )
+        })
+
+        it('one entity with empty id', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseProjections(['Post:'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing projection Post:. Projections must be in the form of <entity name>:<entity id>'
+            )
+        })
+
+        it('many entities with empty id', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseProjections(['Post:id','Comment:'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing projection Comment:. Projections must be in the form of <entity name>:<entity id>'
+            )
+        })
+        
+        it('one entity with empty name', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseProjections([':id'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing projection :id. Projections must be in the form of <entity name>:<entity id>'
+            )
+        })
+
+        it('many entities with empty name', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseProjections(['Post:id',':id'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing projection :id. Projections must be in the form of <entity name>:<entity id>'
+            )
+        })
+
+    })
 })

--- a/packages/cli/test/services/generator/target/parsing.test.ts
+++ b/packages/cli/test/services/generator/target/parsing.test.ts
@@ -1,0 +1,117 @@
+import { parseFields } from '../../../../src/services/generator/target/parsing'
+import { expect } from '../../../expect'
+
+describe('parsing',() => {
+
+    describe('parseFields', () => {
+
+        it('one correct field', async () => {
+            const fields = await parseFields(['title:string'])
+            expect(fields.fields).to.have.lengthOf(1)
+            expect(fields.fields[0].name).to.equal('title')
+            expect(fields.fields[0].type).to.equal('string')
+        })
+
+        it('many correct fields', async () => {
+            const fields = await parseFields(['name:string','age:number','id:UUID'])
+            expect(fields.fields).to.have.lengthOf(3)
+            expect(fields.fields[0].name).to.equal('name')
+            expect(fields.fields[0].type).to.equal('string')
+            expect(fields.fields[1].name).to.equal('age')
+            expect(fields.fields[1].type).to.equal('number')
+            expect(fields.fields[2].name).to.equal('id')
+            expect(fields.fields[2].type).to.equal('UUID')
+        })
+
+        it('one field without type', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseFields(['title'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing field title. Fields must be in the form of <field name>:<field type>'
+            )
+        })
+
+        it('many fields without type', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseFields(['title:string','content'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing field content. Fields must be in the form of <field name>:<field type>'
+            )
+        })
+
+        it('one field with empty type', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseFields(['title:'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing field title:. Fields must be in the form of <field name>:<field type>'
+            )
+        })
+
+        it('many fields with empty type', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseFields(['title:string','content:'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing field content:. Fields must be in the form of <field name>:<field type>'
+            )
+        })
+        
+        it('one field with empty name', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseFields([':string'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing field :string. Fields must be in the form of <field name>:<field type>'
+            )
+        })
+
+        it('many fields with empty name', async () => {
+            let exceptionThrown = false
+            let exceptionMessage = ''
+            try {
+                await parseFields(['title:string',':string'])
+            } catch (e) {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            }
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.contain(
+                'Error parsing field :string. Fields must be in the form of <field name>:<field type>'
+            )
+        })
+    })
+
+})


### PR DESCRIPTION
## Description
Adding some CLI validations to fix the following bugs:
- https://github.com/boostercloud/booster/issues/535
- https://github.com/boostercloud/booster/issues/537

## Changes
- Adding validations to parsing.ts file
- Creating Unit tests for these edge cases

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly
 
## Additional information
