### PR TITLE
fixed Underscore _ in project name must be escaped before deploying #567

### DIFF
--- a/packages/cli/src/services/provider-service.ts
+++ b/packages/cli/src/services/provider-service.ts
@@ -18,7 +18,7 @@ export function assertNameIsCorrect(name: string): void {
     Found: '${name}'`)
   
   if (name.includes('_'))
-    throw new Error(`Project name cannot contain underscore(_):
+    throw new Error(`Project name cannot contain underscore:
 
     Found: '${name}'`)
 

--- a/packages/cli/src/services/provider-service.ts
+++ b/packages/cli/src/services/provider-service.ts
@@ -16,6 +16,11 @@ export function assertNameIsCorrect(name: string): void {
     throw new Error(`Project name cannot contain spaces:
 
     Found: '${name}'`)
+  
+  if (name.includes('_'))
+    throw new Error(`Project name cannot contain underscore(_):
+
+    Found: '${name}'`)
 
   if (name.toLowerCase() != name)
     throw new Error(`Project name cannot contain uppercase letters:


### PR DESCRIPTION
## Description
fixed Underscore _ in project name must be escaped before deploying #567

## Changes
 add a check in  assertNameIsCorrect to check for "_" in project name
## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
## Additional information
