### PR TITLE
Fix: deploy framework packages under development during integration tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,10 @@
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "protocol": "inspector",
-      "runtimeArgs": ["--preserve-symlinks"]
+      "runtimeArgs": ["--preserve-symlinks"],
+      "env": {
+        "BOOSTER_ENV": "test"
+      }
     },
     {
       "type": "node",
@@ -112,6 +115,7 @@
         "999999",
         "--colors",
         "--forbid-only",
+        "--full-trace",
         "${workspaceFolder}/packages/cli/test/**/*.test.ts"
       ],
       "console": "integratedTerminal",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,0 +1,529 @@
+{
+  "name": "@boostercloud/cli",
+  "version": "0.9.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@boostercloud/framework-core": {
+      "version": "0.9.3",
+      "requires": {
+        "@boostercloud/framework-types": "^0.9.3",
+        "fp-ts": "^2.0.3",
+        "graphql": "15.4.0",
+        "graphql-subscriptions": "1.1.0",
+        "graphql-type-json": "0.3.2",
+        "inflected": "^2.1.0",
+        "iterall": "^1.3.0",
+        "jsonwebtoken": "^8.5.1",
+        "jwks-rsa": "^1.11.0",
+        "reflect-metadata": "^0.1",
+        "validator": "^13.1.1"
+      },
+      "dependencies": {
+        "@boostercloud/framework-types": {
+          "version": "0.9.3",
+          "requires": {
+            "uuid": "8.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            }
+          }
+        },
+        "@tootallnate/once": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+          "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+        },
+        "@types/body-parser": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+          "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+          "requires": {
+            "@types/connect": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/connect": {
+          "version": "3.4.34",
+          "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+          "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/express": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
+          "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
+          "requires": {
+            "@types/body-parser": "*",
+            "@types/express-serve-static-core": "^4.17.18",
+            "@types/qs": "*",
+            "@types/serve-static": "*"
+          }
+        },
+        "@types/express-jwt": {
+          "version": "0.0.42",
+          "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+          "integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
+          "requires": {
+            "@types/express": "*",
+            "@types/express-unless": "*"
+          }
+        },
+        "@types/express-serve-static-core": {
+          "version": "4.17.18",
+          "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.18.tgz",
+          "integrity": "sha512-m4JTwx5RUBNZvky/JJ8swEJPKFd8si08pPF2PfizYjGZOKr/svUWPcoUmLow6MmPzhasphB7gSTINY67xn3JNA==",
+          "requires": {
+            "@types/node": "*",
+            "@types/qs": "*",
+            "@types/range-parser": "*"
+          }
+        },
+        "@types/express-unless": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
+          "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
+          "requires": {
+            "@types/express": "*"
+          }
+        },
+        "@types/mime": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+          "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
+        },
+        "@types/node": {
+          "version": "14.14.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+          "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
+        },
+        "@types/qs": {
+          "version": "6.9.5",
+          "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+          "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
+        },
+        "@types/range-parser": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+          "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+        },
+        "@types/serve-static": {
+          "version": "1.13.8",
+          "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.8.tgz",
+          "integrity": "sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==",
+          "requires": {
+            "@types/mime": "*",
+            "@types/node": "*"
+          }
+        },
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "buffer-equal-constant-time": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+          "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            }
+          }
+        },
+        "ecdsa-sig-formatter": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+          "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+        },
+        "fp-ts": {
+          "version": "2.9.3",
+          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.9.3.tgz",
+          "integrity": "sha512-NjzcHYgigcbPQ6yJ52zwgsVDwKz3vwy9sjbxyzcvfXQm+j1BGeOPRuzLKEwsLyE4Xut6gG1FXJtsU9/gUB7tXg=="
+        },
+        "graphql": {
+          "version": "15.4.0",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
+          "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA=="
+        },
+        "graphql-subscriptions": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",
+          "integrity": "sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==",
+          "requires": {
+            "iterall": "^1.2.1"
+          }
+        },
+        "graphql-type-json": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
+          "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
+        },
+        "http-proxy-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+          "requires": {
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "inflected": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/inflected/-/inflected-2.1.0.tgz",
+          "integrity": "sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w=="
+        },
+        "iterall": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+          "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+        },
+        "jsonwebtoken": {
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+          "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+          "requires": {
+            "jws": "^3.2.2",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "jwa": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jwks-rsa": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.12.2.tgz",
+          "integrity": "sha512-6gPo/mQUxXJt75oPtjhM3Jm3FSXnmwg73QDA8dpgP7YmIKlIY+2StngFxt4w4Y1podtSbtV3jttNOdctuxAX1Q==",
+          "requires": {
+            "@types/express-jwt": "0.0.42",
+            "axios": "^0.21.1",
+            "debug": "^4.1.0",
+            "http-proxy-agent": "^4.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "jsonwebtoken": "^8.5.1",
+            "limiter": "^1.1.5",
+            "lru-memoizer": "^2.1.2",
+            "ms": "^2.1.2",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "limiter": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+          "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+        },
+        "lodash.includes": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+          "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+        },
+        "lodash.isboolean": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+          "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+        },
+        "lodash.isinteger": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+          "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+        },
+        "lodash.isnumber": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+          "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+          "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+          "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+        },
+        "lodash.once": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+          "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+        },
+        "lru-cache": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+          "requires": {
+            "pseudomap": "^1.0.1",
+            "yallist": "^2.0.0"
+          }
+        },
+        "lru-memoizer": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
+          "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
+          "requires": {
+            "lodash.clonedeep": "^4.5.0",
+            "lru-cache": "~4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "proxy-from-env": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
+        "reflect-metadata": {
+          "version": "0.1.13",
+          "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+          "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "validator": {
+          "version": "13.5.2",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
+          "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
+    "@boostercloud/framework-types": {
+      "version": "0.9.3",
+      "requires": {
+        "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@types/chai": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.14.tgz",
+      "integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.167",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
+      "integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.14.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.10.tgz",
+      "integrity": "sha512-/faDC0erR06wMdybwI/uR8wEKV/E83T0k4sepIpB7gXuy2gzx2xiOjmztq6a2Y6rIGJ04D+6UU0VBmWy+4HEMA==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "fancy-test": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/fancy-test/-/fancy-test-1.4.10.tgz",
+      "integrity": "sha512-AaUX6wKS7D5OP2YK2q5G7c8PGx2lgoyLUD7Bbg8z323sb9aebBqzb9UN6phzI73UgO/ViihmNfOxF3kdfZLhew==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/lodash": "*",
+        "@types/node": "*",
+        "@types/sinon": "*",
+        "lodash": "^4.17.13",
+        "mock-stdin": "^1.0.0",
+        "nock": "^13.0.0",
+        "stdout-stderr": "^0.1.9"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
+    "mock-stdin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mock-stdin/-/mock-stdin-1.0.0.tgz",
+      "integrity": "sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "nock": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.5.tgz",
+      "integrity": "sha512-1ILZl0zfFm2G4TIeJFW0iHknxr2NyA+aGCMTjDVUsBY4CkMRispF1pfIYkTRdAR/3Bg+UzdEuK0B6HczMQZcCg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
+    },
+    "stdout-stderr": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/stdout-stderr/-/stdout-stderr-0.1.13.tgz",
+      "integrity": "sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    }
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "faker": "5.1.0",
+    "fancy-test": "^1.4.10",
     "rewire": "5.0.0",
     "sinon-chai": "3.5.0"
   },

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -5,12 +5,12 @@ import {
   generateConfigFiles,
   generateRootDirectory,
   initializeGit,
-  installDependencies,
   ProjectInitializerConfig,
 } from '../../services/project-initializer'
 import Prompter from '../../services/user-prompt'
 import { assertNameIsCorrect } from '../../services/provider-service'
 import { Provider } from '../../common/provider'
+import { installDependencies } from '../../services/dependencies'
 
 export default class Project extends Command {
   public static description = 'create a new project from scratch'
@@ -81,7 +81,9 @@ const run = async (flags: Partial<ProjectInitializerConfig>, boosterVersion: str
   Script.init(`boost ${Brand.energize('new')} 🚧`, parseConfig(new Prompter(), flags, boosterVersion))
     .step('Creating project root', generateRootDirectory)
     .step('Generating config files', generateConfigFiles)
-    .optionalStep(Boolean(flags.skipInstall), 'Installing dependencies', installDependencies)
+    .optionalStep(Boolean(flags.skipInstall), 'Installing dependencies', (config) =>
+      installDependencies(config.projectName)
+    )
     .optionalStep(Boolean(flags.skipGit), 'Initializing git repository', initializeGit)
     .info('Project generated!')
     .done()

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -4,18 +4,10 @@ import { exec } from 'child-process-promise'
 import { wrapExecError } from '../common/errors'
 import { checkItIsABoosterProject } from './project-checker'
 import { currentEnvironment } from './environment'
-import { pruneDevDependencies } from './dependencies'
 
-type CompileAndLoadOptions = {
-  production: boolean
-}
-
-export async function compileProjectAndLoadConfig(opts?: CompileAndLoadOptions): Promise<BoosterConfig> {
+export async function compileProjectAndLoadConfig(): Promise<BoosterConfig> {
   const userProjectPath = process.cwd()
   await checkItIsABoosterProject()
-  if (opts?.production) {
-    await pruneDevDependencies()
-  }
   await compileProject(userProjectPath)
   return readProjectConfig(userProjectPath)
 }

--- a/packages/cli/src/services/dependencies.ts
+++ b/packages/cli/src/services/dependencies.ts
@@ -9,7 +9,7 @@ export async function pruneDevDependencies(): Promise<void> {
   }
 }
 
-export async function installAllDependencies(path?: string): Promise<void> {
+export async function installDependencies(path?: string): Promise<void> {
   try {
     await exec('npm install', { cwd: path ?? process.cwd() })
   } catch (e) {

--- a/packages/cli/src/services/project-initializer.ts
+++ b/packages/cli/src/services/project-initializer.ts
@@ -12,14 +12,9 @@ import * as configTs from '../templates/project/config-ts'
 import * as indexTs from '../templates/project/index-ts'
 import * as prettierRc from '../templates/project/prettierrc-yaml'
 import { wrapExecError } from '../common/errors'
-import { installAllDependencies } from './dependencies'
 
 export async function generateConfigFiles(config: ProjectInitializerConfig): Promise<void> {
   await Promise.all(filesToGenerate.map(renderToFile(config)))
-}
-
-export async function installDependencies(config: ProjectInitializerConfig): Promise<void> {
-  return installAllDependencies(projectDir(config))
 }
 
 export async function generateRootDirectory(config: ProjectInitializerConfig): Promise<void> {

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -23,89 +23,60 @@ describe('deploy', () => {
   describe('runTasks function', () => {
     context('when an unexpected problem happens', () => {
       fancy.stdout().it('fails gracefully showing the error message', async () => {
+        replace(dependencies, 'installDependencies', fake())
         const msg = 'weird exception'
         const fakeLoader = Promise.reject(new Error(msg))
         const fakeDeployer = fake()
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks(false, fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })
 
     context('when index.ts structure is not correct', () => {
       fancy.stdout().it('fails gracefully', async () => {
+        replace(dependencies, 'installDependencies', fake())
         const msg = 'An error when loading project'
         const fakeLoader = Promise.reject(new Error(msg))
         const fakeDeployer = fake()
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks(false, fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })
 
-    context('when the `skipRestoreDependencies` flag is set to "false"', () => {
-      fancy.stdout().it('reinstalls dev dependencies after deploy', async (ctx) => {
-        const fakeReinstallDependencies = fake()
-        replace(dependencies, 'installAllDependencies', fakeReinstallDependencies)
+    fancy.stdout().it('installs dependencies before deploy', async (ctx) => {
+      const fakeInstallDependencies = fake()
+      replace(dependencies, 'installDependencies', fakeInstallDependencies)
 
-        const fakeProvider = {} as ProviderLibrary
+      const fakeProvider = {} as ProviderLibrary
 
-        const fakeLoader = fake.resolves({
-          provider: fakeProvider,
-          appName: 'fake app',
-          region: 'tunte',
-          entities: {},
-        })
-
-        const fakeDeployer = fake((_config: unknown, logger: Logger) => {
-          logger.info('this is a progress update')
-        })
-
-        replace(environment, 'currentEnvironment', fake.returns('test-env'))
-
-        await runTasks(false, fakeLoader, fakeDeployer)
-
-        expect(fakeReinstallDependencies).to.have.been.called
-
-        expect(ctx.stdout).to.include('Deployment complete')
-        expect(fakeDeployer).to.have.been.calledOnce
+      const fakeLoader = fake.resolves({
+        provider: fakeProvider,
+        appName: 'fake app',
+        region: 'tunte',
+        entities: {},
       })
-    })
 
-    context('when `skipRestoreDependencies` flag is set to "true"', () => {
-      fancy.stdout().it('does not reinstall dependencies after deployment', async (ctx) => {
-        const fakeReinstallDependencies = fake()
-        replace(dependencies, 'installAllDependencies', fakeReinstallDependencies)
-
-        const fakeProvider = {} as ProviderLibrary
-
-        const fakeLoader = fake.resolves({
-          provider: fakeProvider,
-          appName: 'fake app',
-          region: 'tunte',
-          entities: {},
-        })
-
-        const fakeDeployer = fake((_config: unknown, logger: Logger) => {
-          logger.info('this is a progress update')
-        })
-
-        replace(environment, 'currentEnvironment', fake.returns('test-env'))
-
-        await runTasks(true, fakeLoader, fakeDeployer)
-
-        expect(fakeReinstallDependencies).not.to.have.been.called
-
-        expect(ctx.stdout).to.include('Deployment complete')
-        expect(fakeDeployer).to.have.been.calledOnce
+      const fakeDeployer = fake((_config: unknown, logger: Logger) => {
+        logger.info('this is a progress update')
       })
+
+      replace(environment, 'currentEnvironment', fake.returns('test-env'))
+
+      await runTasks(fakeLoader, fakeDeployer)
+
+      expect(fakeInstallDependencies).to.have.been.called
+
+      expect(ctx.stdout).to.include('Deployment complete')
+      expect(fakeDeployer).to.have.been.calledOnce
     })
 
     context('when there is a valid index.ts', () => {
       fancy.stdout().it('Starts deployment', async (ctx) => {
-        replace(dependencies, 'installAllDependencies', fake())
+        replace(dependencies, 'installDependencies', fake())
 
         const fakeProvider = {} as ProviderLibrary
 
@@ -122,7 +93,7 @@ describe('deploy', () => {
 
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await runTasks(false, fakeLoader, fakeDeployer)
+        await runTasks(fakeLoader, fakeDeployer)
 
         expect(ctx.stdout).to.include('Deployment complete')
 

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -3,7 +3,6 @@ import { expect } from '../expect'
 import { fancy } from 'fancy-test'
 import { restore, fake, replace } from 'sinon'
 import { ProviderLibrary, Logger } from '@boostercloud/framework-types'
-import { test } from '@oclif/test'
 import * as environment from '../../src/services/environment'
 import * as dependencies from '../../src/services/dependencies'
 
@@ -23,33 +22,37 @@ describe('deploy', () => {
   describe('runTasks function', () => {
     context('when an unexpected problem happens', () => {
       fancy.stdout().it('fails gracefully showing the error message', async () => {
-        replace(dependencies, 'installDependencies', fake())
+        replace(dependencies, 'pruneDevDependencies', fake())
+
         const msg = 'weird exception'
         const fakeLoader = Promise.reject(new Error(msg))
         const fakeDeployer = fake()
+
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks(fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(true, fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })
 
     context('when index.ts structure is not correct', () => {
       fancy.stdout().it('fails gracefully', async () => {
-        replace(dependencies, 'installDependencies', fake())
+        replace(dependencies, 'pruneDevDependencies', fake())
+
         const msg = 'An error when loading project'
         const fakeLoader = Promise.reject(new Error(msg))
         const fakeDeployer = fake()
+
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks(fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(true, fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })
 
-    fancy.stdout().it('installs dependencies before deploy', async (ctx) => {
-      const fakeInstallDependencies = fake()
-      replace(dependencies, 'installDependencies', fakeInstallDependencies)
+    fancy.stdout().it('installs dependencies in production mode before deployment', async (ctx) => {
+      const fakePruneDevDependencies = fake()
+      replace(dependencies, 'pruneDevDependencies', fakePruneDevDependencies)
 
       const fakeProvider = {} as ProviderLibrary
 
@@ -66,16 +69,18 @@ describe('deploy', () => {
 
       replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-      await runTasks(fakeLoader, fakeDeployer)
+      await runTasks(true, fakeLoader, fakeDeployer)
 
-      expect(fakeInstallDependencies).to.have.been.called
+      expect(fakePruneDevDependencies).to.have.been.calledOnce
 
       expect(ctx.stdout).to.include('Deployment complete')
       expect(fakeDeployer).to.have.been.calledOnce
     })
 
-    context('when there is a valid index.ts', () => {
-      fancy.stdout().it('Starts deployment', async (ctx) => {
+    context('when the `skipRestoreDependencies` flag is set to false', () => {
+      fancy.stdout().it('reinstalls dependencies in development mode after deployment', async (ctx) => {
+        const fakePruneDevDependencies = fake()
+        replace(dependencies, 'pruneDevDependencies', fakePruneDevDependencies)
         replace(dependencies, 'installDependencies', fake())
 
         const fakeProvider = {} as ProviderLibrary
@@ -93,23 +98,41 @@ describe('deploy', () => {
 
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await runTasks(fakeLoader, fakeDeployer)
+        await runTasks(false, fakeLoader, fakeDeployer)
+
+        expect(dependencies.pruneDevDependencies).to.have.been.calledOnce
+        expect(dependencies.installDependencies).to.have.been.calledAfter(fakePruneDevDependencies)
+
+        expect(ctx.stdout).to.include('Deployment complete')
+        expect(fakeDeployer).to.have.been.calledOnce
+      })
+    })
+
+    context('when there is a valid index.ts', () => {
+      fancy.stdout().it('Starts deployment', async (ctx) => {
+        replace(dependencies, 'pruneDevDependencies', fake())
+
+        const fakeProvider = {} as ProviderLibrary
+
+        const fakeLoader = fake.resolves({
+          provider: fakeProvider,
+          appName: 'fake app',
+          region: 'tunte',
+          entities: {},
+        })
+
+        const fakeDeployer = fake((_config: unknown, logger: Logger) => {
+          logger.info('this is a progress update')
+        })
+
+        replace(environment, 'currentEnvironment', fake.returns('test-env'))
+
+        await runTasks(true, fakeLoader, fakeDeployer)
 
         expect(ctx.stdout).to.include('Deployment complete')
 
         expect(fakeDeployer).to.have.been.calledOnce
       })
-    })
-  })
-
-  describe('run', () => {
-    context('when no environment provided', async () => {
-      test
-        .stdout()
-        .command(['deploy'])
-        .it('shows no environment provided error', (ctx) => {
-          expect(ctx.stdout).to.match(/No environment set/)
-        })
     })
   })
 })

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -10,6 +10,7 @@ import { IConfig } from '@oclif/config'
 import { expect } from '../expect'
 import * as Project from '../../src/commands/new/project'
 import * as ProjectInitializer from '../../src/services/project-initializer'
+import * as dependencies from '../../src/services/dependencies'
 
 describe('new', (): void => {
   describe('Read model', () => {
@@ -108,7 +109,7 @@ describe('new', (): void => {
 
       it('generates all required files and folders', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
-        replace(ProjectInitializer, 'installDependencies', fake.returns({}))
+        replace(dependencies, 'installDependencies', fake.returns({}))
         expect(fs.existsSync(projectDirectory)).to.be.false
 
         await new Project.default([projectName], {} as IConfig).run()
@@ -120,7 +121,7 @@ describe('new', (): void => {
 
       it('generates all required files and folders without installing dependencies', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
-        const installDependenciesSpy = spy(ProjectInitializer, 'installDependencies')
+        const installDependenciesSpy = spy(dependencies, 'installDependencies')
         expect(fs.existsSync(projectDirectory)).to.be.false
 
         await new Project.default([projectName, '--skipInstall'], {} as IConfig).run()
@@ -133,7 +134,7 @@ describe('new', (): void => {
 
       it('generates project with default parameters when using --default flag', async () => {
         const parseConfigSpy = spy(Project, 'parseConfig')
-        replace(ProjectInitializer, 'installDependencies', fake.returns({}))
+        replace(dependencies, 'installDependencies', fake.returns({}))
         expect(fs.existsSync(projectDirectory)).to.be.false
 
         await new Project.default([projectName, '--default'], { version: '0.5.1' } as IConfig).run()
@@ -157,7 +158,7 @@ describe('new', (): void => {
 
       it('initializes git repository', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
-        replace(ProjectInitializer, 'installDependencies', fake.returns({}))
+        replace(dependencies, 'installDependencies', fake.returns({}))
         const initializeGitSpy = spy(ProjectInitializer, 'initializeGit')
 
         await new Project.default([projectName], {} as IConfig).run()
@@ -169,7 +170,7 @@ describe('new', (): void => {
 
       it('skips git repository initialization', async () => {
         replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
-        replace(ProjectInitializer, 'installDependencies', fake.returns({}))
+        replace(dependencies, 'installDependencies', fake.returns({}))
         const initializeGitSpy = spy(ProjectInitializer, 'initializeGit')
 
         await new Project.default([projectName, '--skipGit'], {} as IConfig).run()

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -167,18 +167,6 @@ describe('new', (): void => {
         expect(fs.readdirSync(projectDirectory)).to.have.all.members(expectedDirectoryContent.rootPath)
         expect(fs.readdirSync(`${projectDirectory}/src`)).to.have.all.members(expectedDirectoryContent.src)
       })
-
-      it('skips git repository initialization', async () => {
-        replace(Project, 'parseConfig', fake.returns(defaultProjectInitializerConfig))
-        replace(dependencies, 'installDependencies', fake.returns({}))
-        const initializeGitSpy = spy(ProjectInitializer, 'initializeGit')
-
-        await new Project.default([projectName, '--skipGit'], {} as IConfig).run()
-
-        expect(initializeGitSpy).to.not.have.been.calledOnce
-        expect(fs.existsSync('.git')).to.be.false
-        expect(fs.existsSync(projectDirectory)).to.be.true
-      })
     })
   })
 })

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -47,64 +47,6 @@ describe('configService', () => {
       rewires.forEach((fn) => fn())
     })
 
-    context('when the production option is set to `false`', () => {
-      it('does not prune devDependencies', async () => {
-        const config = new BoosterConfig('test')
-
-        const rewires = [
-          configService.__set__('compileProject', fake()),
-          configService.__set__(
-            'loadUserProject',
-            fake.returns({
-              Booster: {
-                config: config,
-                configuredEnvironments: new Set(['test']),
-                configureCurrentEnv: fake.yields(config),
-              },
-            })
-          ),
-        ]
-
-        replace(environment, 'currentEnvironment', fake.returns('test'))
-        replace(dependencies, 'pruneDevDependencies', fake())
-
-        await expect(configService.compileProjectAndLoadConfig({ prduction: true })).to.eventually.become(config)
-
-        expect(dependencies.pruneDevDependencies).not.to.have.been.called
-
-        rewires.forEach((fn) => fn())
-      })
-    })
-
-    context('when the production option is set to `true`', () => {
-      it('prunes devDependencies', async () => {
-        const config = new BoosterConfig('test')
-
-        const rewires = [
-          configService.__set__('compileProject', fake()),
-          configService.__set__(
-            'loadUserProject',
-            fake.returns({
-              Booster: {
-                config: config,
-                configuredEnvironments: new Set(['test']),
-                configureCurrentEnv: fake.yields(config),
-              },
-            })
-          ),
-        ]
-
-        replace(environment, 'currentEnvironment', fake.returns('test'))
-        replace(dependencies, 'pruneDevDependencies', fake())
-
-        await expect(configService.compileProjectAndLoadConfig({ production: true })).to.eventually.become(config)
-
-        expect(dependencies.pruneDevDependencies).to.have.been.calledOnce
-
-        rewires.forEach((fn) => fn())
-      })
-    })
-
     it('throws the right error when there are not configured environments', async () => {
       const config = new BoosterConfig('test')
 

--- a/packages/cli/test/services/dependencies.test.ts
+++ b/packages/cli/test/services/dependencies.test.ts
@@ -1,6 +1,6 @@
 import * as childProcessPromise from 'child-process-promise'
 import { fake, replace, restore } from 'sinon'
-import { installAllDependencies, pruneDevDependencies } from '../../src/services/dependencies'
+import { installDependencies, pruneDevDependencies } from '../../src/services/dependencies'
 import { expect } from '../expect'
 
 describe('dependencies service', () => {
@@ -25,13 +25,12 @@ describe('dependencies service', () => {
       await expect(pruneDevDependencies()).to.eventually.be.rejectedWith(/Could not prune dev dependencies/)
     })
   })
-
-  describe('installAllDependencies', () => {
+  describe('installDependencies', () => {
     context('without passing a path', () => {
       it('installs dependencies in dev mode in the current directory', async () => {
         replace(childProcessPromise, 'exec', fake.resolves({}))
 
-        await expect(installAllDependencies()).to.eventually.be.fulfilled
+        await expect(installDependencies()).to.eventually.be.fulfilled
 
         expect(childProcessPromise.exec).to.have.been.calledWithMatch('npm install', { cwd: process.cwd() })
       })
@@ -41,7 +40,7 @@ describe('dependencies service', () => {
       it('installs dependencies in dev mode in the passed path', async () => {
         replace(childProcessPromise, 'exec', fake.resolves({}))
 
-        await expect(installAllDependencies('somewhere')).to.eventually.be.fulfilled
+        await expect(installDependencies('somewhere')).to.eventually.be.fulfilled
 
         expect(childProcessPromise.exec).to.have.been.calledWithMatch('npm install', { cwd: 'somewhere' })
       })
@@ -52,7 +51,7 @@ describe('dependencies service', () => {
 
       replace(childProcessPromise, 'exec', fake.rejects(error))
 
-      await expect(installAllDependencies()).to.eventually.be.rejectedWith(/Could not install dependencies/)
+      await expect(installDependencies()).to.eventually.be.rejectedWith(/Could not install dependencies/)
     })
   })
 })

--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -219,7 +219,6 @@ describe('Project', () => {
     const cartDemoPackageJsonObject = JSON.parse(cartDemoPackageJsonContent)
     expect(cartDemoPackageJsonObject['dependencies']['@boostercloud/framework-core']).to.equal(`^${BOOSTER_VERSION}`)
     expect(cartDemoPackageJsonObject['dependencies']['@boostercloud/framework-types']).to.equal(`^${BOOSTER_VERSION}`)
-    expect(cartDemoPackageJsonObject['devDependencies']['@boostercloud/cli']).to.equal(`^${BOOSTER_VERSION}`)
 
     const expectedCartDemoTsConfigEslint = loadFixture('cart-demo/tsconfig.eslint.json')
     const cartDemoTsConfigEslintContent = fileContents('tsconfig.eslint.json')

--- a/packages/framework-integration-tests/integration/expect.ts
+++ b/packages/framework-integration-tests/integration/expect.ts
@@ -1,0 +1,6 @@
+import * as chai from 'chai'
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+
+export const expect = chai.expect

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/package.json
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/package.json
@@ -9,7 +9,6 @@
     "@boostercloud/framework-provider-aws": "whatever"
   },
   "devDependencies": {
-    "@boostercloud/cli": "whatever",
     "rimraf": "whatever",
     "@typescript-eslint/eslint-plugin": "whatever",
     "@typescript-eslint/parser": "whatever",

--- a/packages/framework-integration-tests/integration/providers/aws/functionality/auth.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/functionality/auth.integration.ts
@@ -16,14 +16,11 @@ import {
   graphQLClient,
 } from '../utils'
 import gql from 'graphql-tag'
-import { expect } from 'chai'
-import * as chai from 'chai'
+import { expect } from '../../../expect'
 import { random, internet, finance, lorem, phone } from 'faker'
 import fetch from 'cross-fetch'
 import { ApolloClient } from 'apollo-client'
 import { NormalizedCacheObject } from 'apollo-cache-inmemory'
-
-chai.use(require('chai-as-promised'))
 
 describe('With the auth API', () => {
   let mockProductId: string
@@ -39,11 +36,11 @@ describe('With the auth API', () => {
   context('an internet rando', () => {
     let client: DisconnectableApolloClient
 
-    before(async () => {
+    beforeEach(async () => {
       client = await graphQLClientWithSubscriptions()
     })
 
-    after(() => {
+    afterEach(() => {
       client.disconnect()
     })
 

--- a/packages/framework-integration-tests/integration/providers/aws/functionality/cors.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/functionality/cors.integration.ts
@@ -1,7 +1,7 @@
 import { authClientID, createPassword, signInURL, signOutURL, signUpURL } from '../utils'
 import { internet } from 'faker'
 import fetch from 'cross-fetch'
-import { expect } from '@boostercloud/framework-provider-aws/test/expect'
+import { expect } from '../../../expect'
 
 describe('Given the Authentication API', () => {
   let clientId: string
@@ -84,7 +84,6 @@ describe('Given the Authentication API', () => {
       })
 
       context('POST', () => {
-
         it('should return the Access-Control-Allow-Origin header for 200 responses', async () => {
           const response = await fetch(signInUrl, {
             method: 'POST',


### PR DESCRIPTION
## Description

We've been having issues with local and aws integration tests because the published versions were used or deployed instead of the versions under development. This should unblock some PRs that are blocked because integration tests don't pass (as they're using old versions.

> These changes were rescued from a #528, which is now closed, as switching to npm miraculously fixed the "prune devDependencies" process 🎉 

## Changes

* Replaced calls to `yarn add link:...` by `npm install file:...` to install the actual packages in the project's `node_modules` instead of just symlinking them
* Renamed the function that 

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
 
## TODO

This change depends on #545, so we'll need to fix the tests in that branch before finishing and merging this code.
- [ ] Fix unit and integration tests
