### PR TITLE
541 refactor GraphQLGenerator class

### DIFF
--- a/packages/framework-core/src/booster-graphql-dispatcher.ts
+++ b/packages/framework-core/src/booster-graphql-dispatcher.ts
@@ -26,7 +26,7 @@ export class BoosterGraphQLDispatcher {
 
   public constructor(private config: BoosterConfig, private logger: Logger) {
     this.readModelDispatcher = new BoosterReadModelDispatcher(config, logger)
-    this.graphQLSchema = GraphQLGenerator.getInstance(config, logger).generateSchema()
+    this.graphQLSchema = GraphQLGenerator.build(config, logger).generateSchema()
     this.boosterTokenVerifier = new BoosterTokenVerifier(config)
     this.websocketHandler = new GraphQLWebsocketHandler(
       config,

--- a/packages/framework-core/src/booster-graphql-dispatcher.ts
+++ b/packages/framework-core/src/booster-graphql-dispatcher.ts
@@ -10,7 +10,6 @@ import {
 import { GraphQLSchema, DocumentNode, ExecutionResult, GraphQLError } from 'graphql'
 import * as graphql from 'graphql'
 import { GraphQLGenerator } from './services/graphql/graphql-generator'
-import { BoosterCommandDispatcher } from './booster-command-dispatcher'
 import { BoosterReadModelDispatcher } from './booster-read-model-dispatcher'
 import { GraphQLResolverContext, graphQLWebsocketSubprotocolHeaders } from './services/graphql/common'
 import { NoopReadModelPubSub } from './services/pub-sub/noop-read-model-pub-sub'
@@ -27,9 +26,7 @@ export class BoosterGraphQLDispatcher {
 
   public constructor(private config: BoosterConfig, private logger: Logger) {
     this.readModelDispatcher = new BoosterReadModelDispatcher(config, logger)
-    const commandDispatcher = new BoosterCommandDispatcher(config, logger)
-
-    this.graphQLSchema = new GraphQLGenerator(config, commandDispatcher, this.readModelDispatcher).generateSchema()
+    this.graphQLSchema = GraphQLGenerator.getInstance(config, logger).generateSchema()
     this.boosterTokenVerifier = new BoosterTokenVerifier(config)
     this.websocketHandler = new GraphQLWebsocketHandler(
       config,

--- a/packages/framework-core/src/booster-subscribers-notifier.ts
+++ b/packages/framework-core/src/booster-subscribers-notifier.ts
@@ -19,7 +19,7 @@ export class BoosterSubscribersNotifier {
   private readonly graphQLSchema: GraphQLSchema
 
   public constructor(private config: BoosterConfig, private logger: Logger) {
-    this.graphQLSchema = GraphQLGenerator.getInstance(config,logger).generateSchema()
+    this.graphQLSchema = GraphQLGenerator.getInstance(config, logger).generateSchema()
   }
 
   public async dispatch(request: unknown): Promise<void> {

--- a/packages/framework-core/src/booster-subscribers-notifier.ts
+++ b/packages/framework-core/src/booster-subscribers-notifier.ts
@@ -11,8 +11,6 @@ import {
 import { GraphQLSchema, DocumentNode } from 'graphql'
 import * as graphql from 'graphql'
 import { GraphQLGenerator } from './services/graphql/graphql-generator'
-import { BoosterCommandDispatcher } from './booster-command-dispatcher'
-import { BoosterReadModelDispatcher } from './booster-read-model-dispatcher'
 import { FilteredReadModelPubSub, ReadModelPubSub } from './services/pub-sub/read-model-pub-sub'
 import { GraphQLResolverContext } from './services/graphql/common'
 import { ExecutionResult } from 'graphql/execution/execute'
@@ -21,11 +19,7 @@ export class BoosterSubscribersNotifier {
   private readonly graphQLSchema: GraphQLSchema
 
   public constructor(private config: BoosterConfig, private logger: Logger) {
-    this.graphQLSchema = new GraphQLGenerator(
-      config,
-      new BoosterCommandDispatcher(config, logger),
-      new BoosterReadModelDispatcher(config, logger)
-    ).generateSchema()
+    this.graphQLSchema = GraphQLGenerator.getInstance(config,logger).generateSchema()
   }
 
   public async dispatch(request: unknown): Promise<void> {

--- a/packages/framework-core/src/booster-subscribers-notifier.ts
+++ b/packages/framework-core/src/booster-subscribers-notifier.ts
@@ -19,7 +19,7 @@ export class BoosterSubscribersNotifier {
   private readonly graphQLSchema: GraphQLSchema
 
   public constructor(private config: BoosterConfig, private logger: Logger) {
-    this.graphQLSchema = GraphQLGenerator.getInstance(config, logger).generateSchema()
+    this.graphQLSchema = GraphQLGenerator.build(config, logger).generateSchema()
   }
 
   public async dispatch(request: unknown): Promise<void> {

--- a/packages/framework-core/src/services/graphql/graphql-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-generator.ts
@@ -21,17 +21,14 @@ export class GraphQLGenerator {
   private readonly subscriptionGenerator: GraphQLSubscriptionGenerator
   private readonly typeInformer: GraphQLTypeInformer
 
-  private static singleton: GraphQLGenerator | undefined = undefined
+  private static singleton: GraphQLGenerator | undefined
   
   public static getInstance(config: BoosterConfig, logger: Logger): GraphQLGenerator {
-    if (this.singleton === undefined) {
-      this.singleton = new GraphQLGenerator(
-        config,
-        new BoosterCommandDispatcher(config, logger),
-        new BoosterReadModelDispatcher(config, logger)
-      )
-    }
-    return this.singleton;
+    return this.singleton ?? new GraphQLGenerator(
+      config,
+      new BoosterCommandDispatcher(config, logger),
+      new BoosterReadModelDispatcher(config, logger)
+    )
   }
 
   private constructor(

--- a/packages/framework-core/src/services/graphql/graphql-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-generator.ts
@@ -34,7 +34,7 @@ export class GraphQLGenerator {
     return this.singleton;
   }
 
-  public constructor(
+  private constructor(
     config: BoosterConfig,
     private commandsDispatcher: BoosterCommandDispatcher,
     private readModelsDispatcher: BoosterReadModelDispatcher

--- a/packages/framework-core/src/services/graphql/graphql-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-generator.ts
@@ -1,5 +1,6 @@
 import {
   AnyClass,
+  Logger,
   BoosterConfig,
   CommandEnvelope,
   ReadModelPropertyFilter,
@@ -19,6 +20,19 @@ export class GraphQLGenerator {
   private readonly mutationGenerator: GraphQLMutationGenerator
   private readonly subscriptionGenerator: GraphQLSubscriptionGenerator
   private readonly typeInformer: GraphQLTypeInformer
+
+  private static singleton: GraphQLGenerator | undefined = undefined
+
+  public static getInstance(config: BoosterConfig, logger: Logger): GraphQLGenerator {
+    if (this.singleton === undefined) {
+      this.singleton = new GraphQLGenerator(
+        config,
+        new BoosterCommandDispatcher(config, logger),
+        new BoosterReadModelDispatcher(config, logger)
+      )
+    }
+    return this.singleton;
+  }
 
   public constructor(
     config: BoosterConfig,

--- a/packages/framework-core/src/services/graphql/graphql-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-generator.ts
@@ -24,11 +24,12 @@ export class GraphQLGenerator {
   private static singleton: GraphQLGenerator | undefined
   
   public static getInstance(config: BoosterConfig, logger: Logger): GraphQLGenerator {
-    return this.singleton ?? new GraphQLGenerator(
+    this.singleton = this.singleton ?? new GraphQLGenerator(
       config,
       new BoosterCommandDispatcher(config, logger),
       new BoosterReadModelDispatcher(config, logger)
     )
+    return this.singleton
   }
 
   private constructor(

--- a/packages/framework-core/src/services/graphql/graphql-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-generator.ts
@@ -23,7 +23,7 @@ export class GraphQLGenerator {
 
   private static singleton: GraphQLGenerator | undefined
   
-  public static getInstance(config: BoosterConfig, logger: Logger): GraphQLGenerator {
+  public static build(config: BoosterConfig, logger: Logger): GraphQLGenerator {
     this.singleton = this.singleton ?? new GraphQLGenerator(
       config,
       new BoosterCommandDispatcher(config, logger),

--- a/packages/framework-core/src/services/graphql/graphql-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-generator.ts
@@ -22,7 +22,7 @@ export class GraphQLGenerator {
   private readonly typeInformer: GraphQLTypeInformer
 
   private static singleton: GraphQLGenerator | undefined = undefined
-
+  
   public static getInstance(config: BoosterConfig, logger: Logger): GraphQLGenerator {
     if (this.singleton === undefined) {
       this.singleton = new GraphQLGenerator(

--- a/packages/framework-core/test/services/graphql/graphql-generator.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-generator.test.ts
@@ -20,25 +20,25 @@ describe('GraphQL generator', () => {
     mockEnvironmentName = random.alphaNumeric(10)
     mockConfig = new BoosterConfig(mockEnvironmentName)
     mockLogger = buildLogger(Level.error)
-    sut = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+    sut = GraphQLGenerator.build(mockConfig, mockLogger)
   })
 
   afterEach(() => {
     restore()
   })
 
-  describe('getInstance', () => {
+  describe('build', () => {
     
     it('should create the instance', () => {
-      const instance = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+      const instance = GraphQLGenerator.build(mockConfig, mockLogger)
 
       expect(instance).to.not.be.undefined
       expect(instance).to.be.an.instanceOf(GraphQLGenerator)
     })
 
     it('should return always the same instance', () => {
-      const instance1 = GraphQLGenerator.getInstance(mockConfig, mockLogger)
-      const instance2 = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+      const instance1 = GraphQLGenerator.build(mockConfig, mockLogger)
+      const instance2 = GraphQLGenerator.build(mockConfig, mockLogger)
 
       expect(instance1).to.not.be.undefined
       expect(instance1).to.be.an.instanceOf(GraphQLGenerator)
@@ -148,7 +148,7 @@ describe('GraphQL generator', () => {
       beforeEach(() => {
         fetchStub = stub().resolves(mockFetchResult)
         replace(BoosterReadModelDispatcher.prototype,'fetch',fetchStub)
-        sut = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+        sut = GraphQLGenerator.build(mockConfig, mockLogger)
 
         returnedFunction = sut.readModelResolverBuilder(mockType)
       })
@@ -229,7 +229,7 @@ describe('GraphQL generator', () => {
 
         dispatchCommandStub = stub()
         replace(BoosterCommandDispatcher.prototype,'dispatchCommand', dispatchCommandStub)
-        sut = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+        sut = GraphQLGenerator.build(mockConfig, mockLogger)
 
         returnedFunction = sut.commandResolverBuilder(mockType)
       })
@@ -326,7 +326,7 @@ describe('GraphQL generator', () => {
         asyncIteratorStub = stub().returns(mockAsyncIteratorResult)
 
         replace(BoosterReadModelDispatcher.prototype,'subscribe', subscribeStub)
-        sut = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+        sut = GraphQLGenerator.build(mockConfig, mockLogger)
 
         returnedFunction = sut.subscriptionResolverBuilder(mockType)
       })

--- a/packages/framework-core/test/services/graphql/graphql-generator.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-generator.test.ts
@@ -1,6 +1,5 @@
-import { SinonStubbedInstance, replace, restore, SinonStub, stub } from 'sinon'
+import { replace, restore, SinonStub, stub } from 'sinon'
 import { BoosterCommandDispatcher } from '../../../src/booster-command-dispatcher'
-import sinon = require('sinon')
 import { BoosterReadModelDispatcher } from '../../../src/booster-read-model-dispatcher'
 import { GraphQLGenerator } from '../../../src/services/graphql/graphql-generator'
 import { BoosterConfig, ReadModelInterface, Logger, Level } from '@boostercloud/framework-types/dist'
@@ -15,24 +14,38 @@ describe('GraphQL generator', () => {
   let mockEnvironmentName: string
   let mockConfig: BoosterConfig
   let mockLogger: Logger
-
-  let commandDispatcherStub: SinonStubbedInstance<BoosterCommandDispatcher>
-  let readModelDispatcherStub: SinonStubbedInstance<BoosterReadModelDispatcher>
-
   let sut: GraphQLGenerator
 
   beforeEach(() => {
     mockEnvironmentName = random.alphaNumeric(10)
     mockConfig = new BoosterConfig(mockEnvironmentName)
-
-    commandDispatcherStub = sinon.createStubInstance(BoosterCommandDispatcher)
-    readModelDispatcherStub = sinon.createStubInstance(BoosterReadModelDispatcher)
-
-    sut = new GraphQLGenerator(mockConfig, commandDispatcherStub, readModelDispatcherStub as any)
+    mockLogger = buildLogger(Level.error)
+    sut = GraphQLGenerator.getInstance(mockConfig, mockLogger)
   })
 
   afterEach(() => {
     restore()
+  })
+
+  describe('getInstance', () => {
+    
+    it('should create the instance', () => {
+      const instance = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+
+      expect(instance).to.not.be.undefined
+      expect(instance).to.be.an.instanceOf(GraphQLGenerator)
+    })
+
+    it('should return always the same instance', () => {
+      const instance1 = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+      const instance2 = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+
+      expect(instance1).to.not.be.undefined
+      expect(instance1).to.be.an.instanceOf(GraphQLGenerator)
+      expect(instance2).to.not.be.undefined
+      expect(instance2).to.be.an.instanceOf(GraphQLGenerator)
+      expect(instance1).to.be.eq(instance2)
+    })
   })
 
   describe('generateSchema', () => {
@@ -134,11 +147,8 @@ describe('GraphQL generator', () => {
 
       beforeEach(() => {
         fetchStub = stub().resolves(mockFetchResult)
-
-        readModelDispatcherStub = sinon.createStubInstance(BoosterReadModelDispatcher)
-        replace(readModelDispatcherStub, 'fetch', fetchStub as any)
-
-        sut = new GraphQLGenerator(mockConfig, commandDispatcherStub, readModelDispatcherStub as any)
+        replace(BoosterReadModelDispatcher.prototype,'fetch',fetchStub)
+        sut = GraphQLGenerator.getInstance(mockConfig, mockLogger)
 
         returnedFunction = sut.readModelResolverBuilder(mockType)
       })
@@ -218,11 +228,8 @@ describe('GraphQL generator', () => {
         }
 
         dispatchCommandStub = stub()
-
-        readModelDispatcherStub = sinon.createStubInstance(BoosterReadModelDispatcher)
-        replace(commandDispatcherStub, 'dispatchCommand', dispatchCommandStub as any)
-
-        sut = new GraphQLGenerator(mockConfig, commandDispatcherStub, readModelDispatcherStub as any)
+        replace(BoosterCommandDispatcher.prototype,'dispatchCommand', dispatchCommandStub)
+        sut = GraphQLGenerator.getInstance(mockConfig, mockLogger)
 
         returnedFunction = sut.commandResolverBuilder(mockType)
       })
@@ -318,10 +325,8 @@ describe('GraphQL generator', () => {
         subscribeStub = stub().resolves()
         asyncIteratorStub = stub().returns(mockAsyncIteratorResult)
 
-        readModelDispatcherStub = sinon.createStubInstance(BoosterReadModelDispatcher)
-        replace(readModelDispatcherStub, 'subscribe', subscribeStub as any)
-
-        sut = new GraphQLGenerator(mockConfig, commandDispatcherStub, readModelDispatcherStub as any)
+        replace(BoosterReadModelDispatcher.prototype,'subscribe', subscribeStub)
+        sut = GraphQLGenerator.getInstance(mockConfig, mockLogger)
 
         returnedFunction = sut.subscriptionResolverBuilder(mockType)
       })
@@ -384,31 +389,6 @@ describe('GraphQL generator', () => {
 
         expect(result).to.be.equal(mockAsyncIteratorResult)
       })
-    })
-  })
-
-  describe('getInstance', () => {
-
-    before(() => {
-      mockLogger = buildLogger(Level.error)
-    })
-    
-    it('should create the instance', () => {
-      const instance = GraphQLGenerator.getInstance(mockConfig, mockLogger)
-
-      expect(instance).to.not.be.undefined
-      expect(instance).to.be.an.instanceOf(GraphQLGenerator)
-    })
-
-    it('should return always the same instance', () => {
-      const instance1 = GraphQLGenerator.getInstance(mockConfig, mockLogger)
-      const instance2 = GraphQLGenerator.getInstance(mockConfig, mockLogger)
-
-      expect(instance1).to.not.be.undefined
-      expect(instance1).to.be.an.instanceOf(GraphQLGenerator)
-      expect(instance2).to.not.be.undefined
-      expect(instance2).to.be.an.instanceOf(GraphQLGenerator)
-      expect(instance1).to.be.eq(instance2)
     })
   })
 })

--- a/packages/framework-core/test/services/graphql/graphql-generator.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-generator.test.ts
@@ -3,16 +3,18 @@ import { BoosterCommandDispatcher } from '../../../src/booster-command-dispatche
 import sinon = require('sinon')
 import { BoosterReadModelDispatcher } from '../../../src/booster-read-model-dispatcher'
 import { GraphQLGenerator } from '../../../src/services/graphql/graphql-generator'
-import { BoosterConfig, ReadModelInterface } from '@boostercloud/framework-types/dist'
+import { BoosterConfig, ReadModelInterface, Logger, Level } from '@boostercloud/framework-types/dist'
 import { expect } from '../../expect'
 import { GraphQLQueryGenerator } from '../../../src/services/graphql/graphql-query-generator'
 import { GraphQLMutationGenerator } from '../../../src/services/graphql/graphql-mutation-generator'
 import { GraphQLSubscriptionGenerator } from '../../../src/services/graphql/graphql-subcriptions-generator'
 import { random, internet, lorem } from 'faker'
+import { buildLogger } from '../../../src/booster-logger';
 
 describe('GraphQL generator', () => {
   let mockEnvironmentName: string
   let mockConfig: BoosterConfig
+  let mockLogger: Logger
 
   let commandDispatcherStub: SinonStubbedInstance<BoosterCommandDispatcher>
   let readModelDispatcherStub: SinonStubbedInstance<BoosterReadModelDispatcher>
@@ -382,6 +384,31 @@ describe('GraphQL generator', () => {
 
         expect(result).to.be.equal(mockAsyncIteratorResult)
       })
+    })
+  })
+
+  describe('getInstance', () => {
+
+    before(() => {
+      mockLogger = buildLogger(Level.error)
+    })
+    
+    it('should create the instance', () => {
+      const instance = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+
+      expect(instance).to.not.be.undefined
+      expect(instance).to.be.an.instanceOf(GraphQLGenerator)
+    })
+
+    it('should return always the same instance', () => {
+      const instance1 = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+      const instance2 = GraphQLGenerator.getInstance(mockConfig, mockLogger)
+
+      expect(instance1).to.not.be.undefined
+      expect(instance1).to.be.an.instanceOf(GraphQLGenerator)
+      expect(instance2).to.not.be.undefined
+      expect(instance2).to.be.an.instanceOf(GraphQLGenerator)
+      expect(instance1).to.be.eq(instance2)
     })
   })
 })


### PR DESCRIPTION
## Description
Refactor GraphQLGenerator class to access it in a uniform way. Applying Singleton pattern. Since config: BoosterConfig is declared as static in Booster class, all classes that access config access the same instance of BoosterConfig. Taking that into account, the design has been simplified.

Fixes #541 

## Changes
- I made this class initialized via a Singleton getInstance() method
- Client classes get the GraphQLGenerator singleton instance to use it
- Update unit tests

<img width="832" alt="image" src="https://user-images.githubusercontent.com/7900069/104730203-84ebec00-5731-11eb-8346-eea77dc62c60.png">

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [] Updated documentation accordingly
 
## Additional information
