### PR TITLE
New GraphQL filters

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1565,7 +1565,7 @@ Booster GraphQL API also provides support for real-time updates using subscripti
 
 #### Getting and filtering read models data at code level
 
-Booster allows you to get your read models data in your commands, handlers, etc. Using the `Booster.readModel` method.
+Booster allows you to get your read models data in your commands handlers and event handlers using the `Booster.readModel` method.
 
 For example, you can filter and get the total number of the products that meet your criteria in your commands like this:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,99 +3,99 @@
 <!-- toc -->
 
 - [Introduction](#introduction)
-  * [What is Booster?](#what-is-booster)
-  * [Booster Principles](#booster-principles)
-  * [Why use Booster](#why-use-booster)
+  - [What is Booster?](#what-is-booster)
+  - [Booster Principles](#booster-principles)
+  - [Why use Booster](#why-use-booster)
 - [Getting started](#getting-started)
-  * [Installing Booster](#installing-booster)
-    + [Prerequisites](#prerequisites)
-    + [Installing the Booster CLI](#installing-the-booster-cli)
-  * [Your first Booster app in 10 minutes](#your-first-booster-app-in-10-minutes)
-    + [1. Create the project](#1-create-the-project)
-    + [2. First command](#2-first-command)
-    + [3. First event](#3-first-event)
-    + [4. First entity](#4-first-entity)
-    + [5. First read model](#5-first-read-model)
-    + [6. Deployment](#6-deployment)
-    + [7. Testing](#7-testing)
-    + [8. Removing the stack](#8-removing-the-stack)
-    + [9. More functionalities](#9-more-functionalities)
+  - [Installing Booster](#installing-booster)
+    - [Prerequisites](#prerequisites)
+    - [Installing the Booster CLI](#installing-the-booster-cli)
+  - [Your first Booster app in 10 minutes](#your-first-booster-app-in-10-minutes)
+    - [1. Create the project](#1-create-the-project)
+    - [2. First command](#2-first-command)
+    - [3. First event](#3-first-event)
+    - [4. First entity](#4-first-entity)
+    - [5. First read model](#5-first-read-model)
+    - [6. Deployment](#6-deployment)
+    - [7. Testing](#7-testing)
+    - [8. Removing the stack](#8-removing-the-stack)
+    - [9. More functionalities](#9-more-functionalities)
 - [Booster architecture](#booster-architecture)
-  * [1. Command and command handlers](#1-command-and-command-handlers)
-    + [Commands naming convention](#commands-naming-convention)
-    + [Creating a command](#creating-a-command)
-    + [The command handler function](#the-command-handler-function)
-    + [Authorizing a command](#authorizing-a-command)
-    + [Submitting a command](#submitting-a-command)
-    + [Scheduling a command](#scheduling-a-command)
-    + [Creating a scheduled command](#creating-a-scheduled-command)
-  * [2. Events](#2-events)
-    + [Events naming convention](#events-naming-convention)
-    + [Creating events](#creating-events)
-    + [Registering events in the event store](#registering-events-in-the-event-store)
-    + [Events ordering](#events-ordering)
-  * [3. Event handlers](#3-event-handlers)
-    + [Creating an event handler](#creating-an-event-handler)
-    + [Registering events from an event handler](#registering-events-from-an-event-handler)
-    + [Reading entities from event handlers](#reading-entities-from-event-handlers)
-  * [4. Entities and reducers](#4-entities-and-reducers)
-    + [Entities naming convention](#entities-naming-convention)
-    + [Creating entities](#creating-entities)
-    + [The reducer function](#the-reducer-function)
-    + [Eventual consistency](#eventual-consistency)
-  * [5. Read models and projections](#5-read-models-and-projections)
-    + [Read models naming convention](#read-models-naming-convention)
-    + [Creating a read model](#creating-a-read-model)
-    + [The projection function](#the-projection-function)
-    + [Authorizing read models](#authorizing-read-models)
-    + [Querying a read model](#querying-a-read-model)
-    + [Getting real-time updates for a read model](#getting-real-time-updates-for-a-read-model)
+  - [1. Command and command handlers](#1-command-and-command-handlers)
+    - [Commands naming convention](#commands-naming-convention)
+    - [Creating a command](#creating-a-command)
+    - [The command handler function](#the-command-handler-function)
+    - [Authorizing a command](#authorizing-a-command)
+    - [Submitting a command](#submitting-a-command)
+    - [Scheduling a command](#scheduling-a-command)
+    - [Creating a scheduled command](#creating-a-scheduled-command)
+  - [2. Events](#2-events)
+    - [Events naming convention](#events-naming-convention)
+    - [Creating events](#creating-events)
+    - [Registering events in the event store](#registering-events-in-the-event-store)
+    - [Events ordering](#events-ordering)
+  - [3. Event handlers](#3-event-handlers)
+    - [Creating an event handler](#creating-an-event-handler)
+    - [Registering events from an event handler](#registering-events-from-an-event-handler)
+    - [Reading entities from event handlers](#reading-entities-from-event-handlers)
+  - [4. Entities and reducers](#4-entities-and-reducers)
+    - [Entities naming convention](#entities-naming-convention)
+    - [Creating entities](#creating-entities)
+    - [The reducer function](#the-reducer-function)
+    - [Eventual consistency](#eventual-consistency)
+  - [5. Read models and projections](#5-read-models-and-projections)
+    - [Read models naming convention](#read-models-naming-convention)
+    - [Creating a read model](#creating-a-read-model)
+    - [The projection function](#the-projection-function)
+    - [Authorizing read models](#authorizing-read-models)
+    - [Querying a read model](#querying-a-read-model)
+    - [Getting real-time updates for a read model](#getting-real-time-updates-for-a-read-model)
 - [Features](#features)
-  * [Authentication and Authorization](#authentication-and-authorization)
-    + [Authentication API](#authentication-api)
-  * [Custom Authentication](#custom-authentication)
-    + [JWT Configuration](#jwt-configuration)
-  * [GraphQL API](#graphql-api)
-    + [Relationship between GraphQL operations and commands and read models](#relationship-between-graphql-operations-and-commands-and-read-models)
-    + [How to send GraphQL request](#how-to-send-graphql-request)
-    + [Get GraphQL schema from deployed application](#get-graphql-schema-from-deployed-application)
-    + [Sending commands](#sending-commands)
-    + [Reading read models](#reading-read-models)
-    + [Subscribing to read models](#subscribing-to-read-models)
-    + [Using Apollo Client](#using-apollo-client)
-    + [Authorizing operations](#authorizing-operations)
-    + [The GraphQL over WebSocket protocol](#the-graphql-over-websocket-protocol)
-  * [Cloud native](#cloud-native)
-    + [Configure your provider credentials](#configure-your-provider-credentials)
-    + [Deploy your project](#deploy-your-project)
-    + [Application outputs](#application-outputs)
-    + [Delete your cloud stack](#delete-your-cloud-stack)
+  - [Authentication and Authorization](#authentication-and-authorization)
+    - [Authentication API](#authentication-api)
+  - [Custom Authentication](#custom-authentication)
+    - [JWT Configuration](#jwt-configuration)
+  - [GraphQL API](#graphql-api)
+    - [Relationship between GraphQL operations and commands and read models](#relationship-between-graphql-operations-and-commands-and-read-models)
+    - [How to send GraphQL request](#how-to-send-graphql-request)
+    - [Get GraphQL schema from deployed application](#get-graphql-schema-from-deployed-application)
+    - [Sending commands](#sending-commands)
+    - [Reading read models](#reading-read-models)
+    - [Subscribing to read models](#subscribing-to-read-models)
+    - [Using Apollo Client](#using-apollo-client)
+    - [Authorizing operations](#authorizing-operations)
+    - [The GraphQL over WebSocket protocol](#the-graphql-over-websocket-protocol)
+  - [Cloud native](#cloud-native)
+    - [Configure your provider credentials](#configure-your-provider-credentials)
+    - [Deploy your project](#deploy-your-project)
+    - [Application outputs](#application-outputs)
+    - [Delete your cloud stack](#delete-your-cloud-stack)
 - [Going deeper with Booster](#going-deeper-with-booster)
-  * [Contributing](#contributing)
-  * [Framework Core](#framework-core)
-  * [Framework Types](#framework-types)
-  * [Framework integration tests](#framework-integration-tests)
-  * [Providers](#providers)
-    + [framework-provider-aws-\*](#framework-provider-aws-)
-    + [framework-provider-local-\*](#framework-provider-local-)
-    + [framework-provider-kubernetes-\*](#framework-provider-kubernetes-)
-    + [framework-provider-azure-\*](#framework-provider-azure-)
-  * [Configuration and environments](#configuration-and-environments)
-    + [Booster configuration](#booster-configuration)
-    + [Environments](#environments)
-  * [Extending Booster with Rockets!](#extending-booster-with-rockets)
-    + [Naming recommendations](#naming-recommendations)
-    + [Infrastructure extensions](#infrastructure-extensions)
-    + [Runtime extensions (Not yet implemented)](#runtime-extensions-not-yet-implemented)
-    + [Deploy and init hooks (Not yet implemented)](#deploy-and-init-hooks-not-yet-implemented)
+  - [Contributing](#contributing)
+  - [Framework Core](#framework-core)
+  - [Framework Types](#framework-types)
+  - [Framework integration tests](#framework-integration-tests)
+  - [Providers](#providers)
+    - [framework-provider-aws-\*](#framework-provider-aws-)
+    - [framework-provider-local-\*](#framework-provider-local-)
+    - [framework-provider-kubernetes-\*](#framework-provider-kubernetes-)
+    - [framework-provider-azure-\*](#framework-provider-azure-)
+  - [Configuration and environments](#configuration-and-environments)
+    - [Booster configuration](#booster-configuration)
+    - [Environments](#environments)
+  - [Extending Booster with Rockets!](#extending-booster-with-rockets)
+    - [Naming recommendations](#naming-recommendations)
+    - [Infrastructure extensions](#infrastructure-extensions)
+    - [Runtime extensions (Not yet implemented)](#runtime-extensions-not-yet-implemented)
+    - [Deploy and init hooks (Not yet implemented)](#deploy-and-init-hooks-not-yet-implemented)
 - [Debugging and testing Booster applications](#debugging-and-testing-booster-applications)
-  * [Running Booster applications locally](#running-booster-applications-locally)
-    + [Local development prerequisites](#local-development-prerequisites)
-    + [Starting your application](#starting-your-application)
-    + [Performing Auth requests](#performing-auth-requests)
-    + [Performing GraphQL requests](#performing-graphql-requests)
-    + [Inspect Database information](#inspect-database-information)
-  * [Booster examples](#booster-examples)
+  - [Running Booster applications locally](#running-booster-applications-locally)
+    - [Local development prerequisites](#local-development-prerequisites)
+    - [Starting your application](#starting-your-application)
+    - [Performing Auth requests](#performing-auth-requests)
+    - [Performing GraphQL requests](#performing-graphql-requests)
+    - [Inspect Database information](#inspect-database-information)
+  - [Booster examples](#booster-examples)
 - [Frequently Asked Questions](#frequently-asked-questions)
 
 <!-- tocstop -->
@@ -210,6 +210,7 @@ versions:
 - [`nvm-windows`](https://github.com/coreybutler/nvm-windows) - Works with native Windows
 
 ##### Install Git
+
 Booster will initialize a Git repository when you create a new project (unless you use the `--skipGit` flag), so it is required that you have it already installed in your system.
 
 ###### Ubuntu
@@ -231,6 +232,7 @@ choco install git
 ```
 
 ###### Git configuration variables
+
 After installing git in your machine, make sure that `user.name` and `user.email` are properly configured.
 Take a look at the [Git configuration page](https://git-scm.com/docs/git-config) for more info.
 
@@ -393,15 +395,15 @@ parameters are as follows:
 
 If you prefer to specify each parameter without following the instructions, you can use the following flags with this structure `<flag>=<parameter>`.
 
-| Flag                   | Short version | Description |
-| :--------------------- | :------------ | :---------- |
-| `--homepage`           | `-H`          | The website of this project |
-| `--author`             | `-a`          | Author of this project |
-| `--description`        | `-d`          | A short description |
-| `--license`            | `-l`          | License used in this project |
-| `--providerPackageName`| `-p`          | Package name implementing the cloud provider integration where the application will be deployed |
-| `--repository`         | `-r`          | The URL of the repository |
-| `--version`            | `-v`          | The initial version |
+| Flag                    | Short version | Description                                                                                     |
+| :---------------------- | :------------ | :---------------------------------------------------------------------------------------------- |
+| `--homepage`            | `-H`          | The website of this project                                                                     |
+| `--author`              | `-a`          | Author of this project                                                                          |
+| `--description`         | `-d`          | A short description                                                                             |
+| `--license`             | `-l`          | License used in this project                                                                    |
+| `--providerPackageName` | `-p`          | Package name implementing the cloud provider integration where the application will be deployed |
+| `--repository`          | `-r`          | The URL of the repository                                                                       |
+| `--version`             | `-v`          | The initial version                                                                             |
 
 Additionally, you can use the `--skipInstall` flag if you want to skip installing dependencies and the `--skipGit` flag in case you want to skip git initialization.
 
@@ -1561,6 +1563,42 @@ For more information about queries and how to use them, please check the [GraphQ
 
 Booster GraphQL API also provides support for real-time updates using subscriptions and websocket, to get more information about it go to the [GraphQL API](#subscribing-to-read-models) section.
 
+#### Getting and filtering read models data at code level
+
+Booster allows you to get your read models data in your commands, handlers, etc. Using the `Booster.readModel` method.
+
+For example, you can filter and get the total number of the products that meet your criteria in your commands like this:
+
+```typescript
+@Command({
+  authorize: 'all',
+})
+export class GetProductsCount {
+  public constructor(readonly filters: Record<string, any>) {}
+
+  public static async handle(): Promise<void> {
+    const searcher = Booster.readModel(ProductReadModel)
+
+    searcher.filter({
+      sku: { contains: 'toy' },
+      or: [
+        {
+          description: { contains: 'fancy' },
+        },
+        {
+          description: { contains: 'great' },
+        },
+      ],
+    })
+
+    const result = await searcher.search()
+    return { count: result.length }
+  }
+}
+```
+
+> **Warning**: Notice that `ReadModel`s are eventually consistent objects that are calculated as all events in all entities that affect the read model are settled. You should not assume that a read model is a proper source of truth, so you shouldn't use this feature for data validations. If you need to query the most up-to-date current state, consider fetching your Entities, instead of ReadModels, with `Booster.fetchEntitySnapshot`
+
 ## Features
 
 ### Authentication and Authorization
@@ -1926,7 +1964,7 @@ Booster.configure('production', (config: BoosterConfig): void => {
   config.provider = AWS.Provider
   config.tokenVerifier = {
     jwksUri: 'https://demoapp.auth0.com/.well-known/jwks.json',
-    issuer: 'auth0'
+    issuer: 'auth0',
   }
 })
 ```
@@ -2655,12 +2693,11 @@ The following is the list of the fields you can configure:
 
 _**Note:** So far, there is only one provider fully supported in Booster yet, @boostercloud/framework-provider-aws, and it is probably the one you have already set if you used the generator to create your project. The team is currently working on providers for local development, Azure, and Kubernetes._
 
-- **assets**: This is an array of _relative_ paths from the root of the project pointing to files and folders with static assets. They will be included among the deployed files to the cloud provider. 
-For example, imagine you are using the "dotenv" module so that all the environment variables you have in your `.env` files are loaded into memory in runtime. In order for this to work, you need to include your `.env` files as assets of your project, so that they are included when deploying. Assuming you only have a `.env` file in the root of your project, you should add the following to your configuration:
-  
-  ````typescript
-    config.assets = ['.env']
-  ````
+- **assets**: This is an array of _relative_ paths from the root of the project pointing to files and folders with static assets. They will be included among the deployed files to the cloud provider.
+  For example, imagine you are using the "dotenv" module so that all the environment variables you have in your `.env` files are loaded into memory in runtime. In order for this to work, you need to include your `.env` files as assets of your project, so that they are included when deploying. Assuming you only have a `.env` file in the root of your project, you should add the following to your configuration:
+  ```typescript
+  config.assets = ['.env']
+  ```
 
 #### Environments
 
@@ -2791,12 +2828,15 @@ _src/config/production.ts:_
 ```typescript
 Booster.configure('development', (config: BoosterConfig): void => {
   config.appName = 'my-store'
-  config.provider = AWSProvider([{
-    packageName: 'rocket-your-rocket-name-aws-infrastructure', // The name of your infrastructure rocket package
-    parameters: { // An arbitrary object with the parameters required by your infrastructure rocket initializator
-      hello: 'world'
-    }
-  }])
+  config.provider = AWSProvider([
+    {
+      packageName: 'rocket-your-rocket-name-aws-infrastructure', // The name of your infrastructure rocket package
+      parameters: {
+        // An arbitrary object with the parameters required by your infrastructure rocket initializator
+        hello: 'world',
+      },
+    },
+  ])
 })
 ```
 

--- a/packages/framework-core/src/booster-read-model-dispatcher.ts
+++ b/packages/framework-core/src/booster-read-model-dispatcher.ts
@@ -58,9 +58,7 @@ export class BoosterReadModelDispatcher {
     const readModelMetadata = this.config.readModels[readModelRequest.typeName]
     const searcher = Booster.readModel(readModelMetadata.class)
     if (readModelRequest.filters) {
-      for (const propName in readModelRequest.filters) {
-        searcher.filter(propName as any)
-      }
+      searcher.filter(readModelRequest.filters)
     }
     return searcher.search()
   }

--- a/packages/framework-core/src/booster-read-model-dispatcher.ts
+++ b/packages/framework-core/src/booster-read-model-dispatcher.ts
@@ -61,7 +61,7 @@ export class BoosterReadModelDispatcher {
       for (const propName in readModelRequest.filters) {
         const filter = readModelRequest.filters[propName]
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        searcher.filter(propName as any, filter.operation as any, ...filter.values)
+        searcher.filterOld(propName as any, filter.operation as any, ...filter.values)
       }
     }
     return searcher.search()

--- a/packages/framework-core/src/booster-read-model-dispatcher.ts
+++ b/packages/framework-core/src/booster-read-model-dispatcher.ts
@@ -59,9 +59,7 @@ export class BoosterReadModelDispatcher {
     const searcher = Booster.readModel(readModelMetadata.class)
     if (readModelRequest.filters) {
       for (const propName in readModelRequest.filters) {
-        const filter = readModelRequest.filters[propName]
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        searcher.filterOld(propName as any, filter.operation as any, ...filter.values)
+        searcher.filter(propName as any)
       }
     }
     return searcher.search()

--- a/packages/framework-core/src/services/graphql/graphql-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-generator.ts
@@ -79,7 +79,7 @@ export class GraphQLGenerator {
     readModelClass: AnyClass
   ): GraphQLFieldResolver<any, GraphQLResolverContext, Record<string, ReadModelPropertyFilter>> {
     return async (parent, args, context, info) => {
-      const filterArgs = { id: { operation: '=', values: [args.id] } }
+      const filterArgs = { id: { eq: args.id } }
       const result = await this.readModelResolverBuilder(readModelClass)(parent, filterArgs, context, info)
       return result[0]
     }
@@ -99,7 +99,7 @@ export class GraphQLGenerator {
     readModelClass: AnyClass
   ): GraphQLFieldResolver<any, GraphQLResolverContext, Record<string, ReadModelPropertyFilter>> {
     return async (parent, args, context, info) => {
-      const filterArgs = { id: { operation: '=', values: [args.id] } }
+      const filterArgs = { id: { eq: args.id } }
       return this.subscriptionResolverBuilder(readModelClass)(parent, filterArgs, context, info)
     }
   }

--- a/packages/framework-core/src/services/pub-sub/read-model-pub-sub.ts
+++ b/packages/framework-core/src/services/pub-sub/read-model-pub-sub.ts
@@ -4,6 +4,7 @@ import {
   ReadModelInterface,
   ReadModelPropertyFilter,
   Instance,
+  Operation,
 } from '@boostercloud/framework-types'
 
 export interface ReadModelPubSub {
@@ -27,43 +28,46 @@ function filterReadModel(readModel: Record<string, any>, filters?: Record<string
     return true
   }
   for (const filteredProp in filters) {
+    console.log('*** pub-sub', { filteredProp, filters })
     const readModelPropValue = readModel[filteredProp]
-    const { operation, values }: ReadModelPropertyFilter = filters[filteredProp]
-
-    switch (operation) {
-      case '=':
-        if (readModelPropValue !== values[0]) return false
-        break
-      case '!=':
-        if (readModelPropValue === values[0]) return false
-        break
-      case '<':
-        if (readModelPropValue >= values[0]) return false
-        break
-      case '>':
-        if (readModelPropValue <= values[0]) return false
-        break
-      case '>=':
-        if (readModelPropValue < values[0]) return false
-        break
-      case '<=':
-        if (readModelPropValue > values[0]) return false
-        break
-      case 'in':
-        if (!values.includes(readModelPropValue)) return false
-        break
-      case 'between':
-        if (readModelPropValue < values[0] || readModelPropValue > values[1]) return false
-        break
-      case 'contains':
-        if (!contains(readModelPropValue, values[0])) return false
-        break
-      case 'not-contains':
-        if (contains(readModelPropValue, values[0])) return false
-        break
-      case 'begins-with':
-        if (!beginWith(readModelPropValue, values[0] as string)) return false
-        break
+    // const operation: ReadModelPropertyFilter = filters[filteredProp]
+    for (const [operation, value] of Object.entries(filters[filteredProp] as Operation<any>)) {
+      console.log({ filters, filteredProp, operation, value })
+      switch (operation) {
+        case '=':
+          if (readModelPropValue !== value) return false
+          break
+        case '!=':
+          if (readModelPropValue === value) return false
+          break
+        case '<':
+          if (readModelPropValue >= value) return false
+          break
+        case '>':
+          if (readModelPropValue <= value) return false
+          break
+        case '>=':
+          if (readModelPropValue < value) return false
+          break
+        case '<=':
+          if (readModelPropValue > value) return false
+          break
+        case 'in':
+          // if (!values.includes(readModelPropValue)) return false
+          break
+        case 'between':
+          // if (readModelPropValue < value || readModelPropValue > values[1]) return false
+          break
+        case 'contains':
+          if (!contains(readModelPropValue, value)) return false
+          break
+        case 'not-contains':
+          if (contains(readModelPropValue, value)) return false
+          break
+        case 'begins-with':
+          if (!beginWith(readModelPropValue, value as string)) return false
+          break
+      }
     }
   }
   return true

--- a/packages/framework-core/src/services/pub-sub/read-model-pub-sub.ts
+++ b/packages/framework-core/src/services/pub-sub/read-model-pub-sub.ts
@@ -28,11 +28,8 @@ function filterReadModel(readModel: Record<string, any>, filters?: Record<string
     return true
   }
   for (const filteredProp in filters) {
-    console.log('*** pub-sub', { filteredProp, filters })
     const readModelPropValue = readModel[filteredProp]
-    // const operation: ReadModelPropertyFilter = filters[filteredProp]
     for (const [operation, value] of Object.entries(filters[filteredProp] as Operation<any>)) {
-      console.log({ filters, filteredProp, operation, value })
       switch (operation) {
         case '=':
           if (readModelPropValue !== value) return false
@@ -53,10 +50,7 @@ function filterReadModel(readModel: Record<string, any>, filters?: Record<string
           if (readModelPropValue > value) return false
           break
         case 'in':
-          // if (!values.includes(readModelPropValue)) return false
-          break
-        case 'between':
-          // if (readModelPropValue < value || readModelPropValue > values[1]) return false
+          if (!value.includes(readModelPropValue)) return false
           break
         case 'contains':
           if (!contains(readModelPropValue, value)) return false

--- a/packages/framework-core/src/services/pub-sub/read-model-pub-sub.ts
+++ b/packages/framework-core/src/services/pub-sub/read-model-pub-sub.ts
@@ -29,39 +29,44 @@ function filterReadModel(readModel: Record<string, any>, filters?: Record<string
   }
   for (const filteredProp in filters) {
     const readModelPropValue = readModel[filteredProp]
-    for (const [operation, value] of Object.entries(filters[filteredProp] as Operation<any>)) {
-      switch (operation) {
-        case '=':
-          if (readModelPropValue !== value) return false
-          break
-        case '!=':
-          if (readModelPropValue === value) return false
-          break
-        case '<':
-          if (readModelPropValue >= value) return false
-          break
-        case '>':
-          if (readModelPropValue <= value) return false
-          break
-        case '>=':
-          if (readModelPropValue < value) return false
-          break
-        case '<=':
-          if (readModelPropValue > value) return false
-          break
-        case 'in':
-          if (!value.includes(readModelPropValue)) return false
-          break
-        case 'contains':
-          if (!contains(readModelPropValue, value)) return false
-          break
-        case 'not-contains':
-          if (contains(readModelPropValue, value)) return false
-          break
-        case 'begins-with':
-          if (!beginWith(readModelPropValue, value as string)) return false
-          break
-      }
+    return filterByOperation(filters[filteredProp], readModelPropValue)
+  }
+  return true
+}
+
+function filterByOperation(filter: ReadModelPropertyFilter, readModelPropValue: any): boolean {
+  for (const [operation, value] of Object.entries(filter as Operation<any>)) {
+    switch (operation) {
+      case '=':
+        if (readModelPropValue !== value) return false
+        break
+      case '!=':
+        if (readModelPropValue === value) return false
+        break
+      case '<':
+        if (readModelPropValue >= value) return false
+        break
+      case '>':
+        if (readModelPropValue <= value) return false
+        break
+      case '>=':
+        if (readModelPropValue < value) return false
+        break
+      case '<=':
+        if (readModelPropValue > value) return false
+        break
+      case 'in':
+        if (!value.includes(readModelPropValue)) return false
+        break
+      case 'contains':
+        if (!contains(readModelPropValue, value)) return false
+        break
+      case 'not-contains':
+        if (contains(readModelPropValue, value)) return false
+        break
+      case 'begins-with':
+        if (!beginWith(readModelPropValue, value as string)) return false
+        break
     }
   }
   return true

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/stacks/permissions.ts
@@ -62,7 +62,13 @@ export const setupPermissions = (
   const tableArns = readModelTables.map((table): string => table.tableArn)
   if (tableArns.length > 0) {
     eventsLambda.addToRolePolicy(
-      createPolicyStatement(tableArns, ['dynamodb:Get*', 'dynamodb:Scan*', 'dynamodb:Put*', 'dynamodb:DeleteItem*'])
+      createPolicyStatement(tableArns, [
+        'dynamodb:Get*',
+        'dynamodb:Query*',
+        'dynamodb:Scan*',
+        'dynamodb:Put*',
+        'dynamodb:DeleteItem*',
+      ])
     )
     graphQLLambda.addToRolePolicy(createPolicyStatement(tableArns, ['dynamodb:Query*', 'dynamodb:Scan*']))
     if (scheduledCommandStack) {

--- a/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/infrastructure/stacks/permissions.test.ts
@@ -192,7 +192,7 @@ describe('permissions', () => {
         it('should create read model permissions', () => {
           expect(createPolicyStatementStub).calledWithExactly(
             [mockReadModelTableArn],
-            ['dynamodb:Get*', 'dynamodb:Scan*', 'dynamodb:Put*', 'dynamodb:DeleteItem*']
+            ['dynamodb:Get*', 'dynamodb:Query*', 'dynamodb:Scan*', 'dynamodb:Put*', 'dynamodb:DeleteItem*']
           )
         })
       })

--- a/packages/framework-provider-aws/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-aws/src/library/searcher-adapter.ts
@@ -87,6 +87,8 @@ function buildOperation(propName: string, filter: Operation<any> = {}): string {
           return `contains(#${propName}, ${holder(index)})`
         case 'beginsWith':
           return `begins_with(#${propName}, ${holder(index)})`
+        case 'includes':
+          return `contains(#${propName}, ${holder(index)})`
         default:
           if (typeof value === 'object') {
             return `#${propName}.${buildOperation(operation, value)}`
@@ -123,10 +125,12 @@ function buildExpressionAttributeNames(filters: FilterFor<any>): ExpressionAttri
           Object.assign(attributeNames, buildExpressionAttributeNames(filter as FilterFor<any>))
         }
         break
+      case 'includes':
+        break
       default:
         Object.entries(filters[propName] as FilterFor<any>).forEach(([prop, value]) => {
           attributeNames[`#${propName}`] = propName
-          if (typeof value === 'object') {
+          if (typeof value === 'object' && !Array.isArray(value)) {
             Object.assign(attributeNames, buildExpressionAttributeNames({ [prop]: value }))
           }
         })
@@ -166,7 +170,7 @@ function buildAttributeValue(propName: string, filter: Operation<any> = {}): Exp
       value.forEach((element, subIndex) => {
         attributeValues[holder(index, subIndex)] = element
       })
-    } else if (typeof value === 'object') {
+    } else if (typeof value === 'object' && key !== 'includes') {
       Object.assign(attributeValues, buildExpressionAttributeValues({ [key]: value }))
     } else {
       attributeValues[holder(index)] = value

--- a/packages/framework-provider-aws/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-aws/src/library/searcher-adapter.ts
@@ -10,7 +10,7 @@ export async function searchReadModel(
   config: BoosterConfig,
   logger: Logger,
   readModelName: string,
-  filters: FilterFor<any>
+  filters: FilterFor<unknown>
 ): Promise<Array<any>> {
   let params: DocumentClient.ScanInput = {
     TableName: config.resourceNames.forReadModel(readModelName),

--- a/packages/framework-provider-aws/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-aws/src/library/searcher-adapter.ts
@@ -126,6 +126,7 @@ function buildExpressionAttributeNames(filters: FilterFor<any>): ExpressionAttri
         }
         break
       case 'includes':
+        // In case of includes, avoid the default behaviour
         break
       default:
         Object.entries(filters[propName] as FilterFor<any>).forEach(([prop, value]) => {

--- a/packages/framework-provider-aws/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-aws/src/library/searcher-adapter.ts
@@ -1,4 +1,4 @@
-import { Filter, BoosterConfig, Logger, InvalidParameterError } from '@boostercloud/framework-types'
+import { FilterOld, BoosterConfig, Logger, InvalidParameterError } from '@boostercloud/framework-types'
 import { DynamoDB } from 'aws-sdk'
 import { DocumentClient } from 'aws-sdk/lib/dynamodb/document_client'
 import ExpressionAttributeValueMap = DocumentClient.ExpressionAttributeValueMap
@@ -9,7 +9,7 @@ export async function searchReadModel(
   config: BoosterConfig,
   logger: Logger,
   readModelName: string,
-  filters: Record<string, Filter<any>>
+  filters: Record<string, FilterOld<any>>
 ): Promise<Array<any>> {
   let params: DocumentClient.ScanInput = {
     TableName: config.resourceNames.forReadModel(readModelName),
@@ -32,13 +32,13 @@ export async function searchReadModel(
   return result.Items ?? []
 }
 
-function buildFilterExpression(filters: Record<string, Filter<any>>): string {
+function buildFilterExpression(filters: Record<string, FilterOld<any>>): string {
   return Object.entries(filters)
     .map(([propName, filter]) => buildOperation(propName, filter))
     .join(' AND ')
 }
 
-function buildOperation(propName: string, filter: Filter<any>): string {
+function buildOperation(propName: string, filter: FilterOld<any>): string {
   const holder = placeholderBuilderFor(propName)
   switch (filter.operation) {
     case '=':
@@ -72,7 +72,7 @@ function placeholderBuilderFor(propName: string): (valueIndex: number) => string
   return (valueIndex: number) => `:${propName}_${valueIndex}`
 }
 
-function buildExpressionAttributeNames(filters: Record<string, Filter<any>>): ExpressionAttributeNameMap {
+function buildExpressionAttributeNames(filters: Record<string, FilterOld<any>>): ExpressionAttributeNameMap {
   const attributeNames: ExpressionAttributeNameMap = {}
   for (const propName in filters) {
     attributeNames[`#${propName}`] = propName
@@ -80,7 +80,7 @@ function buildExpressionAttributeNames(filters: Record<string, Filter<any>>): Ex
   return attributeNames
 }
 
-function buildExpressionAttributeValues(filters: Record<string, Filter<any>>): ExpressionAttributeValueMap {
+function buildExpressionAttributeValues(filters: Record<string, FilterOld<any>>): ExpressionAttributeValueMap {
   const attributeValues: ExpressionAttributeValueMap = {}
   for (const propName in filters) {
     const filter = filters[propName]

--- a/packages/framework-provider-aws/test/library/searcher-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/searcher-adapter.test.ts
@@ -62,7 +62,7 @@ describe('Searcher adapter', () => {
       expect(result).to.be.deep.equal([])
     })
 
-    it('Executes query with simple filters', async () => {
+    it('Executes query simple filters', async () => {
       const expectedInput = {
         ...expectedParams,
         FilterExpression: [
@@ -71,7 +71,7 @@ describe('Searcher adapter', () => {
           'AND #stock > :stock_0',
           'AND #stock <= :stock_1',
         ].join(' '),
-        ExpressionAttributeNames: { '#id': 'id', '#in': 'in', '#stock': 'stock' },
+        ExpressionAttributeNames: { '#id': 'id', '#stock': 'stock' },
         ExpressionAttributeValues: {
           ':id_0': '3',
           ':id_1_0': 'test1',
@@ -84,8 +84,6 @@ describe('Searcher adapter', () => {
       const filters: FilterFor<Product> = {
         id: { contains: '3', in: ['test1', 'test2', 'test3'] },
         stock: { gt: 0, lte: 10 },
-        // days: { includes: 2 },
-        // items: { includes: { sku: '2', price: { cents: 8, currency: 'EUR' } } },
       }
 
       await searchReadModel(database, config, logger, readModelName, filters as FilterFor<any>)
@@ -93,7 +91,7 @@ describe('Searcher adapter', () => {
       expect(database.scan).to.have.been.calledWithExactly(expectedInput)
     })
 
-    it('Executes query with using NOT in filters', async () => {
+    it('Executes query using NOT in filters', async () => {
       const expectedInput = {
         ...expectedParams,
         FilterExpression: 'contains(#id, :id_0) AND NOT (#id = :id_1)',
@@ -113,7 +111,7 @@ describe('Searcher adapter', () => {
       expect(database.scan).to.have.been.calledWithExactly(expectedInput)
     })
 
-    it('Executes query with using AND & OR filters', async () => {
+    it('Executes query using AND & OR filters', async () => {
       const expectedInput = {
         ...expectedParams,
         FilterExpression: [
@@ -141,7 +139,7 @@ describe('Searcher adapter', () => {
       expect(database.scan).to.have.been.calledWithExactly(expectedInput)
     })
 
-    it('Executes query with using nested filters', async () => {
+    it('Executes query using nested filters', async () => {
       const expectedInput = {
         ...expectedParams,
         FilterExpression: '#mainItem.#sku = :sku_0 AND #mainItem.#price.#cents >= :cents_0 AND #cents < :cents_1',

--- a/packages/framework-provider-aws/test/library/searcher-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/searcher-adapter.test.ts
@@ -1,0 +1,181 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from '../expect'
+import { searchReadModel } from '../../src/library/searcher-adapter'
+import { createStubInstance, fake, restore, stub, SinonStubbedInstance } from 'sinon'
+import { BoosterConfig, FilterFor, Logger } from '@boostercloud/framework-types'
+import { random } from 'faker'
+import { DynamoDB } from 'aws-sdk'
+
+describe('Searcher adapter', () => {
+  describe('The "searchReadModel" method', () => {
+    const config: BoosterConfig = new BoosterConfig('test')
+    const logger: Logger = {
+      info: fake(),
+      error: fake(),
+      debug: fake(),
+    }
+    const readModelName: string = random.word()
+
+    let database: SinonStubbedInstance<DynamoDB.DocumentClient>
+    const expectedParams = {
+      TableName: config.resourceNames.forReadModel(readModelName),
+      ConsistentRead: true,
+    }
+
+    class Money {
+      constructor(public cents: number, public currency: string) {}
+    }
+
+    class Item {
+      constructor(public sku: string, public price: Money) {}
+    }
+
+    class Product {
+      constructor(
+        readonly id: string,
+        readonly stock: number,
+        public mainItem: Item,
+        public items: Array<Item>,
+        public buyers: Array<string>,
+        public days: Array<number>,
+        public pairs: Array<Array<number>>
+      ) {}
+    }
+
+    beforeEach(() => {
+      database = createStubInstance(DynamoDB.DocumentClient, {
+        scan: {
+          promise: stub().returns({
+            result: stub().returns({}),
+          }),
+        } as any,
+      })
+    })
+    after(() => {
+      restore()
+    })
+
+    it('Executes query without filters', async () => {
+      const result = await searchReadModel(database, config, logger, readModelName, {})
+
+      expect(database.scan).to.have.been.calledWithExactly(expectedParams)
+      expect(result).to.be.deep.equal([])
+    })
+
+    it('Executes query with simple filters', async () => {
+      const expectedInput = {
+        ...expectedParams,
+        FilterExpression: [
+          'contains(#id, :id_0)',
+          'AND #id IN (:id_1_0,:id_1_1,:id_1_2)',
+          'AND #stock > :stock_0',
+          'AND #stock <= :stock_1',
+        ].join(' '),
+        ExpressionAttributeNames: { '#id': 'id', '#in': 'in', '#stock': 'stock' },
+        ExpressionAttributeValues: {
+          ':id_0': '3',
+          ':id_1_0': 'test1',
+          ':id_1_1': 'test2',
+          ':id_1_2': 'test3',
+          ':stock_0': 0,
+          ':stock_1': 10,
+        },
+      }
+      const filters: FilterFor<Product> = {
+        id: { contains: '3', in: ['test1', 'test2', 'test3'] },
+        stock: { gt: 0, lte: 10 },
+        // days: { includes: 2 },
+        // items: { includes: { sku: '2', price: { cents: 8, currency: 'EUR' } } },
+      }
+
+      await searchReadModel(database, config, logger, readModelName, filters as FilterFor<any>)
+
+      expect(database.scan).to.have.been.calledWithExactly(expectedInput)
+    })
+
+    it('Executes query with using NOT in filters', async () => {
+      const expectedInput = {
+        ...expectedParams,
+        FilterExpression: 'contains(#id, :id_0) AND NOT (#id = :id_1)',
+        ExpressionAttributeNames: { '#id': 'id' },
+        ExpressionAttributeValues: {
+          ':id_0': '3',
+          ':id_1': '333',
+        },
+      }
+      const filters: FilterFor<Product> = {
+        id: { contains: '3' },
+        not: { id: { eq: '333' } },
+      }
+
+      await searchReadModel(database, config, logger, readModelName, filters as FilterFor<any>)
+
+      expect(database.scan).to.have.been.calledWithExactly(expectedInput)
+    })
+
+    it('Executes query with using AND & OR filters', async () => {
+      const expectedInput = {
+        ...expectedParams,
+        FilterExpression: [
+          '#id <> :id_0',
+          'AND (begins_with(#id, :id_1) or begins_with(#id, :id_2))',
+          'AND (contains(#id, :id_3) and contains(#id, :id_4))',
+        ].join(' '),
+        ExpressionAttributeNames: { '#id': 'id' },
+        ExpressionAttributeValues: {
+          ':id_0': 'test',
+          ':id_1': '1',
+          ':id_2': '2',
+          ':id_3': '3',
+          ':id_4': '4',
+        },
+      }
+      const filters: FilterFor<Product> = {
+        id: { ne: 'test' },
+        or: [{ id: { beginsWith: '1' } }, { id: { beginsWith: '2' } }],
+        and: [{ id: { contains: '3' } }, { id: { contains: '4' } }],
+      }
+
+      await searchReadModel(database as any, config, logger, readModelName, filters as FilterFor<any>)
+
+      expect(database.scan).to.have.been.calledWithExactly(expectedInput)
+    })
+
+    it('Executes query with using nested filters', async () => {
+      const expectedInput = {
+        ...expectedParams,
+        FilterExpression: '#mainItem.#sku = :sku_0 AND #mainItem.#price.#cents >= :cents_0 AND #cents < :cents_1',
+        ExpressionAttributeNames: {
+          '#mainItem': 'mainItem',
+          '#sku': 'sku',
+          '#price': 'price',
+          '#cents': 'cents',
+        },
+        ExpressionAttributeValues: { ':sku_0': 'test', ':cents_0': 1000, ':cents_1': 100000 },
+      }
+      const filters: FilterFor<Product> = {
+        mainItem: {
+          sku: { eq: 'test' },
+          price: {
+            cents: { gte: 1000, lt: 100000 },
+          },
+        },
+      }
+
+      await searchReadModel(database, config, logger, readModelName, filters as FilterFor<any>)
+
+      expect(database.scan).to.have.been.calledWithExactly(expectedInput)
+    })
+
+    it('Thorw an error with non supported filters', async () => {
+      const unknownOperator = 'existsIn'
+      const filters: FilterFor<any> = {
+        id: { [unknownOperator]: 'test' },
+      }
+
+      await expect(searchReadModel(database, config, logger, readModelName, filters)).to.be.eventually.rejectedWith(
+        `Operator "${unknownOperator}" is not supported`
+      )
+    })
+  })
+})

--- a/packages/framework-provider-aws/test/library/searcher-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/searcher-adapter.test.ts
@@ -165,6 +165,29 @@ describe('Searcher adapter', () => {
       expect(database.scan).to.have.been.calledWithExactly(expectedInput)
     })
 
+    it('Executes query using array includes filters', async () => {
+      const expectedInput = {
+        ...expectedParams,
+        FilterExpression: 'contains(#days, :days_0) AND contains(#items, :items_0)',
+        ExpressionAttributeNames: {
+          '#days': 'days',
+          '#items': 'items',
+        },
+        ExpressionAttributeValues: {
+          ':days_0': 2,
+          ':items_0': { sku: 'test', price: { cents: 1000, currency: 'EUR' } },
+        },
+      }
+      const filters: FilterFor<Product> = {
+        days: { includes: 2 },
+        items: { includes: { sku: 'test', price: { cents: 1000, currency: 'EUR' } } },
+      }
+
+      await searchReadModel(database, config, logger, readModelName, filters as FilterFor<any>)
+
+      expect(database.scan).to.have.been.calledWithExactly(expectedInput)
+    })
+
     it('Thorw an error with non supported filters', async () => {
       const unknownOperator = 'existsIn'
       const filters: FilterFor<any> = {

--- a/packages/framework-provider-azure/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-azure/src/library/searcher-adapter.ts
@@ -1,12 +1,12 @@
 import { CosmosClient, SqlParameter, SqlQuerySpec } from '@azure/cosmos'
-import { BoosterConfig, Filter, Logger, InvalidParameterError } from '@boostercloud/framework-types'
+import { BoosterConfig, FilterOld, Logger, InvalidParameterError } from '@boostercloud/framework-types'
 
 export async function searchReadModel(
   cosmosDb: CosmosClient,
   config: BoosterConfig,
   logger: Logger,
   readModelName: string,
-  filters: Record<string, Filter<any>>
+  filters: Record<string, FilterOld<any>>
 ): Promise<Array<any>> {
   const querySpec: SqlQuerySpec = {
     query: `SELECT * FROM c ${buildFilterExpression(filters)}`,
@@ -25,7 +25,7 @@ export async function searchReadModel(
   return resources ?? []
 }
 
-function buildFilterExpression(filters: Record<string, Filter<any>>): string {
+function buildFilterExpression(filters: Record<string, FilterOld<any>>): string {
   const filterExpression = Object.entries(filters)
     .map(([propName, filter]) => buildOperation(propName, filter))
     .join(' AND ')
@@ -35,7 +35,7 @@ function buildFilterExpression(filters: Record<string, Filter<any>>): string {
   return filterExpression
 }
 
-function buildOperation(propName: string, filter: Filter<any>): string {
+function buildOperation(propName: string, filter: FilterOld<any>): string {
   const holder = placeholderBuilderFor(propName)
   switch (filter.operation) {
     case '=':
@@ -69,7 +69,7 @@ function placeholderBuilderFor(propName: string): (valueIndex: number) => string
   return (valueIndex: number) => `@${propName}_${valueIndex}`
 }
 
-function buildExpressionAttributeValues(filters: Record<string, Filter<any>>): Array<SqlParameter> {
+function buildExpressionAttributeValues(filters: Record<string, FilterOld<any>>): Array<SqlParameter> {
   const attributeValues: Array<SqlParameter> = []
   for (const propName in filters) {
     const filter = filters[propName]

--- a/packages/framework-provider-azure/test/library/searcher-adapter.test.ts
+++ b/packages/framework-provider-azure/test/library/searcher-adapter.test.ts
@@ -3,7 +3,7 @@ import { expect } from '../expect'
 import { searchReadModel } from '../../src/library/searcher-adapter'
 import { createStubInstance, fake, match, restore, stub, SinonStubbedInstance } from 'sinon'
 import { CosmosClient } from '@azure/cosmos'
-import { BoosterConfig, Filter, Logger } from '@boostercloud/framework-types'
+import { BoosterConfig, FilterOld, Logger } from '@boostercloud/framework-types'
 import { random } from 'faker'
 
 describe('Searcher adapter', () => {
@@ -60,7 +60,7 @@ describe('Searcher adapter', () => {
     })
 
     it('Executes a SQL query with filters in the read model table', async () => {
-      const filters: Record<string, Filter<any>> = {
+      const filters: Record<string, FilterOld<any>> = {
         propertyA: { operation: '=', values: [1] },
         propertyB: { operation: '!=', values: ['a'] },
         propertyC: { operation: 'between', values: [1, 100] },
@@ -105,7 +105,7 @@ describe('Searcher adapter', () => {
     })
 
     it('Supports comparison operators', async () => {
-      const filters: Record<string, Filter<any>> = {
+      const filters: Record<string, FilterOld<any>> = {
         propertyA: { operation: '<', values: [100] },
         propertyB: { operation: '>', values: [0] },
         propertyC: { operation: '>=', values: [0] },
@@ -148,7 +148,7 @@ describe('Searcher adapter', () => {
     })
 
     it('Supports other operators', async () => {
-      const filters: Record<string, Filter<any>> = {
+      const filters: Record<string, FilterOld<any>> = {
         propertyA: { operation: 'in', values: [1, 2] },
         propertyB: { operation: 'contains', values: ['a'] },
         propertyC: { operation: 'not-contains', values: ['x'] },

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -12,7 +12,7 @@ import { rawGraphQLRequestToEnvelope } from './library/graphql-adapter'
 import { UserApp } from '@boostercloud/framework-types'
 import * as path from 'path'
 import { ReadModelRegistry } from './services/read-model-registry'
-import { fetchReadModel, searchReadModel, storeReadModel } from './library/read-model-adapter'
+import { fetchReadModel, storeReadModel } from './library/read-model-adapter'
 
 export { User, LoginCredentials, SignUpUser, RegisteredUser, AuthenticatedUser } from './library/auth-adapter'
 export * from './paths'
@@ -35,7 +35,8 @@ export const Provider = (): ProviderLibrary => ({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     rawToEnvelopes: undefined as any,
     fetch: fetchReadModel.bind(null, readModelRegistry),
-    search: searchReadModel.bind(null, readModelRegistry),
+    search: undefined as any,
+    // search: searchReadModel.bind(null, readModelRegistry),
     store: storeReadModel.bind(null, readModelRegistry),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete: undefined as any,

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -1,4 +1,4 @@
-import { ProviderLibrary, ProviderInfrastructure } from '@boostercloud/framework-types'
+import { ProviderLibrary, ProviderInfrastructure, UserApp } from '@boostercloud/framework-types'
 import { rawSignUpDataToUserEnvelope } from './library/auth-adapter'
 import {
   rawEventsToEnvelopes,
@@ -9,10 +9,10 @@ import {
 import { requestSucceeded, requestFailed } from './library/api-adapter'
 import { EventRegistry } from './services'
 import { rawGraphQLRequestToEnvelope } from './library/graphql-adapter'
-import { UserApp } from '@boostercloud/framework-types'
+
 import * as path from 'path'
 import { ReadModelRegistry } from './services/read-model-registry'
-import { fetchReadModel, storeReadModel } from './library/read-model-adapter'
+import { fetchReadModel, searchReadModel, storeReadModel } from './library/read-model-adapter'
 
 export { User, LoginCredentials, SignUpUser, RegisteredUser, AuthenticatedUser } from './library/auth-adapter'
 export * from './paths'
@@ -35,8 +35,7 @@ export const Provider = (): ProviderLibrary => ({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     rawToEnvelopes: undefined as any,
     fetch: fetchReadModel.bind(null, readModelRegistry),
-    search: undefined as any,
-    // search: searchReadModel.bind(null, readModelRegistry),
+    search: searchReadModel.bind(null, readModelRegistry),
     store: storeReadModel.bind(null, readModelRegistry),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete: undefined as any,

--- a/packages/framework-provider-local/src/library/read-model-adapter.ts
+++ b/packages/framework-provider-local/src/library/read-model-adapter.ts
@@ -1,6 +1,6 @@
 import {
   BoosterConfig,
-  Filter,
+  FilterOld,
   Logger,
   ReadModelEnvelope,
   ReadModelInterface,
@@ -53,7 +53,7 @@ export async function searchReadModel(
   _config: BoosterConfig,
   logger: Logger,
   readModelName: string,
-  filters: Record<string, Filter<QueryValue>>
+  filters: Record<string, FilterOld<QueryValue>>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<Array<any>> {
   logger.info('Converting filter to query')

--- a/packages/framework-provider-local/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-local/src/library/searcher-adapter.ts
@@ -1,4 +1,4 @@
-import { Filter } from '@boostercloud/framework-types'
+import { FilterOld } from '@boostercloud/framework-types'
 
 /**
  * Creates a query record out of the read mode name and
@@ -7,7 +7,7 @@ import { Filter } from '@boostercloud/framework-types'
  */
 export function queryRecordFor(
   readModelName: string,
-  filters: Record<string, Filter<QueryValue>>
+  filters: Record<string, FilterOld<QueryValue>>
 ): Record<string, QueryOperation<QueryValue>> {
   const queryFromFilters: Record<string, object> = {}
   if (Object.keys(filters).length != 0) {
@@ -21,7 +21,7 @@ export function queryRecordFor(
 /**
  * Transforms a GraphQL Booster filter into an neDB query
  */
-function filterToQuery(filter: Filter<QueryValue>): QueryOperation<QueryValue> {
+function filterToQuery(filter: FilterOld<QueryValue>): QueryOperation<QueryValue> {
   const query = queryOperatorTable[filter.operation]
   return query(filter.values)
 }

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -1,5 +1,6 @@
 import { EntityInterface, EventInterface, ReadModelInterface, UUID } from './concepts'
 import { GraphQLClientMessage } from './graphql-websocket-messages'
+import { FilterFor } from './searcher'
 
 /**
  * An `Envelope` carries a command/event body together with the name
@@ -42,11 +43,7 @@ export interface ReadModelRequestEnvelope extends Envelope {
   filters?: Record<string, ReadModelPropertyFilter>
 }
 
-export interface ReadModelPropertyFilter {
-  operation: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  values: Array<any>
-}
+export type ReadModelPropertyFilter = FilterFor<any>
 
 export interface GraphQLRequestEnvelope extends Envelope {
   eventType: 'CONNECT' | 'MESSAGE' | 'DISCONNECT'

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -43,7 +43,7 @@ export interface ReadModelRequestEnvelope extends Envelope {
   filters?: Record<string, ReadModelPropertyFilter>
 }
 
-export type ReadModelPropertyFilter = FilterFor<any>
+export type ReadModelPropertyFilter = FilterFor<unknown>
 
 export interface GraphQLRequestEnvelope extends Envelope {
   eventType: 'CONNECT' | 'MESSAGE' | 'DISCONNECT'

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -11,7 +11,7 @@ import {
 import { BoosterConfig } from './config'
 import { Logger } from './logger'
 import { ReadModelInterface, UUID } from './concepts'
-import { Filter } from './searcher'
+import { FilterOld } from './searcher'
 
 export interface ProviderLibrary {
   events: ProviderEventsLibrary
@@ -49,7 +49,7 @@ export interface ProviderReadModelsLibrary {
     config: BoosterConfig,
     logger: Logger,
     entityTypeName: string,
-    filters: Record<string, Filter<unknown>>
+    filters: Record<string, FilterOld<unknown>>
   ): Promise<Array<TReadModel>>
   store(config: BoosterConfig, logger: Logger, readModelName: string, readModel: ReadModelInterface): Promise<unknown>
   delete(config: BoosterConfig, logger: Logger, readModelName: string, readModel: ReadModelInterface): Promise<any>

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -11,7 +11,7 @@ import {
 import { BoosterConfig } from './config'
 import { Logger } from './logger'
 import { ReadModelInterface, UUID } from './concepts'
-import { FilterOld } from './searcher'
+import { FilterFor } from './searcher'
 
 export interface ProviderLibrary {
   events: ProviderEventsLibrary
@@ -49,7 +49,7 @@ export interface ProviderReadModelsLibrary {
     config: BoosterConfig,
     logger: Logger,
     entityTypeName: string,
-    filters: Record<string, FilterOld<unknown>>
+    filters: FilterFor<unknown>
   ): Promise<Array<TReadModel>>
   store(config: BoosterConfig, logger: Logger, readModelName: string, readModel: ReadModelInterface): Promise<unknown>
   delete(config: BoosterConfig, logger: Logger, readModelName: string, readModel: ReadModelInterface): Promise<any>

--- a/packages/framework-types/src/searcher.ts
+++ b/packages/framework-types/src/searcher.ts
@@ -65,7 +65,6 @@ export class Searcher<TObject> {
    * Do the actual search by sending all the configured filters to the provided search function
    */
   public async search(): Promise<Array<TObject>> {
-    console.log(this.filters)
     const searchResult = await this.searcherFunction(this.objectClass.name, this.filters)
     return searchResult as Array<TObject>
   }

--- a/packages/framework-types/src/searcher.ts
+++ b/packages/framework-types/src/searcher.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/indent */
 import { UUID } from './concepts'
 import { Class } from './typelevel'
 

--- a/packages/framework-types/src/searcher.ts
+++ b/packages/framework-types/src/searcher.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Class } from './typelevel'
 
-export type SearcherFunction<TObject> = (className: string, filters: Record<string, Filter<any>>) => Promise<Array<any>>
+export type SearcherFunction<TObject> = (
+  className: string,
+  filters: Record<string, FilterOld<any>>
+) => Promise<Array<any>>
 
 /**
  * This class represents a search intended to be run by any search provider. They way you use it
@@ -11,7 +14,9 @@ export type SearcherFunction<TObject> = (className: string, filters: Record<stri
 export class Searcher<TObject> {
   // private offset?: number
   // private limit?: number
-  readonly filters: Record<string, Filter<any>> = {}
+  private filters: FilterFor<TObject> = {}
+  /** @deprecated */
+  readonly filtersOld: Record<string, FilterOld<any>> = {}
 
   /**
    * @param objectClass The class of the object you want to run the search for.
@@ -21,6 +26,11 @@ export class Searcher<TObject> {
     private readonly objectClass: Class<TObject>,
     private readonly searcherFunction: SearcherFunction<TObject>
   ) {}
+
+  public filter(filters: FilterFor<TObject>): this {
+    this.filters = filters
+    return this
+  }
 
   /**
    * Adds a filter for the search. For example: If you want to search for people whose age is greater than 30
@@ -33,13 +43,14 @@ export class Searcher<TObject> {
    * @param property The property the filter will act upon
    * @param operation The filter operation.
    * @param values The values for the filter. Depending on the operation, you can specify here one or many values
+   * @deprecated Use "filter" instead
    */
-  public filter<TPropName extends keyof TObject, TPropType extends TObject[TPropName]>(
+  public filterOld<TPropName extends keyof TObject, TPropType extends TObject[TPropName]>(
     property: TPropName,
-    operation: Operation<TPropType>,
+    operation: OperationOld<TPropType>,
     ...values: Array<TPropType>
   ): this {
-    this.filters[property as string] = {
+    this.filtersOld[property as string] = {
       operation,
       values,
     }
@@ -56,13 +67,15 @@ export class Searcher<TObject> {
    * Do the actual search by sending all the configured filters to the provided search function
    */
   public async search(): Promise<Array<TObject>> {
-    const searchResult = await this.searcherFunction(this.objectClass.name, this.filters)
+    console.log(this.filters)
+    const searchResult = await this.searcherFunction(this.objectClass.name, this.filtersOld)
     return searchResult as Array<TObject>
   }
 }
 
-export interface Filter<TType> {
-  operation: Operation<TType>
+// ---------------- DEPRECATED ----------------------
+export interface FilterOld<TType> {
+  operation: OperationOld<TType>
   values: Array<TType>
 }
 
@@ -96,7 +109,95 @@ export enum BooleanOperations {
   '!=' = 'not_equal',
 }
 
+// eslint-disable-next-line prettier/prettier
+type OperationOld<TType> =
+  TType extends number ? EnumToUnion<typeof NumberOperations> :
+  TType extends string ? EnumToUnion<typeof StringOperations> :
+  TType extends boolean ? EnumToUnion<typeof BooleanOperations> : never
+
 type EnumToUnion<TEnum> = keyof TEnum
 
-// eslint-disable-next-line prettier/prettier
-type Operation<TType> = TType extends number ? EnumToUnion<typeof NumberOperations> : TType extends string ? EnumToUnion<typeof StringOperations> : TType extends boolean ? EnumToUnion<typeof BooleanOperations> : never
+// ----------------------------------------------------------------------------------------------------
+
+type FilterFor<TType> = {
+  [TProp in keyof TType]?: Operation<TType[TProp]>
+} &
+  FilterCombinators<TType>
+
+interface FilterCombinators<TType> {
+  and?: Array<FilterFor<TType>>
+  or?: Array<FilterFor<TType>>
+  not?: FilterFor<TType>
+}
+
+type Operation<TType> =
+  TType extends Array<infer TElementType> ? ArrayOperators<TElementType>
+  : TType extends string ? StringOperators<TType>
+  : TType extends number ? ScalarOperators<TType>
+  : TType extends boolean ? BooleanOperators<TType>
+  : TType extends Record<string, any> ? FilterFor<TType>
+  : never
+
+interface BooleanOperators<TType> {
+  eq?: TType
+  ne?: TType
+}
+interface ScalarOperators<TType> extends BooleanOperators<TType> {
+  gt?: TType
+  gte?: TType
+  lt?: TType
+  lte?: TType
+  in?: TType
+}
+
+interface StringOperators<TType> extends ScalarOperators<TType> {
+  beginsWith?: TType
+  contains?: TType
+}
+
+interface ArrayOperators<TElementType> {
+  includes?: TElementType extends string | number | boolean ? Array<TElementType>
+           : TElementType extends Array<infer TElementTypeElement> ? Array<ArrayOperators<TElementTypeElement>>
+           : TElementType extends Record<string, any> ? Array<FilterFor<TElementType>>
+           : never
+}
+
+// ----------------------------
+
+class Money {
+  constructor(public cents: number, public currency: string) {}
+}
+
+class Item {
+  constructor(public sku: string, public price: Money) {}
+}
+
+class Product {
+  constructor(
+    readonly id: string,
+    readonly stock: number,
+    public mainItem: Item,
+    public items: Array<Item>,
+    public buyers: Array<string>,
+    public days: Array<number>,
+    public pairs: Array<Array<number>>
+  ) {}
+}
+
+const filter: FilterFor<Product> = {
+  id: { beginsWith: 'pepe' },
+  stock: { lte: 90 },
+  mainItem: { price: { cents: { eq: 4 } } },
+  buyers: { includes: ['123'] },
+  days: { includes: [34, 4] },
+  items: { includes: [{ sku: { eq: '2' } }] },
+  pairs: {
+    includes: [
+      {
+        includes: [8],
+      },
+    ],
+  },
+}
+
+console.log(filter)

--- a/packages/framework-types/src/searcher.ts
+++ b/packages/framework-types/src/searcher.ts
@@ -156,10 +156,7 @@ interface StringOperators<TType> extends ScalarOperators<TType> {
 }
 
 interface ArrayOperators<TElementType> {
-  includes?: TElementType extends string | number | boolean ? Array<TElementType>
-           : TElementType extends Array<infer TElementTypeElement> ? Array<ArrayOperators<TElementTypeElement>>
-           : TElementType extends Record<string, any> ? Array<FilterFor<TElementType>>
-           : never
+  includes?: TElementType
 }
 
 // ----------------------------
@@ -188,15 +185,11 @@ const filter: FilterFor<Product> = {
   id: { beginsWith: 'pepe' },
   stock: { lte: 90 },
   mainItem: { price: { cents: { eq: 4 } } },
-  buyers: { includes: ['123'] },
-  days: { includes: [34, 4] },
-  items: { includes: [{ sku: { eq: '2' } }] },
+  buyers: { includes: '123' },
+  days: { includes: 34 },
+  items: { includes: { sku: '2', price: { cents: 8, currency: 'EUR' } } },
   pairs: {
-    includes: [
-      {
-        includes: [8],
-      },
-    ],
+    includes: [8],
   },
 }
 

--- a/packages/framework-types/src/searcher.ts
+++ b/packages/framework-types/src/searcher.ts
@@ -121,8 +121,9 @@ type EnumToUnion<TEnum> = keyof TEnum
 // ----------------------------------------------------------------------------------------------------
 
 export type FilterFor<TType> = {
-  [TProp in keyof TType]?: Operation<TType[TProp]> & FilterCombinators<TType>
-}
+  [TProp in keyof TType]?: Operation<TType[TProp]>
+} &
+  FilterCombinators<TType>
 
 interface FilterCombinators<TType> {
   and?: Array<FilterFor<TType>>


### PR DESCRIPTION
## Description
This new way of filtering is based on the Amplify one, which is way less limiting than the previous one.

## Changes
* The core `searcher` function has been changed to the new format. The old filter system is still compatible until we update the rest of the providers.
* The AWS `searcher-adapter` has been modified to translate these new filters to DynamoDB queries.
* Unit tests for AWS `searcher-adapter` has been added to ensure stability across all the different scenarios.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly - Just basic documentation. The rest will be added when the GraphQL schema gets updated in a new PR.
 
## Additional information
This is working just for retrieving and filtering ReadModels inside commands, events, etc. The GraphQL schema will be changed in a future PR.
