### PR TITLE
Remainders and fixes from the previous "yarn to npm" spike

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,15 +157,19 @@ Finally, **always use exact numbers for dependency versions**. This means that i
 
 ### Running integration tests
 
-- Integration tests are run automatically in Github Actions when a PR is locked, but it would be recommendable to run them locally before submitting a PR for review. You can find several scripts in `packages/framework-integration-tests/package.json` to run different test suites. You can run them using lerna too:
+Integration tests are run automatically in Github Actions when a PR is locked, but it would be recommendable to run them locally before submitting a PR for review. You can find several scripts in `packages/framework-integration-tests/package.json` to run different test suites. You can run them using lerna tool:
 
-- `lerna run integration`: Run all the integration test suites in the right order.
-- `integration/aws-deploy`: This test just checks that the sample project in `packages/framework-integration-tests/src` can be successfully deployed to AWS. The deployment process takes several minutes and this project is used by all the other AWS integration tests, so it's a requirement to run this test before.
-- `integration/aws-func`: AWS functional integration tests. They stress the deployed app write API and checks that the results are the expected ones both in the databases and the read APIs.
-- `integration/end-to-end`: Runs complete and realistic use cases on several cloud providers. This tests are intended to verify that a single project can be deployed to different cloud providers. Currently, only AWS is implemented though.
-- `integration/aws-nuke`: This test checks that the application deployed to AWS can be properly nuked. This test should be the last one after other test suites related to AWS have finished.
-- `integration/local`: Checks that the test application can be launched locally and that the APIs and the databases behave as expected.
-- `integration/cli`: Checks cli commands and check that they produce the expected results.
+`lerna run <script name> --stream`
+
+These are the available scripts to run integration tests:
+
+- `lerna run integration --stream`: Run all the integration test suites in the right order.
+- `lerna run integration/aws-deploy --stream`: This test just checks that the sample project in `packages/framework-integration-tests/src` can be successfully deployed to AWS. The deployment process takes several minutes and this project is used by all the other AWS integration tests, so it's a requirement to run this test before.
+- `lerna run integration/aws-func --stream`: AWS functional integration tests. They stress the deployed app write API and checks that the results are the expected ones both in the databases and the read APIs.
+- `lerna run integration/end-to-end --stream`: Runs complete and realistic use cases on several cloud providers. This tests are intended to verify that a single project can be deployed to different cloud providers. Currently, only AWS is implemented though.
+- `lerna run integration/aws-nuke --stream`: This test checks that the application deployed to AWS can be properly nuked. This test should be the last one after other test suites related to AWS have finished.
+- `lerna run integration/local --stream`: Checks that the test application can be launched locally and that the APIs and the databases behave as expected.
+- `lerna run integration/cli --stream`: Checks cli commands and check that they produce the expected results.
 
 AWS integration tests are run in real AWS resources, so you'll need to have your AWS credentials properly set in your development machine. By default, the sample project will be deployed to your default account. Basically, if you can deploy a Booster project to AWS, you should be good to go ([See more details about setting up an AWS account in the docs](https://github.com/boostercloud/booster/tree/master/docs#set-up-an-aws-account)). Notice that while all resources used by Booster are included in the AWS free tier, running these tests in your own AWS account could incur in some expenses.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,19 +11,21 @@ Remember that if something here doesn't make sense, you can also propose a chang
 - [Code of Conduct](#code-of-conduct)
 - [I don't want to read this whole thing, I just have a question!!!](#i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
 - [What should I know before I get started?](#what-should-i-know-before-i-get-started)
-  * [Packages](#packages)
+  - [Packages](#packages)
 - [How Can I Contribute?](#how-can-i-contribute)
-  * [Reporting Bugs](#reporting-bugs)
-  * [Suggesting Enhancements](#suggesting-enhancements)
-  * [Improving documentation](#improving-documentation)
-  * [Create your very first GitHub issue](#create-your-very-first-github-issue)
+  - [Reporting Bugs](#reporting-bugs)
+  - [Suggesting Enhancements](#suggesting-enhancements)
+  - [Improving documentation](#improving-documentation)
+  - [Create your very first GitHub issue](#create-your-very-first-github-issue)
 - [Your First Code Contribution](#your-first-code-contribution)
-  * [Getting the code](#getting-the-code)
-  * [Github flow](#github-flow)
-  * [Test-driven approach](#test-driven-approach)
-  * [Publishing your Pull Request](#publishing-your-pull-request)
-  * [Branch naming conventions](#branch-naming-conventions)
-  * [Commit message guidelines](#commit-message-guidelines)
+  - [Getting the code](#getting-the-code)
+  - [Understanding the "lerna monorepo" approach and how dependencies are structured in the project](#understanding-the-lerna-monorepo-approach-and-how-dependencies-are-structured-in-the-project)
+  - [Running integration tests](#running-integration-tests)
+  - [Github flow](#github-flow)
+  - [Test-driven approach](#test-driven-approach)
+  - [Publishing your Pull Request](#publishing-your-pull-request)
+  - [Branch naming conventions](#branch-naming-conventions)
+  - [Commit message guidelines](#commit-message-guidelines)
 
 <!-- tocstop -->
 
@@ -41,9 +43,10 @@ Go ahead and [create a new issue](https://github.com/boostercloud/booster/issues
 ### Packages
 
 Booster is divided in many different packages. The criteria to split the code in packages is that each package meets at least one of the following conditions:
-* They must be run separately, for instance, the CLI is run locally, while the support code for the project is run on the cloud.
-* They contain code that is used by at least two of the other packages.
-* They're a vendor-specific specialization of some abstract part of the framework (for instance, all the code that is required by AWS is in separate packages). 
+
+- They must be run separately, for instance, the CLI is run locally, while the support code for the project is run on the cloud.
+- They contain code that is used by at least two of the other packages.
+- They're a vendor-specific specialization of some abstract part of the framework (for instance, all the code that is required by AWS is in separate packages).
 
 The packages are managed using [Lerna](https://lerna.js.org) and [npm](https://npmjs.com), if you run `lerna run compile`, it will run `npm run compile` in all the package folders.
 
@@ -103,10 +106,10 @@ Bear in mind that if you have added a new section, or changed an existing one yo
 ```sh
 npm run update-tocs
 ```
+
 ### Create your very first GitHub issue
 
 [Click here](https://github.com/boostercloud/booster/issues/new) to start making contributions to Booster.
-
 
 ## Your First Code Contribution
 
@@ -139,17 +142,32 @@ To start contributing to the project you would need to set up the project in you
   - `./scripts/check-all-the-things.sh` on Linux and MacOS
   - `.\scripts\check-all-the-things.ps1` on Windows
 
-
 ### Understanding the "lerna monorepo" approach and how dependencies are structured in the project
+
 The Booster Framework project is organized following the ["lerna monorepo"](https://lerna.js.org/) structure. There are several "package.json" files and each one has its purpose with regard to the dependencies you include on them:
-- The "package.json" located at the project root is _only_ intended for development tools that you use at project level, like the Typescript compiler, linter plugins, etc. You should never put there dependencies that you would use inside a package like `framework-core`, for example (there is a linter rule that will fail if you do this). 
+
+- The "package.json" located at the project root is _only_ intended for development tools that you use at project level, like the Typescript compiler, linter plugins, etc. You should never put there dependencies that you would use inside a package like `framework-core`, for example (there is a linter rule that will fail if you do this).
 - The "package.json" files that are on each package root should contain the dependencies used by that specific package. Be sure to correctly differentiate which dependency is only for development and which one is for production.
 
 When you bootstrap your project with `lerna bootstrap`, all the needed dependencies will be installed. Lerna is configured to use a "hoisted" approach. This means that if there is the same dependency specified in several "package.json" files, it will be "hoisted": that dependency will be installed inside the `node_modules` located in the project root, and _not_ on the `node_modules` of each package. This saves space, makes the development speed faster and resolves some problems.
 
 There could be the situation in which two packages depends on the same dependency but with different versions. In that case you would get an error during `lerna bootstrap`, and that's good. Specify the same dependency version and it will be fixed.
 
-Finally, **always use exact numbers for dependency versions**. This means that if you want to add the dependency "aws-sdk" in version 1.2.3, you should add `"aws-sdk": "1.2.3"` to the corresponding "package.json" file, and never `"aws-sdk": "^1.2.3"` or `"aws-sdk": "~1.2.3"`. This restriction comes from hard problems we've had in the past
+Finally, **always use exact numbers for dependency versions**. This means that if you want to add the dependency "aws-sdk" in version 1.2.3, you should add `"aws-sdk": "1.2.3"` to the corresponding "package.json" file, and never `"aws-sdk": "^1.2.3"` or `"aws-sdk": "~1.2.3"`. This restriction comes from hard problems we've had in the past.
+
+### Running integration tests
+
+- Integration tests are run automatically in Github Actions when a PR is locked, but it would be recommendable to run them locally before submitting a PR for review. You can find several scripts in `packages/framework-integration-tests/package.json` to run different test suites. You can run them using lerna too:
+
+- `lerna run integration`: Run all the integration test suites in the right order.
+- `integration/aws-deploy`: This test just checks that the sample project in `packages/framework-integration-tests/src` can be successfully deployed to AWS. The deployment process takes several minutes and this project is used by all the other AWS integration tests, so it's a requirement to run this test before.
+- `integration/aws-func`: AWS functional integration tests. They stress the deployed app write API and checks that the results are the expected ones both in the databases and the read APIs.
+- `integration/end-to-end`: Runs complete and realistic use cases on several cloud providers. This tests are intended to verify that a single project can be deployed to different cloud providers. Currently, only AWS is implemented though.
+- `integration/aws-nuke`: This test checks that the application deployed to AWS can be properly nuked. This test should be the last one after other test suites related to AWS have finished.
+- `integration/local`: Checks that the test application can be launched locally and that the APIs and the databases behave as expected.
+- `integration/cli`: Checks cli commands and check that they produce the expected results.
+
+AWS integration tests are run in real AWS resources, so you'll need to have your AWS credentials properly set in your development machine. By default, the sample project will be deployed to your default account. Basically, if you can deploy a Booster project to AWS, you should be good to go ([See more details about setting up an AWS account in the docs](https://github.com/boostercloud/booster/tree/master/docs#set-up-an-aws-account)). Notice that while all resources used by Booster are included in the AWS free tier, running these tests in your own AWS account could incur in some expenses.
 
 ### Github flow
 
@@ -189,13 +207,14 @@ You can run only the tests for a specific provider using the more specific scope
 
 ### Publishing your Pull Request
 
-Make sure that you describe your change thoroughly in the PR body, adding references for any related issues and links to any resource that helps clarifying the intent and goals of the change. 
+Make sure that you describe your change thoroughly in the PR body, adding references for any related issues and links to any resource that helps clarifying the intent and goals of the change.
 
 When you submit a PR to the Booster repository:
-* _Unit tests_ will be automatically run. PRs with non-passing tests can't be merged.
-* If tests pass, your code will be reviewed by at least two people from the core team. Clarifications or improvements might be asked, and they reserve the right to close any PR that do not meet the project quality standards, goals or philosophy, so it's always a good idea to discuss your plans in an issue or the Spectrum channel before committing to significant changes.
-* Code must be mergeable and all conflicts solved before merging it.
-* Once the review process is done, unit tests pass and conflicts are fixed, you still need to make the _Integration tests check_ to pass. In order to do that, you need to **post a comment** in the pull request with the content "**bot: integration**". The _integration tests_ will run and a new check will appear with an "In progress" status. After some time, if everything went well, the status check will become green and your PR is now ready to merge. One of the contributors with write permissions will merge it as soon as possible. 
+
+- _Unit tests_ will be automatically run. PRs with non-passing tests can't be merged.
+- If tests pass, your code will be reviewed by at least two people from the core team. Clarifications or improvements might be asked, and they reserve the right to close any PR that do not meet the project quality standards, goals or philosophy, so it's always a good idea to discuss your plans in an issue or the Spectrum channel before committing to significant changes.
+- Code must be mergeable and all conflicts solved before merging it.
+- Once the review process is done, unit tests pass and conflicts are fixed, you still need to make the _Integration tests check_ to pass. In order to do that, you need to **post a comment** in the pull request with the content "**bot: integration**". The _integration tests_ will run and a new check will appear with an "In progress" status. After some time, if everything went well, the status check will become green and your PR is now ready to merge. One of the contributors with write permissions will merge it as soon as possible.
 
 ### Branch naming conventions
 
@@ -210,6 +229,7 @@ In the right side of the branch name you can include the GitHub issue number. An
 ```bash
 git checkout -b feature/XXX_add-an-awesome-new-feature
 ```
+
 (where `XXX` is the issue number)
 
 ### Commit message guidelines

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,7 @@
     + [Deploy and init hooks (Not yet implemented)](#deploy-and-init-hooks-not-yet-implemented)
 - [Debugging and testing Booster applications](#debugging-and-testing-booster-applications)
   * [Running Booster applications locally](#running-booster-applications-locally)
-    + [Prerequisites](#prerequisites-1)
+    + [Local development prerequisites](#local-development-prerequisites)
     + [Starting your application](#starting-your-application)
     + [Performing Auth requests](#performing-auth-requests)
     + [Performing GraphQL requests](#performing-graphql-requests)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/boostercloud/booster/issues",
   "private": true,
   "scripts": {
-    "update-tocs": "npm update-documentation-toc && npm update-contributing-toc",
+    "update-tocs": "npm run update-documentation-toc && npm run update-contributing-toc",
     "update-documentation-toc": "markdown-toc -i --maxdepth 4 docs/README.md",
     "update-contributing-toc": "markdown-toc -i --maxdepth 4 CONTRIBUTING.md"
   },

--- a/packages/framework-core/test/booster-command-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-command-dispatcher.test.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { Booster } from '../src/booster'
-import { fake, replace, restore, match } from 'sinon'
+import { fake, replace, restore } from 'sinon'
 import { expect } from './expect'
 import { BoosterCommandDispatcher } from '../src/booster-command-dispatcher'
 import { Logger, Register } from '@boostercloud/framework-types'
 import { Command } from '../src/decorators'
 import { RegisterHandler } from '../src/booster-register-handler'
+import { random } from 'faker'
 
 describe('the `BoosterCommandsDispatcher`', () => {
   afterEach(() => {
@@ -25,93 +26,174 @@ describe('the `BoosterCommandsDispatcher`', () => {
     error() {},
   }
 
-  describe('private methods', () => {
-    describe('the `dispatchCommand` method', () => {
-      it('calls the handler method of a registered command', () => {
-        @Command({ authorize: 'all' })
-        class PostComment {
-          public constructor(readonly comment: string) {}
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          public static async handle(_command: PostComment, _register: Register): Promise<void> {
-            throw new Error('Not implemented')
-          }
+  describe('the `dispatchCommand` method', () => {
+    it('fails if the command "version" is not sent', () => {
+      const command = {
+        typeName: 'PostComment',
+        value: { comment: 'This comment is pointless' },
+      }
+      Booster.configure('test', async (config) => {
+        // We use `bind` to generate a thunk that chai will then call, checking that it throws
+        await expect(
+          new BoosterCommandDispatcher(config, logger).dispatchCommand(command as any)
+        ).to.be.eventually.rejectedWith('The required command "version" was not present')
+      })
+    })
+
+    it('fails if the command is not registered', () => {
+      const command = {
+        version: 1,
+        typeName: 'PostComment',
+        value: { comment: 'This comment is pointless' },
+      }
+      Booster.configure('test', async (config) => {
+        // We use `bind` to generate a thunk that chai will then call, checking that it throws
+        await expect(
+          new BoosterCommandDispatcher(config, logger).dispatchCommand(command as any)
+        ).to.be.eventually.rejectedWith('Could not find a proper handler for PostComment')
+      })
+    })
+
+    it('fails if the current user is not authorized', async () => {
+      class Thor {}
+
+      const config = {
+        commandHandlers: {
+          UnauthorizedCommand: {
+            authorizedRoles: [Thor],
+          },
+        },
+      }
+
+      const commandEnvelope = {
+        typeName: 'UnauthorizedCommand',
+        version: 'π', // JS doesn't care, and π is a number after all xD...
+        currentUser: {
+          role: 'Loki',
+        },
+      }
+
+      await expect(
+        new BoosterCommandDispatcher(config as any, logger).dispatchCommand(commandEnvelope as any)
+      ).to.be.eventually.rejectedWith("Access denied for command 'UnauthorizedCommand'")
+    })
+
+    it('calls the handler method of a registered command', async () => {
+      const fakeHandler = fake()
+      class ProperlyHandledCommand {
+        public static handle() {}
+      }
+
+      replace(ProperlyHandledCommand, 'handle', fakeHandler)
+      replace(RegisterHandler, 'handle', fake())
+
+      const config = {
+        commandHandlers: {
+          ProperlyHandledCommand: {
+            authorizedRoles: 'all',
+            class: ProperlyHandledCommand,
+          },
+        },
+      }
+      const commandValue = {
+        something: 'to handle',
+      }
+
+      const commandEnvelope = {
+        typeName: 'ProperlyHandledCommand',
+        version: 'π', // JS doesn't care, and π is a number after all xD...
+        currentUser: {
+          role: 'Loki',
+        },
+        value: commandValue,
+        requestID: '42',
+      }
+
+      await new BoosterCommandDispatcher(config as any, logger).dispatchCommand(commandEnvelope as any)
+
+      expect(fakeHandler).to.have.been.calledWithMatch(commandValue)
+    })
+
+    it('properly handle the registered events', async () => {
+      class SomethingHappened {
+        public constructor(readonly when: string) {}
+        public entityID() {
+          return random.uuid()
         }
+      }
 
-        const fakeHandler = fake()
-        const command = new PostComment('This test is good!')
-        replace(PostComment, 'handle', fakeHandler)
-        replace(RegisterHandler, 'handle', fake())
+      const event = new SomethingHappened('right now!')
 
-        Booster.configure(
-          'test',
-          async (config): Promise<void> => {
-            await new BoosterCommandDispatcher(config, logger).dispatchCommand({
-              requestID: '1234',
-              version: 1,
-              typeName: 'PostComment',
-              value: command,
-            })
-            expect(fakeHandler).to.have.been.calledOnce
-            expect(RegisterHandler.handle).to.have.been.calledOnceWith(config, logger, match.instanceOf(Register))
-          }
-        )
+      const fakeHandler = fake((_command: any, register: Register) => {
+        register.events(event)
       })
 
-      it('waits for the handler method of a registered command to finish any async operation', async () => {
-        let asyncOperationFinished = false
-        @Command({ authorize: 'all' })
-        class PostComment {
-          public constructor(readonly comment: string) {}
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          public static async handle(command: PostComment, _register: Register): Promise<void> {
-            await new Promise((resolve) => setTimeout(resolve, 100))
-            asyncOperationFinished = true
-          }
+      class ProperlyHandledCommand {
+        public static handle() {}
+      }
+
+      replace(ProperlyHandledCommand, 'handle', fakeHandler)
+      replace(RegisterHandler, 'handle', fake())
+
+      const config = {
+        commandHandlers: {
+          ProperlyHandledCommand: {
+            authorizedRoles: 'all',
+            class: ProperlyHandledCommand,
+          },
+        },
+      }
+      const commandValue = {
+        something: 'to handle',
+      }
+
+      const commandEnvelope = {
+        typeName: 'ProperlyHandledCommand',
+        version: 'π', // JS doesn't care, and π is a number after all xD...
+        currentUser: {
+          role: 'Loki',
+        },
+        value: commandValue,
+        requestID: '42',
+      }
+
+      await new BoosterCommandDispatcher(config as any, logger).dispatchCommand(commandEnvelope as any)
+
+      expect(fakeHandler).to.have.been.calledWithMatch(commandValue)
+      expect(RegisterHandler.handle).to.have.been.calledWithMatch(config, logger, {
+        requestID: '42',
+        currentUser: commandEnvelope.currentUser,
+        eventList: [event],
+      })
+    })
+
+    it('waits for the handler method of a registered command to finish any async operation', async () => {
+      let asyncOperationFinished = false
+      @Command({ authorize: 'all' })
+      class PostComment {
+        public constructor(readonly comment: string) {}
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        public static async handle(command: PostComment, _register: Register): Promise<void> {
+          await new Promise((resolve) => setTimeout(resolve, 100))
+          asyncOperationFinished = true
         }
+      }
 
-        const command = new PostComment('This test is good!')
-        replace(RegisterHandler, 'handle', fake())
+      const command = new PostComment('This test is good!')
+      replace(RegisterHandler, 'handle', fake())
 
-        let boosterConfig: any
-        Booster.configure('test', (config) => {
-          boosterConfig = config
-        })
-
-        await new BoosterCommandDispatcher(boosterConfig, logger).dispatchCommand({
-          requestID: '1234',
-          version: 1,
-          typeName: 'PostComment',
-          value: command,
-        })
-        expect(asyncOperationFinished).to.be.true
+      let boosterConfig: any
+      Booster.configure('test', (config) => {
+        boosterConfig = config
       })
 
-      it('fails if the command "version" is not sent', () => {
-        const command = {
-          typeName: 'PostComment',
-          value: { comment: 'This comment is pointless' },
-        }
-        Booster.configure('test', async (config) => {
-          // We use `bind` to generate a thunk that chai will then call, checking that it throws
-          await expect(
-            new BoosterCommandDispatcher(config, logger).dispatchCommand(command as any)
-          ).to.eventually.throw('The required command "version" was not present')
-        })
+      await new BoosterCommandDispatcher(boosterConfig, logger).dispatchCommand({
+        requestID: '1234',
+        version: 1,
+        typeName: 'PostComment',
+        value: command,
       })
-
-      it('fails if the command is not registered', () => {
-        const command = {
-          version: 1,
-          typeName: 'PostComment',
-          value: { comment: 'This comment is pointless' },
-        }
-        Booster.configure('test', async (config) => {
-          // We use `bind` to generate a thunk that chai will then call, checking that it throws
-          await expect(
-            new BoosterCommandDispatcher(config, logger).dispatchCommand(command as any)
-          ).to.eventually.throw('Could not find a proper handler for PostComment')
-        })
-      })
+      expect(asyncOperationFinished).to.be.true
     })
   })
 })

--- a/packages/framework-core/test/booster-command-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-command-dispatcher.test.ts
@@ -33,7 +33,6 @@ describe('the `BoosterCommandsDispatcher`', () => {
         value: { comment: 'This comment is pointless' },
       }
       Booster.configure('test', async (config) => {
-        // We use `bind` to generate a thunk that chai will then call, checking that it throws
         await expect(
           new BoosterCommandDispatcher(config, logger).dispatchCommand(command as any)
         ).to.be.eventually.rejectedWith('The required command "version" was not present')
@@ -47,7 +46,6 @@ describe('the `BoosterCommandsDispatcher`', () => {
         value: { comment: 'This comment is pointless' },
       }
       Booster.configure('test', async (config) => {
-        // We use `bind` to generate a thunk that chai will then call, checking that it throws
         await expect(
           new BoosterCommandDispatcher(config, logger).dispatchCommand(command as any)
         ).to.be.eventually.rejectedWith('Could not find a proper handler for PostComment')

--- a/packages/framework-provider-aws/test/library/subscription-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/subscription-adapter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from '../expect'
 import { DynamoDB } from 'aws-sdk'
 import { fake, createStubInstance, stub, restore, SinonStub } from 'sinon'
@@ -23,7 +24,8 @@ const config = new BoosterConfig('test')
 
 describe('The "subscribeToReadModel" method', () => {
   let db: DynamoDB.DocumentClient
-  let envelope: SubscriptionEnvelope
+  let envelope: any // Not using the actual type to allow the `delete` operators remove non-optional properties in the tests. TypeScript 4.x.x thows a compile error in these cases.
+
   beforeEach(() => {
     db = createStubInstance(DynamoDB.DocumentClient)
     envelope = {

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/utils.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/utils.ts
@@ -65,12 +65,12 @@ export async function packageAzureFunction(functionDefinitions: Array<FunctionDe
     })
 
     output.on('end', () => {
-      resolve()
+      resolve(output.path)
     })
 
     archive.on('warning', (err: any) => {
       if (err.code === 'ENOENT') {
-        resolve()
+        resolve(output.path)
       } else {
         reject(err)
       }

--- a/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/utils.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/utils.ts
@@ -63,11 +63,11 @@ export async function createProjectZipFile(): Promise<string> {
     })
 
     output.on('end', () => {
-      resolve()
+      resolve(output.path.toString())
     })
 
     archive.on('warning', (err: any) => {
-      err.code === 'ENOENT' ? resolve() : reject(err)
+      err.code === 'ENOENT' ? resolve(output.path.toString()) : reject(err)
     })
 
     archive.on('error', (err: any) => {

--- a/packages/framework-types/src/concepts/uuid.ts
+++ b/packages/framework-types/src/concepts/uuid.ts
@@ -1,4 +1,4 @@
-import { v4 } from 'uuid'
+import { v4 as uuid } from 'uuid'
 /**
  * `UUID` type to work globally as a identifier for Entities,
  * Commands, Events or any other booster artifact.
@@ -7,6 +7,6 @@ import { v4 } from 'uuid'
  */
 export class UUID extends String {
   public static generate(): UUID {
-    return v4()
+    return uuid()
   }
 }


### PR DESCRIPTION
**Note: This code was already reviewed and approved in #498**

## Description

While working on the first spike to switch to npm (#496) I applied several fixes/improvements to a few tests, but that branch was closed. This branch cherry-picked the nice parts that deserve being saved.

> This PR is a rebase of #498. We're switching to npm and the current master is too unstable for integration tests to pass, so we'll try better luck using npm.

## Changes
* Documented the process to run integration tests in the CONTRIBUTING.md guide.
* Fixed Booster Command Dispatcher unit tests in the `framework-core` package.
* Reviewed subscription adapter unit tests in the `framework-provider-aws` package.
* Fixed a small issue in the azure and kubernetes infrastructure packages related to promise handling.
* Minor change in the way we import the `uuid` library.

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [x] Updated documentation accordingly
 