### PR TITLE
Fix/509 missing rimraf dependency cli package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,8 @@
     "access": "public"
   },
   "bin": {
-    "boost": "./bin/run"
+    "boost": "./bin/run",
+    "rimraf": "./node_modules/rimraf/bin.js"
   },
   "bugs": "https://github.com/boostercloud/booster/issues",
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "inquirer": "^7.0.0",
     "mustache": "^3.0.1",
     "ora": "^3.4.0",
+    "rimraf": "^3.0.2",
     "tslib": "^1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9486,7 +9486,7 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
## Description
**rimraf** is used in `yarn clean` script. If it's not installed globally, yarn fails. I included **rimraf** as a cli `package.json` dependency. I included it as a global binary command, so yarn execution doesn't fail.

## Changes
- Update `packages/cli/package.json` to add the dependency

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly
 
## Additional information
- I'm not sure if this is the best solution. Adding **rimraf** in the bin package.json property will install the command globally and it may collide with another software that installs the same dependency globally. Rimraf is likely to be commonly used in other projects. An alternative is creating our own delete script and require the **rimraf** and **glob** dependencies to perform the deletion without declaring **rimraf** as a global binary