### PR TITLE
Fake provider for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -98,3 +98,15 @@ jobs:
       - run: npx lerna bootstrap
       - run: npx lerna run compile
       - run: npx lerna run integration/local --stream
+
+  fake-integration-tests:
+    name: Fake Environment Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: npx lerna bootstrap
+      - run: npx lerna run compile
+      - run: npx lerna run integration/fake --stream

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -290,6 +290,27 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Fake Integration Tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--colors",
+        "--forbid-only",
+        "--config",
+        "${workspaceFolder}/packages/framework-integration-tests/integration/providers/fake/.mocharc.yml",
+        "${workspaceFolder}/packages/framework-integration-tests/integration/providers/fake/**/*.integration.ts"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "protocol": "inspector",
+      "cwd": "${workspaceFolder}/packages/framework-integration-tests",
+      "runtimeArgs": ["--preserve-symlinks"],
+      "env": {
+        "BOOSTER_ENV": "fake"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "framework-provider-kubernetes tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [

--- a/packages/framework-core/src/booster-graphql-dispatcher.ts
+++ b/packages/framework-core/src/booster-graphql-dispatcher.ts
@@ -107,6 +107,11 @@ export class BoosterGraphQLDispatcher {
       }
 
       const queryDocument = graphql.parse(operation.query)
+      this.logger.debug(
+        `Validating Query Document\n\n  Query Document: ${JSON.stringify(queryDocument)}\n\n  Schema: ${JSON.stringify(
+          this.graphQLSchema
+        )}`
+      )
       const errors = graphql.validate(this.graphQLSchema, queryDocument)
       if (errors.length > 0) {
         throw errors

--- a/packages/framework-integration-tests/integration/providers/fake/.mocharc.yml
+++ b/packages/framework-integration-tests/integration/providers/fake/.mocharc.yml
@@ -1,0 +1,12 @@
+diff: true
+require: 'ts-node/register'
+extension:
+  - ts
+package: './package.json'
+recursive: true
+reporter: 'spec'
+timeout: 600000
+file:
+  - './integration/providers/fake/setup.ts'
+full-trace: true
+bail: true

--- a/packages/framework-integration-tests/integration/providers/fake/application-helper.ts
+++ b/packages/framework-integration-tests/integration/providers/fake/application-helper.ts
@@ -1,0 +1,7 @@
+import * as path from 'path'
+import { sandboxPath } from './constants'
+import { BoosterApp } from '@boostercloud/framework-types'
+
+export function loadBoosterApp(): BoosterApp {
+  return require(path.join(sandboxPath, 'dist', 'index.js')).Booster
+}

--- a/packages/framework-integration-tests/integration/providers/fake/commands.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/fake/commands.integration.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai'
+import { loadBoosterApp } from './application-helper'
+
+describe('commands', () => {
+  context('a valid command', () => {
+    xit('should be properly executed', () => {
+      const app = loadBoosterApp()
+
+      expect(app).not.to.be.null
+    })
+  })
+})

--- a/packages/framework-integration-tests/integration/providers/fake/constants.ts
+++ b/packages/framework-integration-tests/integration/providers/fake/constants.ts
@@ -1,0 +1,2 @@
+export const sandboxName = 'fake-provider'
+export const sandboxPath = `${sandboxName}-integration-sandbox`

--- a/packages/framework-integration-tests/integration/providers/fake/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/fake/setup.ts
@@ -1,0 +1,19 @@
+import { createSandboxProject, removeFolders } from '../../helper/fileHelper'
+import { runCommand } from '../../helper/runCommand'
+import { sandboxName } from './constants'
+
+let sandboxPath: string
+
+before(async () => {
+  console.log('preparing sandboxed project...')
+  sandboxPath = await createSandboxProject(sandboxName)
+  console.log(`Created sandbox named "${sandboxPath}"`)
+
+  console.log('installing dependencies...')
+  await runCommand(sandboxPath, 'npm install')
+})
+
+after(async () => {
+  console.log('removing sandbox project')
+  removeFolders([sandboxPath])
+})

--- a/packages/framework-integration-tests/package.json
+++ b/packages/framework-integration-tests/package.json
@@ -16,6 +16,7 @@
     "@boostercloud/framework-types": "^0.9.3"
   },
   "devDependencies": {
+    "typescript": "3.9.4",
     "@boostercloud/framework-provider-aws-infrastructure": "^0.9.3",
     "@boostercloud/framework-provider-local-infrastructure": "^0.9.3",
     "@types/aws-lambda": "8.10.48",
@@ -48,11 +49,12 @@
     "lint:fix": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
     "compile": "tsc -b tsconfig.json",
     "clean": "npx rimraf ./dist tsconfig.tsbuildinfo",
-    "integration": "npm run integration/cli && npm run integration/local && npm run integration/aws-deploy && npm run integration/aws-func && npm run integration/end-to-end && npm run integration/aws-nuke",
+    "integration": "npm run integration/cli && npm run integration/fake && npm run integration/local && npm run integration/aws-deploy && npm run integration/aws-func && npm run integration/end-to-end && npm run integration/aws-nuke",
     "integration/aws-deploy": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --full-stack --exit --config \"integration/providers/aws/deployment/.mocharc.yml\" \"integration/providers/aws/deployment/**/*.integration.ts\"",
     "integration/aws-func": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --full-stack --exit --config \"integration/providers/aws/functionality/.mocharc.yml\" \"integration/providers/aws/functionality/**/*.integration.ts\"",
     "integration/aws-nuke": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --full-stack --exit --config \"integration/providers/aws/nuke/.mocharc.yml\" \"integration/providers/aws/nuke/**/*.integration.ts\"",
     "integration/local": "BOOSTER_ENV=local mocha --forbid-only --full-stack --exit --config \"integration/providers/local/.mocharc.yml\" \"integration/providers/local/**/*.integration.ts\"",
+    "integration/fake": "BOOSTER_ENV=fake mocha --forbid-only --full-stack --exit --config \"integration/providers/fake/.mocharc.yml\" \"integration/providers/fake/**/*.integration.ts\"",
     "integration/cli": "mocha --forbid-only --full-stack --exit --config \"integration/cli/.mocharc.yml\" \"integration/cli/**/*.integration.ts\"",
     "integration/end-to-end": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --full-stack --exit --config \"integration/end-to-end/.mocharc.yml\" \"integration/end-to-end/**/*.integration.ts\""
   },

--- a/packages/framework-integration-tests/src/config/config.ts
+++ b/packages/framework-integration-tests/src/config/config.ts
@@ -1,6 +1,7 @@
 import { Booster } from '@boostercloud/framework-core'
 import { BoosterConfig } from '@boostercloud/framework-types'
 import * as AWS from '@boostercloud/framework-provider-aws'
+import { FakeProvider } from '../fake-provider/fake-provider'
 
 // TODO: After prunning `devDependencies` to deploy the project to lambda, we cannot import the local provider anymore. We should look for a better solution than this, maybe loading a different config file depending on the configured environment in BOOSTER_ENV
 if (process.env.BOOSTER_ENV === 'local') {
@@ -15,6 +16,11 @@ if (process.env.BOOSTER_ENV === 'local') {
 Booster.configure('development', (config: BoosterConfig): void => {
   config.appName = 'my-store'
   config.provider = AWS.Provider()
+})
+
+Booster.configure('fake', (config: BoosterConfig): void => {
+  config.appName = 'my-store'
+  config.provider = FakeProvider // For integration tests only
 })
 
 Booster.configure('production', (config: BoosterConfig): void => {

--- a/packages/framework-integration-tests/src/fake-provider/fake-provider.ts
+++ b/packages/framework-integration-tests/src/fake-provider/fake-provider.ts
@@ -1,0 +1,5 @@
+import { ProviderLibrary } from '@boostercloud/framework-types'
+
+// Only the objects/methods involved in tests will be implemented here
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const FakeProvider: ProviderLibrary = {} as any


### PR DESCRIPTION
## Description

Current provider integration tests are pure black-box tests where one application is actually deployed to the provider and run through the Booster and provider's APIs to check that everything goes as expected. These tests are great but there's one thing they don't easily allow: Debugging the code as it's run in the provider.

## Changes

In this PR I introduce the concept of the "Fake provider", which is just a JS module that simulates the different operations that are provider-specific. This should allow us to run an integration tests suite locally, to simulate how the framework would behave in a lambda function. This will help us to debug sneaky things like how Booster builds the different objects in the `BoosterConfig` object under different environment circumstances, which are hard to debug with the current testing schemas.

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
 
## Additional information
