### PR TITLE
Fix for lambda size problem (and probably others related to dependencies)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ coverage
 scripts/mirroring.js
 .docs
 .booster
+.deploy
 *-integration-sandbox

--- a/package-lock.json
+++ b/package-lock.json
@@ -4703,9 +4703,9 @@
 			}
 		},
 		"@types/lodash": {
-			"version": "4.14.167",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
-			"integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw=="
+			"version": "4.14.168",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+			"integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
 		},
 		"@types/mime": {
 			"version": "2.0.3",
@@ -4741,8 +4741,7 @@
 		"@types/mocha": {
 			"version": "5.2.7",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
-			"dev": true
+			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
 		},
 		"@types/mustache": {
 			"version": "4.1.0",
@@ -4779,11 +4778,18 @@
 				}
 			}
 		},
+		"@types/nock": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/@types/nock/-/nock-11.1.0.tgz",
+			"integrity": "sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==",
+			"requires": {
+				"nock": "*"
+			}
+		},
 		"@types/node": {
 			"version": "14.14.20",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
-			"integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
-			"dev": true
+			"integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
 		},
 		"@types/node-fetch": {
 			"version": "2.5.8",
@@ -4889,8 +4895,7 @@
 		"@types/sinon": {
 			"version": "7.5.2",
 			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
-			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
-			"dev": true
+			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg=="
 		},
 		"@types/sinon-chai": {
 			"version": "3.2.5",
@@ -10961,33 +10966,19 @@
 			"integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw=="
 		},
 		"fancy-test": {
-			"version": "1.4.10",
-			"resolved": "https://registry.npmjs.org/fancy-test/-/fancy-test-1.4.10.tgz",
-			"integrity": "sha512-AaUX6wKS7D5OP2YK2q5G7c8PGx2lgoyLUD7Bbg8z323sb9aebBqzb9UN6phzI73UgO/ViihmNfOxF3kdfZLhew==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/fancy-test/-/fancy-test-1.4.3.tgz",
+			"integrity": "sha512-Lt3mcQ0jn9Kg9JDmobVb4ZANiyT4e2VC5qbQvuzJVNYXyKjSgFWKn7bZN4BKei33v5jYWx28KlbDgsxuqnBRvg==",
 			"requires": {
 				"@types/chai": "*",
 				"@types/lodash": "*",
+				"@types/mocha": "*",
+				"@types/nock": "*",
 				"@types/node": "*",
 				"@types/sinon": "*",
-				"lodash": "^4.17.13",
-				"mock-stdin": "^1.0.0",
-				"nock": "^13.0.0",
+				"lodash": "^4.17.11",
+				"mock-stdin": "^0.3.1",
 				"stdout-stderr": "^0.1.9"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "14.14.21",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.21.tgz",
-					"integrity": "sha512-cHYfKsnwllYhjOzuC5q1VpguABBeecUp24yFluHpn/BQaVxB1CuQ1FSRZCzrPxrkIfWISXV2LbeoBthLWg0+0A=="
-				},
-				"@types/sinon": {
-					"version": "9.0.10",
-					"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.10.tgz",
-					"integrity": "sha512-/faDC0erR06wMdybwI/uR8wEKV/E83T0k4sepIpB7gXuy2gzx2xiOjmztq6a2Y6rIGJ04D+6UU0VBmWy+4HEMA==",
-					"requires": {
-						"@types/sinonjs__fake-timers": "*"
-					}
-				}
 			}
 		},
 		"fast-check": {
@@ -14800,9 +14791,9 @@
 			}
 		},
 		"mock-stdin": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/mock-stdin/-/mock-stdin-1.0.0.tgz",
-			"integrity": "sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q=="
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/mock-stdin/-/mock-stdin-0.3.1.tgz",
+			"integrity": "sha1-xlfZZC2QeGQ1xkyl6Zu9TQm9fdM="
 		},
 		"modify-values": {
 			"version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4613,6 +4613,14 @@
 				}
 			}
 		},
+		"@types/graphql": {
+			"version": "14.5.0",
+			"resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.5.0.tgz",
+			"integrity": "sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==",
+			"requires": {
+				"graphql": "*"
+			}
+		},
 		"@types/graphql-type-json": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@types/graphql-type-json/-/graphql-type-json-0.3.2.tgz",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "@types/rewire": "^2.5.28",
     "chai": "4.2.0",
     "sinon":"9.2.3",
+    "fancy-test": "1.4.3",
     "chai-as-promised": "7.1.1",
     "faker": "5.1.0",
     "rewire": "5.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,6 +39,7 @@
     "@types/mustache": "4.1.0",
     "@types/rewire": "^2.5.28",
     "chai": "4.2.0",
+    "sinon":"9.2.3",
     "chai-as-promised": "7.1.1",
     "faker": "5.1.0",
     "rewire": "5.0.0",

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,12 +1,11 @@
 import { Command, flags } from '@oclif/command'
 import { deployToCloudProvider } from '../services/provider-service'
-import { compileProjectAndLoadConfig, DEPLOYMENT_SANDBOX } from '../services/config-service'
+import { cleanProjectFiles, compileProjectAndLoadConfig } from '../services/config-service'
 import { BoosterConfig, Logger } from '@boostercloud/framework-types'
 import { Script } from '../common/script'
 import Brand from '../common/brand'
 import { logger } from '../services/logger'
 import { currentEnvironment, initializeEnvironment } from '../services/environment'
-import { removeSandboxProject } from '../common/sandbox'
 
 const runTasks = async (
   skipRestoreDependencies: boolean,
@@ -15,7 +14,7 @@ const runTasks = async (
 ): Promise<void> =>
   Script.init(`boost ${Brand.dangerize('deploy')} [${currentEnvironment()}] 🚀`, compileAndLoad)
     .step('Deploying', (config) => deployer(config, logger))
-    .step('Cleaning up deployment files', async () => removeSandboxProject(DEPLOYMENT_SANDBOX))
+    .step('Cleaning up deployment files', cleanProjectFiles)
     .info('Deployment complete!')
     .done()
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -3,7 +3,7 @@ import { deployToCloudProvider } from '../services/provider-service'
 import {
   cleanProductionSandbox,
   compileProjectAndLoadConfig,
-  createProductionSandbox,
+  createDeploymentSandbox,
 } from '../services/config-service'
 import { BoosterConfig, Logger } from '@boostercloud/framework-types'
 import { Script } from '../common/script'
@@ -36,9 +36,8 @@ export default class Deploy extends Command {
     const { flags } = this.parse(Deploy)
 
     if (initializeEnvironment(logger, flags.environment)) {
-      const deploymentProjectPath = await createProductionSandbox()
-      process.chdir(deploymentProjectPath) // The deployment will work inside the production sandbox
-      await runTasks(compileProjectAndLoadConfig(), deployToCloudProvider)
+      const deploymentProjectPath = await createDeploymentSandbox()
+      await runTasks(compileProjectAndLoadConfig(deploymentProjectPath), deployToCloudProvider)
     }
   }
 }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,7 +1,7 @@
 import { Command, flags } from '@oclif/command'
 import { deployToCloudProvider } from '../services/provider-service'
 import {
-  cleanProductionSandbox,
+  cleanDeploymentSandbox,
   compileProjectAndLoadConfig,
   createDeploymentSandbox,
 } from '../services/config-service'
@@ -17,7 +17,7 @@ const runTasks = async (
 ): Promise<void> =>
   Script.init(`boost ${Brand.dangerize('deploy')} [${currentEnvironment()}] 🚀`, compileAndLoad)
     .step('Deploying', (config) => deployer(config, logger))
-    .step('Cleaning up deployment files', cleanProductionSandbox)
+    .step('Cleaning up deployment files', cleanDeploymentSandbox)
     .info('Deployment complete!')
     .done()
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,6 +1,10 @@
 import { Command, flags } from '@oclif/command'
 import { deployToCloudProvider } from '../services/provider-service'
-import { cleanProjectFiles, compileProjectAndLoadConfig } from '../services/config-service'
+import {
+  cleanProductionSandbox,
+  compileProjectAndLoadConfig,
+  createProductionSandbox,
+} from '../services/config-service'
 import { BoosterConfig, Logger } from '@boostercloud/framework-types'
 import { Script } from '../common/script'
 import Brand from '../common/brand'
@@ -13,7 +17,7 @@ const runTasks = async (
 ): Promise<void> =>
   Script.init(`boost ${Brand.dangerize('deploy')} [${currentEnvironment()}] 🚀`, compileAndLoad)
     .step('Deploying', (config) => deployer(config, logger))
-    .step('Cleaning up deployment files', cleanProjectFiles)
+    .step('Cleaning up deployment files', cleanProductionSandbox)
     .info('Deployment complete!')
     .done()
 
@@ -32,6 +36,8 @@ export default class Deploy extends Command {
     const { flags } = this.parse(Deploy)
 
     if (initializeEnvironment(logger, flags.environment)) {
+      const deploymentProjectPath = await createProductionSandbox()
+      process.chdir(deploymentProjectPath) // The deployment will work inside the production sandbox
       await runTasks(compileProjectAndLoadConfig(), deployToCloudProvider)
     }
   }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -8,7 +8,6 @@ import { logger } from '../services/logger'
 import { currentEnvironment, initializeEnvironment } from '../services/environment'
 
 const runTasks = async (
-  skipRestoreDependencies: boolean,
   compileAndLoad: Promise<BoosterConfig>,
   deployer: (config: BoosterConfig, logger: Logger) => Promise<void>
 ): Promise<void> =>
@@ -27,17 +26,13 @@ export default class Deploy extends Command {
       char: 'e',
       description: 'environment configuration to run',
     }),
-    skipRestoreDependencies: flags.boolean({
-      char: 's',
-      description: 'skips restoring dependencies after deployment',
-    }),
   }
 
   public async run(): Promise<void> {
     const { flags } = this.parse(Deploy)
 
     if (initializeEnvironment(logger, flags.environment)) {
-      await runTasks(flags.skipRestoreDependencies, compileProjectAndLoadConfig(), deployToCloudProvider)
+      await runTasks(compileProjectAndLoadConfig(), deployToCloudProvider)
     }
   }
 }

--- a/packages/cli/src/commands/new/command.ts
+++ b/packages/cli/src/commands/new/command.ts
@@ -12,7 +12,7 @@ import {
 } from '../../services/generator/target'
 import * as path from 'path'
 import { templates } from '../../templates'
-import { checkItIsABoosterProject } from '../../services/project-checker'
+import { checkCurrentDirIsABoosterProject } from '../../services/project-checker'
 
 export default class Command extends Oclif.Command {
   public static description = "generate new resource, write 'boost new' to see options"
@@ -43,7 +43,7 @@ type CommandInfo = HasName & HasFields
 
 const run = async (name: string, rawFields: Array<string>): Promise<void> =>
   Script.init(`boost ${Brand.energize('new:command')} 🚧`, joinParsers(parseName(name), parseFields(rawFields)))
-    .step('Verifying project', checkItIsABoosterProject)
+    .step('Verifying project', checkCurrentDirIsABoosterProject)
     .step('Creating new command', generateCommand)
     .info('Command generated!')
     .done()

--- a/packages/cli/src/commands/new/entity.ts
+++ b/packages/cli/src/commands/new/entity.ts
@@ -14,7 +14,7 @@ import {
 import * as path from 'path'
 import { generate } from '../../services/generator'
 import { templates } from '../../templates'
-import { checkItIsABoosterProject } from '../../services/project-checker'
+import { checkCurrentDirIsABoosterProject } from '../../services/project-checker'
 import { classNameToFileName } from '../../common/filenames'
 
 export default class Entity extends Oclif.Command {
@@ -55,7 +55,7 @@ const run = async (name: string, rawFields: Array<string>, rawEvents: Array<stri
     `boost ${Brand.energize('new:entity')} 🚧`,
     joinParsers(parseName(name), parseFields(rawFields), parseReaction(rawEvents))
   )
-    .step('Verifying project', checkItIsABoosterProject)
+    .step('Verifying project', checkCurrentDirIsABoosterProject)
     .step('Creating new entity', generateEntity)
     .info('Entity generated!')
     .done()

--- a/packages/cli/src/commands/new/event-handler.ts
+++ b/packages/cli/src/commands/new/event-handler.ts
@@ -9,7 +9,7 @@ import {
 } from '../../services/generator/target'
 import { Script } from '../../common/script'
 import Brand from '../../common/brand'
-import { checkItIsABoosterProject } from '../../services/project-checker'
+import { checkCurrentDirIsABoosterProject } from '../../services/project-checker'
 import { generate } from '../../services/generator'
 import * as path from 'path'
 import { templates } from '../../templates'
@@ -46,7 +46,7 @@ type EventHandlerInfo = HasName & HasEvent
 
 const run = async (name: string, eventName: string): Promise<void> =>
   Script.init(`boost ${Brand.energize('new:event-handler')} 🚧`, joinParsers(parseName(name), parseEvent(eventName)))
-    .step('Verifying project', checkItIsABoosterProject)
+    .step('Verifying project', checkCurrentDirIsABoosterProject)
     .step('Creating new event handler', generateEventHandler)
     .info('Event handler generated!')
     .done()

--- a/packages/cli/src/commands/new/event.ts
+++ b/packages/cli/src/commands/new/event.ts
@@ -12,7 +12,7 @@ import {
 import { generate } from '../../services/generator'
 import * as path from 'path'
 import { templates } from '../../templates'
-import { checkItIsABoosterProject } from '../../services/project-checker'
+import { checkCurrentDirIsABoosterProject } from '../../services/project-checker'
 
 export default class Event extends Oclif.Command {
   public static description = 'create a new event'
@@ -43,7 +43,7 @@ type EventInfo = HasName & HasFields
 
 const run = async (name: string, rawFields: Array<string>): Promise<void> =>
   Script.init(`boost ${Brand.energize('new:event')} 🚧`, joinParsers(parseName(name), parseFields(rawFields)))
-    .step('Verifying project', checkItIsABoosterProject)
+    .step('Verifying project', checkCurrentDirIsABoosterProject)
     .step('Creating new event', generateEvent)
     .info('Event generated!')
     .done()

--- a/packages/cli/src/commands/new/read-model.ts
+++ b/packages/cli/src/commands/new/read-model.ts
@@ -14,7 +14,7 @@ import {
 import * as path from 'path'
 import { generate } from '../../services/generator'
 import { templates } from '../../templates'
-import { checkItIsABoosterProject } from '../../services/project-checker'
+import { checkCurrentDirIsABoosterProject } from '../../services/project-checker'
 import { classNameToFileName } from '../../common/filenames'
 
 export default class ReadModel extends Oclif.Command {
@@ -56,7 +56,7 @@ const run = async (name: string, rawFields: Array<string>, rawProjections: Array
     `boost ${Brand.energize('new:read-model')} 🚧`,
     joinParsers(parseName(name), parseFields(rawFields), parseProjections(rawProjections))
   )
-    .step('Verifying project', checkItIsABoosterProject)
+    .step('Verifying project', checkCurrentDirIsABoosterProject)
     .step('Creating new read model', generateReadModel)
     .info('Read model generated!')
     .done()

--- a/packages/cli/src/commands/new/scheduled-command.ts
+++ b/packages/cli/src/commands/new/scheduled-command.ts
@@ -5,7 +5,7 @@ import { generate } from '../../services/generator'
 import { HasName, joinParsers, parseName, ImportDeclaration } from '../../services/generator/target'
 import * as path from 'path'
 import { templates } from '../../templates'
-import { checkItIsABoosterProject } from '../../services/project-checker'
+import { checkCurrentDirIsABoosterProject } from '../../services/project-checker'
 
 export default class ScheduledCommand extends Oclif.Command {
   public static description = "generate new scheduled command, write 'boost new:scheduled-command -h' to see options"
@@ -31,7 +31,7 @@ type ScheduledCommandInfo = HasName
 
 const run = async (name: string): Promise<void> =>
   Script.init(`boost ${Brand.energize('new:scheduled-command')} 🚧`, joinParsers(parseName(name)))
-    .step('Verifying project', checkItIsABoosterProject)
+    .step('Verifying project', checkCurrentDirIsABoosterProject)
     .step('Creating new scheduled command', generateScheduledCommand)
     .info('Scheduled command generated!')
     .done()

--- a/packages/cli/src/commands/new/type.ts
+++ b/packages/cli/src/commands/new/type.ts
@@ -5,7 +5,7 @@ import { HasFields, HasName, joinParsers, parseName, parseFields } from '../../s
 import { templates } from '../../templates'
 import { generate } from '../../services/generator'
 import * as path from 'path'
-import { checkItIsABoosterProject } from '../../services/project-checker'
+import { checkCurrentDirIsABoosterProject } from '../../services/project-checker'
 
 export default class Type extends Oclif.Command {
   public static description = 'create a new type'
@@ -37,7 +37,7 @@ type TypeInfo = HasName & HasFields
 
 const run = async (name: string, rawFields: Array<string>): Promise<void> =>
   Script.init(`boost ${Brand.energize('new:type')} 🚧`, joinParsers(parseName(name), parseFields(rawFields)))
-    .step('Verifying project', checkItIsABoosterProject)
+    .step('Verifying project', checkCurrentDirIsABoosterProject)
     .step('Creating new type', generateType)
     .info('Type generated!')
     .done()

--- a/packages/cli/src/commands/nuke.ts
+++ b/packages/cli/src/commands/nuke.ts
@@ -56,7 +56,7 @@ export default class Nuke extends Command {
     const { flags } = this.parse(Nuke)
     if (initializeEnvironment(logger, flags.environment)) {
       await runTasks(
-        askToConfirmRemoval(new Prompter(), flags.force, compileProjectAndLoadConfig()),
+        askToConfirmRemoval(new Prompter(), flags.force, compileProjectAndLoadConfig(process.cwd())),
         nukeCloudProviderResources
       )
     }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -35,7 +35,7 @@ export default class Start extends Command {
   public async run(): Promise<void> {
     const { flags } = this.parse(Start)
     if (initializeEnvironment(logger, flags.environment)) {
-      await runTasks(flags.port, compileProjectAndLoadConfig(), startProvider.bind(null, flags.port))
+      await runTasks(flags.port, compileProjectAndLoadConfig(process.cwd()), startProvider.bind(null, flags.port))
     }
   }
 }

--- a/packages/cli/src/common/sandbox.ts
+++ b/packages/cli/src/common/sandbox.ts
@@ -1,0 +1,29 @@
+import { copyFileSync, mkdirSync, readdirSync, rmdirSync } from 'fs'
+import * as path from 'path'
+
+const copyFolder = (origin: string, destiny: string): void => {
+  readdirSync(origin, { withFileTypes: true }).forEach((dirEnt) => {
+    if (dirEnt.isFile()) {
+      copyFileSync(path.join(origin, dirEnt.name), path.join(destiny, dirEnt.name))
+    }
+    if (dirEnt.isDirectory()) {
+      mkdirSync(path.join(destiny, dirEnt.name), { recursive: true })
+      copyFolder(path.join(origin, dirEnt.name), path.join(destiny, dirEnt.name))
+    }
+  })
+}
+
+export const createSandboxProject = (sandboxPath: string): string => {
+  rmdirSync(sandboxPath, { recursive: true })
+  mkdirSync(sandboxPath, { recursive: true })
+  copyFolder('src', path.join(sandboxPath, 'src'))
+
+  const projectFiles = ['.eslintignore', 'package.json', 'tsconfig.eslint.json', 'tsconfig.json']
+  projectFiles.forEach((file: string) => copyFileSync(file, path.join(sandboxPath, file)))
+
+  return sandboxPath
+}
+
+export const removeSandboxProject = (sandboxPath: string): void => {
+  rmdirSync(sandboxPath, { recursive: true })
+}

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -9,7 +9,7 @@ import { installProductionDependencies } from './dependencies'
 
 export const DEPLOYMENT_SANDBOX = '.deploy'
 
-export async function createProductionSandbox(): Promise<string> {
+export async function createDeploymentSandbox(): Promise<string> {
   const sandboxRelativePath = createSandboxProject(DEPLOYMENT_SANDBOX)
   await installProductionDependencies(sandboxRelativePath)
   return sandboxRelativePath

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -9,12 +9,19 @@ import { installProductionDependencies } from './dependencies'
 
 export const DEPLOYMENT_SANDBOX = '.deploy'
 
+export async function createProductionSandbox(): Promise<string> {
+  const sandboxRelativePath = createSandboxProject(DEPLOYMENT_SANDBOX)
+  await installProductionDependencies(sandboxRelativePath)
+  return sandboxRelativePath
+}
+
+export async function cleanProductionSandbox(): Promise<void> {
+  removeSandboxProject(DEPLOYMENT_SANDBOX)
+}
+
 export async function compileProjectAndLoadConfig(): Promise<BoosterConfig> {
   await checkItIsABoosterProject()
-  const sandboxRelativePath = createSandboxProject(DEPLOYMENT_SANDBOX)
-  process.chdir(sandboxRelativePath) // The booster application needs to bw in the current working directory
   const userProjectPath = process.cwd()
-  await installProductionDependencies(userProjectPath)
   await compileProject(userProjectPath)
   return readProjectConfig(userProjectPath)
 }
@@ -62,8 +69,4 @@ function checkEnvironmentWasConfigured(app: BoosterApp): void {
       ).join(', ')}'`
     )
   }
-}
-
-export async function cleanProjectFiles(): Promise<void> {
-  removeSandboxProject(DEPLOYMENT_SANDBOX)
 }

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -15,7 +15,7 @@ export async function createDeploymentSandbox(): Promise<string> {
   return sandboxRelativePath
 }
 
-export async function cleanProductionSandbox(): Promise<void> {
+export async function cleanDeploymentSandbox(): Promise<void> {
   removeSandboxProject(DEPLOYMENT_SANDBOX)
 }
 

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -19,9 +19,8 @@ export async function cleanProductionSandbox(): Promise<void> {
   removeSandboxProject(DEPLOYMENT_SANDBOX)
 }
 
-export async function compileProjectAndLoadConfig(): Promise<BoosterConfig> {
-  await checkItIsABoosterProject()
-  const userProjectPath = process.cwd()
+export async function compileProjectAndLoadConfig(userProjectPath: string): Promise<BoosterConfig> {
+  await checkItIsABoosterProject(userProjectPath)
   await compileProject(userProjectPath)
   return readProjectConfig(userProjectPath)
 }
@@ -47,7 +46,8 @@ function readProjectConfig(userProjectPath: string): Promise<BoosterConfig> {
 }
 
 function loadUserProject(userProjectPath: string): { Booster: BoosterApp } {
-  return require(path.join(userProjectPath, 'dist', 'index.js'))
+  const projectIndexJSPath = path.resolve(path.join(userProjectPath, 'dist', 'index.js'))
+  return require(projectIndexJSPath)
 }
 
 function checkEnvironmentWasConfigured(app: BoosterApp): void {

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -4,16 +4,12 @@ import { exec } from 'child-process-promise'
 import { wrapExecError } from '../common/errors'
 import { checkItIsABoosterProject } from './project-checker'
 import { currentEnvironment } from './environment'
-import { createSandboxProject } from '../common/sandbox'
+import { createSandboxProject, removeSandboxProject } from '../common/sandbox'
 import { installProductionDependencies } from './dependencies'
 
 export const DEPLOYMENT_SANDBOX = '.deploy'
 
-type CompileAndLoadOptions = {
-  production: boolean
-}
-
-export async function compileProjectAndLoadConfig(opts?: CompileAndLoadOptions): Promise<BoosterConfig> {
+export async function compileProjectAndLoadConfig(): Promise<BoosterConfig> {
   await checkItIsABoosterProject()
   const sandboxRelativePath = createSandboxProject(DEPLOYMENT_SANDBOX)
   process.chdir(sandboxRelativePath) // The booster application needs to bw in the current working directory
@@ -61,4 +57,8 @@ function checkEnvironmentWasConfigured(app: BoosterApp): void {
       ).join(', ')}'`
     )
   }
+}
+
+export async function cleanProjectFiles(): Promise<void> {
+  removeSandboxProject(DEPLOYMENT_SANDBOX)
 }

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -44,10 +44,15 @@ function loadUserProject(userProjectPath: string): { Booster: BoosterApp } {
 }
 
 function checkEnvironmentWasConfigured(app: BoosterApp): void {
+  if (app.configuredEnvironments.size == 0) {
+    throw new Error(
+      "You haven't configured any environment. Please make sure you have at least one environment configured by calling 'Booster.configure' method (normally done inside the folder 'src/config')"
+    )
+  }
   const currentEnv = currentEnvironment()
   if (!currentEnv) {
     throw new Error(
-      "You haven't configured any environment. Please make sure you have at least one environment configured by calling 'Booster.configure' method (normally done inside the folder 'src/config')"
+      "You haven't provided any environment. Please make sure you are using option '-e' with a valid environment name"
     )
   }
   if (!app.configuredEnvironments.has(currentEnv)) {

--- a/packages/cli/src/services/dependencies.ts
+++ b/packages/cli/src/services/dependencies.ts
@@ -8,3 +8,11 @@ export async function installProductionDependencies(projectPath: string): Promis
     throw wrapExecError(e, 'Could not install production dependencies')
   }
 }
+
+export async function installAllDependencies(path?: string): Promise<void> {
+  try {
+    await exec('npm install', { cwd: path ?? process.cwd() })
+  } catch (e) {
+    throw wrapExecError(e, 'Could not install dependencies')
+  }
+}

--- a/packages/cli/src/services/dependencies.ts
+++ b/packages/cli/src/services/dependencies.ts
@@ -1,18 +1,10 @@
 import { exec } from 'child-process-promise'
 import { wrapExecError } from '../common/errors'
 
-export async function pruneDevDependencies(): Promise<void> {
+export async function installProductionDependencies(projectPath: string): Promise<void> {
   try {
-    await exec('npm install --production --no-bin-links')
+    await exec('npm install --production --no-bin-links', { cwd: projectPath })
   } catch (e) {
-    throw wrapExecError(e, 'Could not prune dev dependencies')
-  }
-}
-
-export async function installAllDependencies(path?: string): Promise<void> {
-  try {
-    await exec('npm install', { cwd: path ?? process.cwd() })
-  } catch (e) {
-    throw wrapExecError(e, 'Could not install dependencies')
+    throw wrapExecError(e, 'Could not install production dependencies')
   }
 }

--- a/packages/cli/src/services/project-checker.ts
+++ b/packages/cli/src/services/project-checker.ts
@@ -3,19 +3,22 @@ import * as path from 'path'
 
 function checkIndexFileIsBooster(indexFilePath: string): void {
   const contents = fs.readFileSync(indexFilePath)
-  if (!contents.includes('Booster.start()')) {
+  if (!contents.includes('Booster.start(')) {
     throw new Error(
       'The main application file does not start a Booster application. Verify you are in the right project'
     )
   }
 }
 
-export async function checkItIsABoosterProject(): Promise<void> {
-  const currentPath = process.cwd()
+export async function checkCurrentDirIsABoosterProject(): Promise<void> {
+  return checkItIsABoosterProject(process.cwd())
+}
+
+export async function checkItIsABoosterProject(projectPath: string): Promise<void> {
   try {
-    const tsConfigJsonContents = require(path.join(currentPath, 'tsconfig.json'))
+    const tsConfigJsonContents = require(path.join(projectPath, 'tsconfig.json'))
     const indexFilePath = path.normalize(
-      path.join(currentPath, tsConfigJsonContents.compilerOptions.rootDir, 'index.ts')
+      path.join(projectPath, tsConfigJsonContents.compilerOptions.rootDir, 'index.ts')
     )
     checkIndexFileIsBooster(indexFilePath)
   } catch (e) {

--- a/packages/cli/src/services/project-checker.ts
+++ b/packages/cli/src/services/project-checker.ts
@@ -15,10 +15,11 @@ export async function checkCurrentDirIsABoosterProject(): Promise<void> {
 }
 
 export async function checkItIsABoosterProject(projectPath: string): Promise<void> {
+  const projectAbsolutePath = path.resolve(projectPath)
   try {
-    const tsConfigJsonContents = require(path.join(projectPath, 'tsconfig.json'))
+    const tsConfigJsonContents = require(path.join(projectAbsolutePath, 'tsconfig.json'))
     const indexFilePath = path.normalize(
-      path.join(projectPath, tsConfigJsonContents.compilerOptions.rootDir, 'index.ts')
+      path.join(projectAbsolutePath, tsConfigJsonContents.compilerOptions.rootDir, 'index.ts')
     )
     checkIndexFileIsBooster(indexFilePath)
   } catch (e) {

--- a/packages/cli/src/templates/project/index-ts.ts
+++ b/packages/cli/src/templates/project/index-ts.ts
@@ -8,5 +8,5 @@ export {
   boosterTriggerScheduledCommand,
 } from '@boostercloud/framework-core'
 
-Booster.start()
+Booster.start(__dirname)
 `

--- a/packages/cli/src/templates/project/package-json.ts
+++ b/packages/cli/src/templates/project/package-json.ts
@@ -14,6 +14,7 @@ export const template = `{
   },
   "devDependencies": {
     "@boostercloud/cli": "^${VERSION}",
+    "{{{providerPackageName}}}-infrastructure": "*",
     "rimraf": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",
@@ -25,8 +26,7 @@ export const template = `{
     "prettier": "^1.19.1",
     "typescript": "^3.9.3",
     "ts-node": "^8.6.2",
-    "@types/node": "^13.5.1",
-    "{{{providerPackageName}}}-infrastructure": "*"
+    "@types/node": "^13.5.1"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -28,7 +28,7 @@ describe('deploy', () => {
         const fakeDeployer = fake()
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks(false, fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
       })
     })
@@ -40,66 +40,8 @@ describe('deploy', () => {
         const fakeDeployer = fake()
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await expect(runTasks(false, fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
+        await expect(runTasks(fakeLoader, fakeDeployer)).to.eventually.be.rejectedWith(msg)
         expect(fakeDeployer).not.to.have.been.called
-      })
-    })
-
-    context('when the `skipRestoreDependencies` flag is set to "false"', () => {
-      fancy.stdout().it('reinstalls dev dependencies after deploy', async (ctx) => {
-        const fakeReinstallDependencies = fake()
-        replace(dependencies, 'installAllDependencies', fakeReinstallDependencies)
-
-        const fakeProvider = {} as ProviderLibrary
-
-        const fakeLoader = fake.resolves({
-          provider: fakeProvider,
-          appName: 'fake app',
-          region: 'tunte',
-          entities: {},
-        })
-
-        const fakeDeployer = fake((_config: unknown, logger: Logger) => {
-          logger.info('this is a progress update')
-        })
-
-        replace(environment, 'currentEnvironment', fake.returns('test-env'))
-
-        await runTasks(false, fakeLoader, fakeDeployer)
-
-        expect(fakeReinstallDependencies).to.have.been.called
-
-        expect(ctx.stdout).to.include('Deployment complete')
-        expect(fakeDeployer).to.have.been.calledOnce
-      })
-    })
-
-    context('when `skipRestoreDependencies` flag is set to "true"', () => {
-      fancy.stdout().it('does not reinstall dependencies after deployment', async (ctx) => {
-        const fakeReinstallDependencies = fake()
-        replace(dependencies, 'installAllDependencies', fakeReinstallDependencies)
-
-        const fakeProvider = {} as ProviderLibrary
-
-        const fakeLoader = fake.resolves({
-          provider: fakeProvider,
-          appName: 'fake app',
-          region: 'tunte',
-          entities: {},
-        })
-
-        const fakeDeployer = fake((_config: unknown, logger: Logger) => {
-          logger.info('this is a progress update')
-        })
-
-        replace(environment, 'currentEnvironment', fake.returns('test-env'))
-
-        await runTasks(true, fakeLoader, fakeDeployer)
-
-        expect(fakeReinstallDependencies).not.to.have.been.called
-
-        expect(ctx.stdout).to.include('Deployment complete')
-        expect(fakeDeployer).to.have.been.calledOnce
       })
     })
 
@@ -122,7 +64,7 @@ describe('deploy', () => {
 
         replace(environment, 'currentEnvironment', fake.returns('test-env'))
 
-        await runTasks(false, fakeLoader, fakeDeployer)
+        await runTasks(fakeLoader, fakeDeployer)
 
         expect(ctx.stdout).to.include('Deployment complete')
 

--- a/packages/cli/test/commands/new.test.ts
+++ b/packages/cli/test/commands/new.test.ts
@@ -24,7 +24,7 @@ describe('new', (): void => {
     })
     context('projections', () => {
       it('renders according to the template', async () => {
-        stub(ProjectChecker, 'checkItIsABoosterProject').returnsThis()
+        stub(ProjectChecker, 'checkCurrentDirIsABoosterProject').returnsThis()
         await new ReadModel([readModel, '--fields', 'title:string', '--projects', 'Post:id'], {} as IConfig).run()
         const readModelFileContent = fs.readFileSync(readModelPath).toString()
         const renderedReadModel = Mustache.render(templates.readModel, {

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -9,6 +9,7 @@ const rewire = require('rewire')
 const configService = rewire('../../src/services/config-service')
 
 describe('configService', () => {
+  const userProjectPath = 'path/to/project'
   let fakeInstallProductionDependencies: SinonSpy
   beforeEach(() => {
     fakeInstallProductionDependencies = fake()
@@ -44,8 +45,8 @@ describe('configService', () => {
 
       replace(environment, 'currentEnvironment', fake.returns('test'))
 
-      await expect(configService.compileProjectAndLoadConfig()).to.eventually.become(config)
-      expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly()
+      await expect(configService.compileProjectAndLoadConfig(userProjectPath)).to.eventually.become(config)
+      expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly(userProjectPath)
 
       rewires.forEach((fn) => fn())
     })
@@ -67,10 +68,10 @@ describe('configService', () => {
         ),
       ]
 
-      await expect(configService.compileProjectAndLoadConfig()).to.eventually.be.rejectedWith(
+      await expect(configService.compileProjectAndLoadConfig(userProjectPath)).to.eventually.be.rejectedWith(
         /You haven't configured any environment/
       )
-      expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly()
+      expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly(userProjectPath)
 
       rewires.forEach((fn) => fn())
     })
@@ -94,10 +95,10 @@ describe('configService', () => {
 
       replace(environment, 'currentEnvironment', fake.returns('test'))
 
-      await expect(configService.compileProjectAndLoadConfig()).to.eventually.be.rejectedWith(
+      await expect(configService.compileProjectAndLoadConfig(userProjectPath)).to.eventually.be.rejectedWith(
         /The environment 'test' does not match any of the environments/
       )
-      expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly()
+      expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly(userProjectPath)
 
       rewires.forEach((fn) => fn())
     })

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -4,6 +4,7 @@ import { BoosterConfig } from '@boostercloud/framework-types'
 import { expect } from '../expect'
 import * as environment from '../../src/services/environment'
 import * as dependencies from '../../src/services/dependencies'
+import * as sandbox from '../../src/common/sandbox'
 
 const rewire = require('rewire')
 const configService = rewire('../../src/services/config-service')
@@ -18,6 +19,34 @@ describe('configService', () => {
 
     beforeEach(() => {
       checkItIsABoosterProject = stub(projectChecker, 'checkItIsABoosterProject').resolves()
+    })
+
+    it('creates a sandbox project', async () => {
+      const config = new BoosterConfig('test')
+
+      const rewires = [
+        configService.__set__('compileProject', fake()),
+        configService.__set__(
+          'loadUserProject',
+          fake.returns({
+            Booster: {
+              config: config,
+              configuredEnvironments: new Set(['test']),
+              configureCurrentEnv: fake.yields(config),
+            },
+          })
+        ),
+      ]
+
+      replace(environment, 'currentEnvironment', fake.returns('test'))
+      replace(dependencies, 'installProductionDependencies', fake())
+
+      const fakeCreateSandbox = fake()
+      replace(sandbox, 'createSandboxProject', fakeCreateSandbox)
+      await configService.compileProjectAndLoadConfig()
+      expect(fakeCreateSandbox).to.have.been.calledOnce
+
+      rewires.forEach((fn) => fn())
     })
 
     it('loads the config when the selected environment exists', async () => {
@@ -38,71 +67,13 @@ describe('configService', () => {
       ]
 
       replace(environment, 'currentEnvironment', fake.returns('test'))
-      replace(dependencies, 'pruneDevDependencies', fake())
+      replace(dependencies, 'installProductionDependencies', fake())
 
       await expect(configService.compileProjectAndLoadConfig()).to.eventually.become(config)
       expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly()
-      expect(dependencies.pruneDevDependencies).not.to.have.been.called
+      expect(dependencies.installProductionDependencies).not.to.have.been.called
 
       rewires.forEach((fn) => fn())
-    })
-
-    context('when the production option is set to `false`', () => {
-      it('does not prune devDependencies', async () => {
-        const config = new BoosterConfig('test')
-
-        const rewires = [
-          configService.__set__('compileProject', fake()),
-          configService.__set__(
-            'loadUserProject',
-            fake.returns({
-              Booster: {
-                config: config,
-                configuredEnvironments: new Set(['test']),
-                configureCurrentEnv: fake.yields(config),
-              },
-            })
-          ),
-        ]
-
-        replace(environment, 'currentEnvironment', fake.returns('test'))
-        replace(dependencies, 'pruneDevDependencies', fake())
-
-        await expect(configService.compileProjectAndLoadConfig({ prduction: true })).to.eventually.become(config)
-
-        expect(dependencies.pruneDevDependencies).not.to.have.been.called
-
-        rewires.forEach((fn) => fn())
-      })
-    })
-
-    context('when the production option is set to `true`', () => {
-      it('prunes devDependencies', async () => {
-        const config = new BoosterConfig('test')
-
-        const rewires = [
-          configService.__set__('compileProject', fake()),
-          configService.__set__(
-            'loadUserProject',
-            fake.returns({
-              Booster: {
-                config: config,
-                configuredEnvironments: new Set(['test']),
-                configureCurrentEnv: fake.yields(config),
-              },
-            })
-          ),
-        ]
-
-        replace(environment, 'currentEnvironment', fake.returns('test'))
-        replace(dependencies, 'pruneDevDependencies', fake())
-
-        await expect(configService.compileProjectAndLoadConfig({ production: true })).to.eventually.become(config)
-
-        expect(dependencies.pruneDevDependencies).to.have.been.calledOnce
-
-        rewires.forEach((fn) => fn())
-      })
     })
 
     it('throws the right error when there are not configured environments', async () => {

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -4,20 +4,15 @@ import { BoosterConfig } from '@boostercloud/framework-types'
 import { expect } from '../expect'
 import * as environment from '../../src/services/environment'
 import * as dependencies from '../../src/services/dependencies'
-import * as sandbox from '../../src/common/sandbox'
 
 const rewire = require('rewire')
 const configService = rewire('../../src/services/config-service')
 
 describe('configService', () => {
   let fakeInstallProductionDependencies: SinonSpy
-  let fakeCreateSandboxProject: SinonSpy
   beforeEach(() => {
     fakeInstallProductionDependencies = fake()
-    fakeCreateSandboxProject = fake()
     replace(dependencies, 'installProductionDependencies', fakeInstallProductionDependencies)
-    replace(sandbox, 'createSandboxProject', fakeCreateSandboxProject)
-    replace(process, 'chdir', fake())
   })
   afterEach(() => {
     restore()
@@ -28,31 +23,6 @@ describe('configService', () => {
 
     beforeEach(() => {
       checkItIsABoosterProject = stub(projectChecker, 'checkItIsABoosterProject').resolves()
-    })
-
-    it('creates a sandbox project', async () => {
-      const config = new BoosterConfig('test')
-
-      const rewires = [
-        configService.__set__('compileProject', fake()),
-        configService.__set__(
-          'loadUserProject',
-          fake.returns({
-            Booster: {
-              config: config,
-              configuredEnvironments: new Set(['test']),
-              configureCurrentEnv: fake.yields(config),
-            },
-          })
-        ),
-      ]
-
-      replace(environment, 'currentEnvironment', fake.returns('test'))
-
-      await configService.compileProjectAndLoadConfig()
-      expect(fakeCreateSandboxProject).to.have.been.calledOnce
-
-      rewires.forEach((fn) => fn())
     })
 
     it('loads the config when the selected environment exists', async () => {

--- a/packages/cli/test/services/dependencies.test.ts
+++ b/packages/cli/test/services/dependencies.test.ts
@@ -1,6 +1,6 @@
 import * as childProcessPromise from 'child-process-promise'
 import { fake, replace, restore } from 'sinon'
-import { installAllDependencies, pruneDevDependencies } from '../../src/services/dependencies'
+import { installAllDependencies, installProductionDependencies } from '../../src/services/dependencies'
 import { expect } from '../expect'
 
 describe('dependencies service', () => {
@@ -8,21 +8,27 @@ describe('dependencies service', () => {
     restore()
   })
 
-  describe('pruneDevDependencies', () => {
+  describe('installProductionDependencies', () => {
     it('installs dependencies in production mode', async () => {
       replace(childProcessPromise, 'exec', fake.resolves({}))
+      const path = 'aPath'
 
-      await expect(pruneDevDependencies()).to.eventually.be.fulfilled
+      await expect(installProductionDependencies(path)).to.eventually.be.fulfilled
 
-      expect(childProcessPromise.exec).to.have.been.calledWithMatch('npm install --production --no-bin-links')
+      expect(childProcessPromise.exec).to.have.been.calledWithMatch('npm install --production --no-bin-links', {
+        cwd: path,
+      })
     })
 
     it('wraps the exec error', async () => {
       const error = new Error('something wrong happened')
+      const path = 'aPath'
 
       replace(childProcessPromise, 'exec', fake.rejects(error))
 
-      await expect(pruneDevDependencies()).to.eventually.be.rejectedWith(/Could not prune dev dependencies/)
+      await expect(installProductionDependencies(path)).to.eventually.be.rejectedWith(
+        /Could not install production dependencies/
+      )
     })
   })
 

--- a/packages/framework-core/src/booster.ts
+++ b/packages/framework-core/src/booster.ts
@@ -53,9 +53,11 @@ export class Booster {
   /**
    * Initializes the Booster project
    */
-  public static start(): void {
+  public static start(codeRootPath: string): void {
+    const projectRootPath = codeRootPath.replace(new RegExp(this.config.codeRelativePath + '$'), '')
+    this.config.userProjectRootPath = projectRootPath
     this.logger = buildLogger(this.config.logLevel)
-    Importer.importUserProjectFiles()
+    Importer.importUserProjectFiles(codeRootPath)
     this.config.validate()
   }
 

--- a/packages/framework-core/src/importer.ts
+++ b/packages/framework-core/src/importer.ts
@@ -2,16 +2,16 @@ import * as fs from 'fs'
 import * as path from 'path'
 
 export class Importer {
-  public static importUserProjectFiles(): void {
-    Importer.getImportFiles().forEach(Importer.importWithoutExtension)
+  public static importUserProjectFiles(codeRootPath: string): void {
+    Importer.getImportFiles(codeRootPath).forEach(Importer.importWithoutExtension)
   }
 
   private static importWithoutExtension(file: string): void {
     require(Importer.removeDevExtension(file))
   }
 
-  private static getImportFiles(): Array<string> {
-    return Importer.walkDir(Importer.distFolder())
+  private static getImportFiles(codeRootPath: string): Array<string> {
+    return Importer.walkDir(codeRootPath)
       .filter(Importer.isJavaScriptFile)
       .filter(Importer.isNotIndexJs)
   }
@@ -28,10 +28,6 @@ export class Importer {
       }
     })
     return files
-  }
-
-  private static distFolder(): string {
-    return path.join(process.cwd(), 'dist')
   }
 
   private static isJavaScriptFile(file: string): boolean {

--- a/packages/framework-core/test/booster.test.ts
+++ b/packages/framework-core/test/booster.test.ts
@@ -40,7 +40,7 @@ describe('the `Booster` class', () => {
     it('imports all the user files', () => {
       const fakeImporter = fake()
       replace(Importer, 'importUserProjectFiles', fakeImporter)
-      Booster.start()
+      Booster.start('path/to/code')
       expect(fakeImporter).to.have.been.calledOnce
     })
   })

--- a/packages/framework-core/test/importer.test.ts
+++ b/packages/framework-core/test/importer.test.ts
@@ -4,7 +4,6 @@
 import { restore, replace, stub, spy } from 'sinon'
 import * as fs from 'fs'
 import * as path from 'path'
-import * as process from 'process'
 import { Importer } from '../src/importer'
 import { expect } from './expect'
 
@@ -16,6 +15,7 @@ describe('the `importer` service', () => {
   // FIXME
   describe('the `importUserProjectFiles` function', () => {
     it('calls `require` for each import file', () => {
+      const codeRelativePath = 'dist'
       const fakeStatSync = (fileName: string) => ({
         isDirectory: () => !fileName.includes('.'),
       })
@@ -28,17 +28,14 @@ describe('the `importer` service', () => {
         .returns(['index.js', 'test.ts', 'types.d.ts', 'lol.js'])
       replace(fs, 'readdirSync', fakeReaddirSync as any)
 
-      const fakeCwd = stub().returns('')
-      replace(process, 'cwd', fakeCwd)
-
       const fakeImportWithoutExtension = spy()
       replace(Importer as any, 'importWithoutExtension', fakeImportWithoutExtension)
 
-      Importer.importUserProjectFiles()
+      Importer.importUserProjectFiles(codeRelativePath)
 
       expect(fakeImportWithoutExtension).to.have.been.calledTwice
-      expect(fakeImportWithoutExtension.firstCall).to.have.been.calledWith(path.join('dist', 'src', 'lol.js'))
-      expect(fakeImportWithoutExtension.secondCall).to.have.been.calledWith(path.join('dist', 'lol.js'))
+      expect(fakeImportWithoutExtension.firstCall).to.have.been.calledWith(path.join(codeRelativePath, 'src', 'lol.js'))
+      expect(fakeImportWithoutExtension.secondCall).to.have.been.calledWith(path.join(codeRelativePath, 'lol.js'))
     })
   })
 })

--- a/packages/framework-integration-tests/integration/cli/cli.command.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.command.integration.ts
@@ -1,13 +1,10 @@
 import * as path from 'path'
 import { expect } from 'chai'
-import {
-  createSandboxProject,
-  loadFixture,
-  readFileContent,
-  removeFolders,
-  writeFileContent,
-} from '../helper/fileHelper'
+import { loadFixture, readFileContent, removeFolders, sandboxPathFor, writeFileContent } from '../helper/fileHelper'
 import { exec } from 'child-process-promise'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../cli/src/common/sandbox'
 
 const COMMAND_AUTH_PLACEHOLDER = "// Specify authorized roles here. Use 'all' to authorize anyone"
 
@@ -15,7 +12,7 @@ describe('Command', () => {
   let commandSandboxDir: string
 
   before(async () => {
-    commandSandboxDir = createSandboxProject('command')
+    commandSandboxDir = createSandboxProject(sandboxPathFor('command'))
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.entity.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.entity.integration.ts
@@ -1,13 +1,10 @@
 import { expect } from 'chai'
-import {
-  readFileContent,
-  writeFileContent,
-  loadFixture,
-  createSandboxProject,
-  removeFolders,
-} from '../helper/fileHelper'
+import { readFileContent, writeFileContent, loadFixture, removeFolders, sandboxPathFor } from '../helper/fileHelper'
 import * as path from 'path'
 import { exec } from 'child-process-promise'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../cli/src/common/sandbox'
 
 const EVENT_ENTITY_ID_PLACEHOLDER = '/* the associated entity ID */'
 const ENTITY_REDUCER_PLACEHOLDER = '/* NEW PostWithReducer HERE */'
@@ -16,7 +13,7 @@ describe('Entity', () => {
   let entitySandboxDir: string
 
   before(async () => {
-    entitySandboxDir = createSandboxProject('entity')
+    entitySandboxDir = createSandboxProject(sandboxPathFor('entity'))
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.event-handler.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.event-handler.integration.ts
@@ -1,13 +1,16 @@
 import * as path from 'path'
 import { expect } from 'chai'
-import { createSandboxProject, loadFixture, readFileContent, removeFolders } from '../helper/fileHelper'
+import { loadFixture, readFileContent, removeFolders, sandboxPathFor } from '../helper/fileHelper'
 import { exec } from 'child-process-promise'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../cli/src/common/sandbox'
 
 describe('Event handler', () => {
   let eventHandlerSandboxDir: string
 
   before(async () => {
-    eventHandlerSandboxDir = createSandboxProject('event-handler')
+    eventHandlerSandboxDir = createSandboxProject(sandboxPathFor('event-handler'))
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.event.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.event.integration.ts
@@ -1,13 +1,10 @@
 import * as path from 'path'
 import { expect } from 'chai'
-import {
-  createSandboxProject,
-  loadFixture,
-  readFileContent,
-  removeFolders,
-  writeFileContent,
-} from '../helper/fileHelper'
+import { loadFixture, readFileContent, removeFolders, sandboxPathFor, writeFileContent } from '../helper/fileHelper'
 import { exec } from 'child-process-promise'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../cli/src/common/sandbox'
 
 const EVENT_ENTITY_ID_PLACEHOLDER = '/* the associated entity ID */'
 
@@ -15,7 +12,7 @@ describe('Event', () => {
   let eventSandboxDir: string
 
   before(async () => {
-    eventSandboxDir = createSandboxProject('event')
+    eventSandboxDir = createSandboxProject(sandboxPathFor('event'))
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -29,7 +29,7 @@ const LICENSE = 'Apache'
 const REPO_URL = 'https://github.com/boostercloud/booster/'
 const PROVIDER = '@boostercloud/framework-provider-aws'
 
-describe('Project', () => {
+describe.only('Project', () => {
   const SANDBOX_INTEGRATION_DIR = 'new-project-integration-sandbox'
 
   before(async () => {

--- a/packages/framework-integration-tests/integration/cli/cli.readmodel.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.readmodel.integration.ts
@@ -1,13 +1,10 @@
 import { expect } from 'chai'
 import * as path from 'path'
-import {
-  createSandboxProject,
-  loadFixture,
-  readFileContent,
-  removeFolders,
-  writeFileContent,
-} from '../helper/fileHelper'
+import { loadFixture, readFileContent, removeFolders, sandboxPathFor, writeFileContent } from '../helper/fileHelper'
 import { exec } from 'child-process-promise'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../cli/src/common/sandbox'
 
 const READ_MODEL_AUTH_PLACEHOLDER = "// Specify authorized roles here. Use 'all' to authorize anyone"
 const READ_MODEL_PROJECTION_PLACEHOLDER = '/* NEW CartWithProjectionReadModel HERE */'
@@ -16,7 +13,7 @@ describe('Read model', () => {
   let readModelSandboxDir: string
 
   before(async () => {
-    readModelSandboxDir = createSandboxProject('read-model')
+    readModelSandboxDir = createSandboxProject(sandboxPathFor('read-model'))
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.scheduled-command.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.scheduled-command.integration.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import { expect } from 'chai'
-import { createSandboxProject, loadFixture, readFileContent, removeFolders, sandboxPathFor } from '../helper/fileHelper'
+import { loadFixture, readFileContent, removeFolders, sandboxPathFor } from '../helper/fileHelper'
 import { exec } from 'child-process-promise'
 // Imported from another package to avoid duplication
 // It is OK-ish, since integration tests are always run in the context of the whole monorepo

--- a/packages/framework-integration-tests/integration/cli/cli.scheduled-command.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.scheduled-command.integration.ts
@@ -1,13 +1,16 @@
 import * as path from 'path'
 import { expect } from 'chai'
-import { createSandboxProject, loadFixture, readFileContent, removeFolders } from '../helper/fileHelper'
+import { createSandboxProject, loadFixture, readFileContent, removeFolders, sandboxPathFor } from '../helper/fileHelper'
 import { exec } from 'child-process-promise'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../cli/src/common/sandbox'
 
 describe('Scheduled Command', () => {
   let scheduledCommandSandboxDir: string
 
   before(async () => {
-    scheduledCommandSandboxDir = createSandboxProject('scheduled-command')
+    scheduledCommandSandboxDir = createSandboxProject(sandboxPathFor('scheduled-command'))
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/cli/cli.type.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.type.integration.ts
@@ -1,13 +1,16 @@
 import * as path from 'path'
 import { expect } from 'chai'
-import { createSandboxProject, loadFixture, readFileContent, removeFolders } from '../helper/fileHelper'
+import { loadFixture, readFileContent, removeFolders, sandboxPathFor } from '../helper/fileHelper'
 import { exec } from 'child-process-promise'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../cli/src/common/sandbox'
 
 describe('Type', () => {
   let typeSandboxDir: string
 
   before(async () => {
-    typeSandboxDir = createSandboxProject('type')
+    typeSandboxDir = createSandboxProject(sandboxPathFor('type'))
   })
 
   after(() => {

--- a/packages/framework-integration-tests/integration/fixtures/cart-demo/src/index.ts
+++ b/packages/framework-integration-tests/integration/fixtures/cart-demo/src/index.ts
@@ -8,4 +8,4 @@ export {
   boosterTriggerScheduledCommand,
 } from '@boostercloud/framework-core'
 
-Booster.start()
+Booster.start(__dirname)

--- a/packages/framework-integration-tests/integration/helper/depsHelper.ts
+++ b/packages/framework-integration-tests/integration/helper/depsHelper.ts
@@ -22,9 +22,9 @@ export async function overrideWithBoosterLocalDependencies(projectPath: string):
         ?.trim()
         ?.split('\n')
         ?.pop()!
-      const dotBoosterRelativePath = path.relative(projectPath, dotBooster)
+      const dotBoosterAbsolutePath = path.resolve(dotBooster)
       // Now override the packageJSON dependencies with the path to the packed dependency
-      packageJSON.dependencies[packageName] = `file:${path.join(dotBoosterRelativePath, packedDependencyFileName)}`
+      packageJSON.dependencies[packageName] = `file:${path.join(dotBoosterAbsolutePath, packedDependencyFileName)}`
     }
   }
   fs.writeFileSync(path.join(projectPath, 'package.json'), JSON.stringify(packageJSON, undefined, 2))

--- a/packages/framework-integration-tests/integration/helper/fileHelper.ts
+++ b/packages/framework-integration-tests/integration/helper/fileHelper.ts
@@ -6,9 +6,7 @@ import {
   rmdirSync,
   unlinkSync,
   writeFileSync,
-  copyFileSync,
 } from 'fs'
-import * as path from 'path'
 
 export const loadFixture = (fixturePath: string, replacements?: Array<Array<string>>): string => {
   const template = readFileContent(`integration/fixtures/${fixturePath}`)

--- a/packages/framework-integration-tests/integration/helper/fileHelper.ts
+++ b/packages/framework-integration-tests/integration/helper/fileHelper.ts
@@ -47,34 +47,4 @@ export const removeFolders = (paths: Array<string>): void => {
 export const fileExists = existsSync
 export const dirContents = readdirSync
 
-const copyFolder = (origin: string, destiny: string): void => {
-  readdirSync(origin, { withFileTypes: true }).forEach((dirEnt) => {
-    if (dirEnt.isFile()) {
-      copyFileSync(path.join(origin, dirEnt.name), path.join(destiny, dirEnt.name))
-    }
-    if (dirEnt.isDirectory()) {
-      mkdirSync(path.join(destiny, dirEnt.name), { recursive: true })
-      copyFolder(path.join(origin, dirEnt.name), path.join(destiny, dirEnt.name))
-    }
-  })
-}
-
-const sandboxPathFor = (sandboxName: string): string => sandboxName + '-integration-sandbox' // Add the suffix to make sure this folder is gitignored
-
-export const createSandboxProject = (sandboxName: string): string => {
-  const sandboxPath = sandboxPathFor(sandboxName)
-
-  rmdirSync(sandboxPath, { recursive: true })
-  mkdirSync(sandboxPath, { recursive: true })
-  copyFolder('src', path.join(sandboxPath, 'src'))
-
-  const projectFiles = ['.eslintignore', 'package.json', 'tsconfig.eslint.json', 'tsconfig.json']
-  projectFiles.forEach((file: string) => copyFileSync(file, path.join(sandboxPath, file)))
-
-  return sandboxPath
-}
-
-export const removeSandboxProject = (sandboxName: string): void => {
-  const sandboxPath = sandboxPathFor(sandboxName)
-  rmdirSync(sandboxPath, { recursive: true })
-}
+export const sandboxPathFor = (sandboxName: string): string => sandboxName + '-integration-sandbox' // Add the suffix to make sure this folder is gitignored

--- a/packages/framework-integration-tests/integration/providers/aws/deployment/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/deployment/setup.ts
@@ -1,12 +1,15 @@
 import { deploy } from '../deploy'
 import { sleep } from '../../../helper/sleep'
 import { setEnv, checkConfigAnd } from '../utils'
-import { createSandboxProject } from '../../../helper/fileHelper'
+import { sandboxPathFor } from '../../../helper/fileHelper'
 import { overrideWithBoosterLocalDependencies } from '../../../helper/depsHelper'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../cli/src/common/sandbox'
 
 before(async () => {
   await setEnv()
-  const sandboxedProject = createSandboxProject('deploy')
+  const sandboxedProject = createSandboxProject(sandboxPathFor('deploy'))
 
   await overrideWithBoosterLocalDependencies(sandboxedProject)
 

--- a/packages/framework-integration-tests/integration/providers/aws/deployment/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/deployment/setup.ts
@@ -5,7 +5,7 @@ import { sandboxPathFor } from '../../../helper/fileHelper'
 import { overrideWithBoosterLocalDependencies } from '../../../helper/depsHelper'
 // Imported from another package to avoid duplication
 // It is OK-ish, since integration tests are always run in the context of the whole monorepo
-import { createSandboxProject } from '../../../cli/src/common/sandbox'
+import { createSandboxProject } from '../../../../../cli/src/common/sandbox'
 
 before(async () => {
   await setEnv()

--- a/packages/framework-integration-tests/integration/providers/aws/nuke/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/nuke/setup.ts
@@ -1,14 +1,18 @@
 import { overrideWithBoosterLocalDependencies } from '../../../helper/depsHelper'
-import { createSandboxProject, removeSandboxProject } from '../../../helper/fileHelper'
 import { nuke } from '../deploy'
 import { setEnv, checkConfigAnd } from '../utils'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject, removeSandboxProject } from '../../../cli/src/common/sandbox'
+import { sandboxPathFor } from '../../../helper/fileHelper'
 
 before(async () => {
   await setEnv()
-  const sandboxedProject = createSandboxProject('deploy')
+  const sandboxPath = sandboxPathFor('deploy')
+  const sandboxedProject = createSandboxProject(sandboxPath)
 
   await overrideWithBoosterLocalDependencies(sandboxedProject)
 
   await checkConfigAnd(nuke.bind(null, sandboxedProject))
-  removeSandboxProject('deploy')
+  removeSandboxProject(sandboxPath)
 })

--- a/packages/framework-integration-tests/integration/providers/aws/nuke/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/nuke/setup.ts
@@ -3,7 +3,7 @@ import { nuke } from '../deploy'
 import { setEnv, checkConfigAnd } from '../utils'
 // Imported from another package to avoid duplication
 // It is OK-ish, since integration tests are always run in the context of the whole monorepo
-import { createSandboxProject, removeSandboxProject } from '../../../cli/src/common/sandbox'
+import { createSandboxProject, removeSandboxProject } from '../../../../../cli/src/common/sandbox'
 import { sandboxPathFor } from '../../../helper/fileHelper'
 
 before(async () => {

--- a/packages/framework-integration-tests/integration/providers/local/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/local/setup.ts
@@ -1,17 +1,20 @@
 import { start } from './utils'
 import { sleep } from '../../helper/sleep'
 import { ChildProcess } from 'child_process'
-import { createSandboxProject, removeFolders } from '../../helper/fileHelper'
+import { removeFolders, sandboxPathFor } from '../../helper/fileHelper'
 import { overrideWithBoosterLocalDependencies } from '../../helper/depsHelper'
 import { sandboxName } from './constants'
 import { runCommand } from '../../helper/runCommand'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../../cli/src/common/sandbox'
 
 let serverProcess: ChildProcess
 let sandboxPath: string
 
 before(async () => {
   console.log('preparing sandboxed project...')
-  sandboxPath = createSandboxProject(sandboxName)
+  sandboxPath = createSandboxProject(sandboxPathFor(sandboxName))
 
   console.log('installing dependencies...')
   await runCommand(sandboxPath, 'npm install')

--- a/packages/framework-integration-tests/package.json
+++ b/packages/framework-integration-tests/package.json
@@ -49,12 +49,12 @@
     "compile": "tsc -b tsconfig.json",
     "clean": "npx rimraf ./dist tsconfig.tsbuildinfo",
     "integration": "npm run integration/cli && npm run integration/local && npm run integration/aws-deploy && npm run integration/aws-func && npm run integration/end-to-end && npm run integration/aws-nuke",
-    "integration/aws-deploy": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --full-stack --exit --config \"integration/providers/aws/deployment/.mocharc.yml\" \"integration/providers/aws/deployment/**/*.integration.ts\"",
-    "integration/aws-func": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --full-stack --exit --config \"integration/providers/aws/functionality/.mocharc.yml\" \"integration/providers/aws/functionality/**/*.integration.ts\"",
-    "integration/aws-nuke": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --full-stack --exit --config \"integration/providers/aws/nuke/.mocharc.yml\" \"integration/providers/aws/nuke/**/*.integration.ts\"",
-    "integration/local": "BOOSTER_ENV=local mocha --forbid-only --full-stack --exit --config \"integration/providers/local/.mocharc.yml\" \"integration/providers/local/**/*.integration.ts\"",
-    "integration/cli": "mocha --forbid-only --full-stack --exit --config \"integration/cli/.mocharc.yml\" \"integration/cli/**/*.integration.ts\"",
-    "integration/end-to-end": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --full-stack --exit --config \"integration/end-to-end/.mocharc.yml\" \"integration/end-to-end/**/*.integration.ts\""
+    "integration/aws-deploy": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --exit --config \"integration/providers/aws/deployment/.mocharc.yml\" \"integration/providers/aws/deployment/**/*.integration.ts\"",
+    "integration/aws-func": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --exit --config \"integration/providers/aws/functionality/.mocharc.yml\" \"integration/providers/aws/functionality/**/*.integration.ts\"",
+    "integration/aws-nuke": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --exit --config \"integration/providers/aws/nuke/.mocharc.yml\" \"integration/providers/aws/nuke/**/*.integration.ts\"",
+    "integration/local": "BOOSTER_ENV=local mocha --forbid-only --exit --config \"integration/providers/local/.mocharc.yml\" \"integration/providers/local/**/*.integration.ts\"",
+    "integration/cli": "mocha --full-trace --exit --config \"integration/cli/.mocharc.yml\" \"integration/cli/**/*.integration.ts\"",
+    "integration/end-to-end": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --exit --config \"integration/end-to-end/.mocharc.yml\" \"integration/end-to-end/**/*.integration.ts\""
   },
   "types": "dist/index.d.ts"
 }

--- a/packages/framework-integration-tests/src/entities/payment.ts
+++ b/packages/framework-integration-tests/src/entities/payment.ts
@@ -1,6 +1,5 @@
-import { Entity } from '@boostercloud/framework-core'
+import { Entity, Reduces } from '@boostercloud/framework-core'
 import { UUID } from '@boostercloud/framework-types'
-import { Reduces } from '@boostercloud/framework-core/dist'
 import { CartPaid } from '../events/cart-paid'
 
 @Entity

--- a/packages/framework-integration-tests/src/index.ts
+++ b/packages/framework-integration-tests/src/index.ts
@@ -8,4 +8,4 @@ export {
   boosterTriggerScheduledCommand,
 } from '@boostercloud/framework-core'
 
-Booster.start()
+Booster.start(__dirname)

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/deploy.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/deploy.test.ts
@@ -13,6 +13,8 @@ const testEnvironment = {
   account: 'testAccount',
   region: 'testRegion',
 }
+const config = new BoosterConfig('test')
+config.userProjectRootPath = '.'
 
 describe('the deployment module', () => {
   beforeEach(() => {
@@ -25,8 +27,6 @@ describe('the deployment module', () => {
 
   describe('the `deploy` method', () => {
     it('logs progress through the passed logger', async () => {
-      const config = new BoosterConfig('test')
-
       replace(
         StackTools,
         'getStackServiceConfiguration',
@@ -48,7 +48,6 @@ describe('the deployment module', () => {
     })
 
     it('throws errors', async () => {
-      const config = new BoosterConfig('test')
       const errorMessage = 'Testing error'
 
       replace(
@@ -72,8 +71,6 @@ describe('the deployment module', () => {
     })
 
     it('builds the AppStack calling to the `getStackServiceConfiguration`', async () => {
-      const config = new BoosterConfig('test')
-
       replace(
         StackTools,
         'getStackServiceConfiguration',
@@ -96,7 +93,6 @@ describe('the deployment module', () => {
     })
 
     it('calls the CDK bootstrap with the default environment parameters', async () => {
-      const config = new BoosterConfig('test')
       const fakeBootstrap = fake()
 
       replace(
@@ -123,7 +119,6 @@ describe('the deployment module', () => {
     })
 
     it('calls the CDK bootstrap with the right config parameters', async () => {
-      const config = new BoosterConfig('test')
       const testAppName = 'testing'
       config.appName = testAppName
       const fakeBootstrap = fake()
@@ -162,8 +157,6 @@ describe('the deployment module', () => {
 
     context('with rockets', () => {
       it('forwards the rockets to the `getStackServiceConfiguration` method for initialization', async () => {
-        const config = new BoosterConfig('test')
-
         replace(
           StackTools,
           'getStackServiceConfiguration',

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stack-tools.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stack-tools.test.ts
@@ -1,5 +1,5 @@
 import { StreamViewType } from '@aws-cdk/aws-dynamodb'
-import { InfrastructureRocket } from '../../src/rockets/infrastructure-rocket'
+import { InfrastructureRocket } from '../../src'
 import { BoosterConfig, UUID } from '@boostercloud/framework-types'
 import { fake, replace, restore, spy } from 'sinon'
 import { expect } from '../expect'
@@ -79,6 +79,7 @@ describe('the `stack-tools` module', () => {
       }
 
       const config = new BoosterConfig('test')
+      config.userProjectRootPath = '.'
       config.appName = 'testing-app'
       config.entities[EmptyEntity.name] = {
         class: EmptyEntity,
@@ -111,6 +112,7 @@ describe('the `stack-tools` module', () => {
       }
 
       const config = new BoosterConfig('test')
+      config.userProjectRootPath = '.'
       config.appName = 'testing-app'
       config.readModels[SomeReadModel.name] = {
         class: SomeReadModel,
@@ -170,6 +172,7 @@ describe('the `stack-tools` module', () => {
         }
 
         const config = new BoosterConfig('test')
+        config.userProjectRootPath = '.'
         config.appName = 'testing-app'
         config.entities[EmptyEntity.name] = {
           class: EmptyEntity,

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/application-stack.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/application-stack.test.ts
@@ -25,6 +25,7 @@ describe('the application stack builder', () => {
 
   const config = new BoosterConfig('test')
   config.appName = 'testing-app'
+  config.userProjectRootPath = '.'
   // eslint-disable-next-line prettier/prettier
   readModels.forEach((readModel) => {
     config.readModels[readModel.name] = {

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/read-models-stack.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/read-models-stack.test.ts
@@ -13,6 +13,7 @@ describe('ReadModelsStack', () => {
       public constructor(readonly id: UUID) {}
     }
     const config = new BoosterConfig('test')
+    config.userProjectRootPath = '.'
     config.readModels['SomeReadModel'] = {
       class: SomeReadModel,
       authorizedRoles: 'all',

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/setup.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/setup.ts
@@ -2,7 +2,7 @@ import ResourceManagementClient from 'azure-arm-resource/lib/resource/resourceMa
 import { configuration } from './params'
 import { ApplicationTokenCredentials, loginWithServicePrincipalSecret } from 'ms-rest-azure'
 import { ResourceGroup } from 'azure-arm-resource/lib/resource/models'
-import { BoosterConfig } from '@boostercloud/framework-types/dist'
+import { BoosterConfig } from '@boostercloud/framework-types'
 import WebSiteManagement from 'azure-arm-website'
 
 export async function createResourceManagementClient(

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/api-stack.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/api-stack.ts
@@ -1,4 +1,4 @@
-import { BoosterConfig } from '@boostercloud/framework-types/dist'
+import { BoosterConfig } from '@boostercloud/framework-types'
 import { buildResource } from '../utils'
 import { configuration } from '../params'
 import ResourceManagementClient from 'azure-arm-resource/lib/resource/resourceManagementClient'

--- a/packages/framework-provider-local-infrastructure/test/controllers/graphql.test.ts
+++ b/packages/framework-provider-local-infrastructure/test/controllers/graphql.test.ts
@@ -1,6 +1,6 @@
 import { mockRes, mockReq } from 'sinon-express-mock'
 import { restore, SinonStub, SinonStubbedInstance, createStubInstance, stub, replace } from 'sinon'
-import { GraphQLService } from '@boostercloud/framework-provider-local/dist'
+import { GraphQLService } from '@boostercloud/framework-provider-local'
 import { GraphQLController } from '../../src/controllers/graphql'
 import { Request, Response } from 'express'
 import { expect } from '../expect'

--- a/packages/framework-provider-local/src/library/events-adapter.ts
+++ b/packages/framework-provider-local/src/library/events-adapter.ts
@@ -1,7 +1,5 @@
-import { Logger, BoosterConfig, EventEnvelope } from '@boostercloud/framework-types'
+import { UUID, UserApp, Logger, BoosterConfig, EventEnvelope } from '@boostercloud/framework-types'
 import { EventRegistry } from '..'
-import { UUID } from '@boostercloud/framework-types'
-import { UserApp } from '@boostercloud/framework-types/dist'
 
 // eslint-disable-next-line @typescript-eslint/no-magic-numbers
 const originOfTime = new Date(0).toISOString()

--- a/packages/framework-provider-local/test/helpers/event-helper.ts
+++ b/packages/framework-provider-local/test/helpers/event-helper.ts
@@ -1,4 +1,4 @@
-import { EventEnvelope } from '@boostercloud/framework-types/dist/envelope'
+import { EventEnvelope } from '@boostercloud/framework-types'
 import { random, date } from 'faker'
 
 export function createMockEventEnvelop(): EventEnvelope {

--- a/packages/framework-provider-local/test/helpers/read-model-helper.ts
+++ b/packages/framework-provider-local/test/helpers/read-model-helper.ts
@@ -1,4 +1,4 @@
-import { ReadModelEnvelope } from '@boostercloud/framework-types/dist/envelope'
+import { ReadModelEnvelope } from '@boostercloud/framework-types'
 import { random } from 'faker'
 
 export function createMockReadModelEnvelope(): ReadModelEnvelope {

--- a/packages/framework-provider-local/test/library/events-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/events-adapter.test.ts
@@ -1,10 +1,8 @@
 import { createStubInstance, fake, SinonStub, SinonStubbedInstance, replace, stub } from 'sinon'
 import { EventRegistry } from '../../src/services'
 import { readEntityEventsSince, readEntityLatestSnapshot, storeEvents } from '../../src/library/events-adapter'
-import { BoosterConfig, Logger } from '@boostercloud/framework-types'
+import { UserApp, EventEnvelope, UUID, BoosterConfig, Logger } from '@boostercloud/framework-types'
 import { expect } from '../expect'
-import { UserApp } from '@boostercloud/framework-types'
-import { EventEnvelope, UUID } from '@boostercloud/framework-types/dist'
 import { createMockEventEnvelop, createMockSnapshot } from '../helpers/event-helper'
 import { random, date } from 'faker'
 

--- a/packages/framework-types/package.json
+++ b/packages/framework-types/package.json
@@ -31,14 +31,14 @@
     "url": "https://github.com/boostercloud/booster/issues"
   },
   "dependencies": {
-    "uuid": "8.3.2"
+    "uuid": "8.3.2",
+    "@types/graphql": "14.5.0"
   },
   "devDependencies": {
     "@types/uuid": "8.3.0",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "fast-check": "^1.18.1",
-    "graphql": "15.4.0",
     "sinon-chai": "3.5.0"
   }
 }

--- a/packages/framework-types/src/booster-app.ts
+++ b/packages/framework-types/src/booster-app.ts
@@ -5,7 +5,7 @@ import { BoosterConfig, UUID, EntityInterface, Class, ReadModelInterface, Search
  * the framework provides.
  */
 export interface BoosterApp {
-  start(): void
+  start(projectPath: string): void
   configure(environment: string, configurator: (config: BoosterConfig) => void): void
   configureCurrentEnv(configurator: (config: BoosterConfig) => void): void
   fetchEntitySnapshot<TEntity extends EntityInterface>(

--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -11,6 +11,7 @@ import {
 } from './concepts'
 import { ProviderLibrary } from './provider'
 import { Level } from './logger'
+import * as path from 'path'
 
 /**
  * Class used by external packages that needs to get a representation of
@@ -24,12 +25,16 @@ export class BoosterConfig {
     maxConnectionDurationInSeconds: 7 * 24 * 60 * 60, // 7 days
     maxDurationInSeconds: 2 * 24 * 60 * 60, // 2 days
   }
-  public readonly userProjectRootPath: string = process.cwd()
-  public readonly eventDispatcherHandler: string = 'dist/index.boosterEventDispatcher'
-  public readonly preSignUpHandler: string = 'dist/index.boosterPreSignUpChecker'
-  public readonly serveGraphQLHandler: string = 'dist/index.boosterServeGraphQL'
-  public readonly scheduledTaskHandler: string = 'dist/index.boosterTriggerScheduledCommand'
-  public readonly notifySubscribersHandler: string = 'dist/index.boosterNotifySubscribers'
+  private _userProjectRootPath?: string
+  public readonly codeRelativePath: string = 'dist'
+  public readonly eventDispatcherHandler: string = path.join(this.codeRelativePath, 'index.boosterEventDispatcher')
+  public readonly preSignUpHandler: string = path.join(this.codeRelativePath, 'index.boosterPreSignUpChecker')
+  public readonly serveGraphQLHandler: string = path.join(this.codeRelativePath, 'index.boosterServeGraphQL')
+  public readonly scheduledTaskHandler: string = path.join(
+    this.codeRelativePath,
+    'index.boosterTriggerScheduledCommand'
+  )
+  public readonly notifySubscribersHandler: string = path.join(this.codeRelativePath, 'index.boosterNotifySubscribers')
 
   public readonly entities: Record<EntityName, EntityMetadata> = {}
   public readonly reducers: Record<EventName, ReducerMetadata> = {}
@@ -101,6 +106,16 @@ export class BoosterConfig {
 
   public set provider(provider: ProviderLibrary) {
     this._provider = provider
+  }
+
+  public get userProjectRootPath(): string {
+    if (!this._userProjectRootPath)
+      throw new Error('Property "userProjectRootPath" is not set. Ensure you have called "Booster.start"')
+    return this._userProjectRootPath
+  }
+
+  public set userProjectRootPath(path: string) {
+    this._userProjectRootPath = path
   }
 
   public mustGetEnvironmentVar(varName: string): string {

--- a/packages/framework-types/src/graphql-websocket-messages.ts
+++ b/packages/framework-types/src/graphql-websocket-messages.ts
@@ -1,4 +1,8 @@
 import { GraphQLOperation } from './envelope'
+// Disable this lint rule here. In "framework-types" we only need the types of graphql,
+// so we use the dependency "@types/graphql". However, this lint rule expects us to use the whole "graphql"
+// dependency, which doesn't make sense for this case.
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { ExecutionResult } from 'graphql'
 
 export enum MessageTypes {


### PR DESCRIPTION
## Description of the problem
We were having a lot of problems when deploying because:
- We were including dev dependencies in the deployed lambdas, making them weight too much and getting errors
- To fix this, we were installing production dependencies and removing the dev ones before deployment, but then we were missing dependencies that were really needed at deployment time.
- To fix the above, we tried to install some of those dependencies globally, but we discovered that there were more dependencies than expected and people started to also have problems with this.

## Description of this PR's solution
Apply the same technique we were applying in the integration tests by creating a sandbox project. In brief:
- When you call `boost deploy`, before doing the actual deployment, we create a sandbox project (it is a copy of the project with only the strictly needed files)
- Go inside that sandbox project, and **install only the production deployment**
- Leave the rest of the deployment process run as always.

## Why this works?
When NPM wants to find a dependency, it first searches inside `./node_modules` folder. If not found, then it goes up one directory level and searches inside `../node_modules`. If not found again, searches inside `../../node_modules`, if not, inside `../../../node_modules`, etc.
The sandboxed project only contains the production dependencies, which means they don't include the _required_ `*-infrastructure` packages. But there is no problem: they will be found one level up, in the original non-sandboxed project, which contains all de devDependencies.

So thanks to this solution, we:
- Only deploy what is strictly needed for runtime
- Can have as many devDependencies as we want
- The deployment works correctly

## Important notice
With this solution, we **don't need to install globally the infrastructure dependencies**, but **they must be listed in the `devDependencies` section of the "package.json" file

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
