### PR TITLE
Switch to `main` as the base branch of the project

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,13 +2,12 @@ name: Lint
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - '**.md'
   pull_request:
     branches:
-      - master
-      - master-mirror
+      - main
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     paths-ignore:
       - '**.md'
 
@@ -38,7 +38,7 @@ jobs:
           USER_NAME: ${{ secrets.DEPLOYING_USER_NAME }}
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN_ACTION }} # Token for pushing
 
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@main
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
@@ -64,7 +64,7 @@ jobs:
       - name: Discard all the changes after integration tests
         run: git stash
 
-      - uses: theam/actions/lerna-semantic-publish@master
+      - uses: theam/actions/lerna-semantic-publish@main
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_ACTION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,13 +2,12 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - '**.md'
   pull_request:
     branches:
-      - master
-      - master-mirror
+      - main
     paths-ignore:
       - '**.md'
 

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,5 +1,5 @@
 {
-    "_comment": "Other rules are described here https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#rules",
+    "_comment": "Other rules are described here https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#rules",
     "default": true,
     "line-length": false,
     "no-trailing-punctuation": false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ These are the available scripts to run integration tests:
 - `lerna run integration/local --stream`: Checks that the test application can be launched locally and that the APIs and the databases behave as expected.
 - `lerna run integration/cli --stream`: Checks cli commands and check that they produce the expected results.
 
-AWS integration tests are run in real AWS resources, so you'll need to have your AWS credentials properly set in your development machine. By default, the sample project will be deployed to your default account. Basically, if you can deploy a Booster project to AWS, you should be good to go ([See more details about setting up an AWS account in the docs](https://github.com/boostercloud/booster/tree/master/docs#set-up-an-aws-account)). Notice that while all resources used by Booster are included in the AWS free tier, running these tests in your own AWS account could incur in some expenses.
+AWS integration tests are run in real AWS resources, so you'll need to have your AWS credentials properly set in your development machine. By default, the sample project will be deployed to your default account. Basically, if you can deploy a Booster project to AWS, you should be good to go ([See more details about setting up an AWS account in the docs](https://github.com/boostercloud/booster/tree/main/docs#set-up-an-aws-account)). Notice that while all resources used by Booster are included in the AWS free tier, running these tests in your own AWS account could incur in some expenses.
 
 ### Github flow
 
@@ -239,7 +239,7 @@ When you submit a PR to the Booster repository:
 
 ### Branch naming conventions
 
-In order to create a PR, you must create a branch from `master`. You should follow the GitFlow naming conventions, as detailed below:
+In order to create a PR, you must create a branch from `main`. You should follow the GitFlow naming conventions, as detailed below:
 
 - `feature/*` - PR that implements a new feature
 - `fix/*` - PR that fixes a bug

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fboostercloud%2Fbooster%2Fbadge&style=flat)](https://actions-badge.atrox.dev/boostercloud/booster/goto)
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
-[![License](https://img.shields.io/npm/l/@boostercloud/cli)](https://github.com/boostercloud/booster/blob/master/package.json)
+[![License](https://img.shields.io/npm/l/@boostercloud/cli)](https://github.com/boostercloud/booster/blob/main/package.json)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 ![Integration tests](https://github.com/boostercloud/booster/workflows/Integration%20tests/badge.svg)
 [![Discord](https://img.shields.io/discord/763753198388510780.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/bDY8MKx)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2594,7 +2594,7 @@ For a force delete without asking for confirmation, you can run `boost nuke -e <
 
 ### Contributing
 
-If you want to start making contributions to Booster, we strongly recommend that you read our [contributing guide](https://github.com/boostercloud/booster/blob/master/CONTRIBUTING.md).
+If you want to start making contributions to Booster, we strongly recommend that you read our [contributing guide](https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md).
 
 ### Framework Core
 
@@ -2602,7 +2602,7 @@ If you want to start making contributions to Booster, we strongly recommend that
 
 ### Framework integration tests
 
-Booster framework integration tests package is used to test the Booster project itself, but it is also an example of how a Booster application could be tested. We encourage developers to have a look at our [Booster project repository](https://github.com/boostercloud/booster/tree/master/packages/framework-integration-tests).
+Booster framework integration tests package is used to test the Booster project itself, but it is also an example of how a Booster application could be tested. We encourage developers to have a look at our [Booster project repository](https://github.com/boostercloud/booster/tree/main/packages/framework-integration-tests).
 
 Some integration tests highly depend on the provider chosen for the project, and the infrastructure is normally deployed locally or in the cloud right before the tests run. Once tests are completed, the application is teared down.
 


### PR DESCRIPTION
Github, Git and many other organizations and open-source communities are proposing to rename `master` branch as `main` [for the reasons explained in this document](https://sfconservancy.org/news/2020/jun/23/gitbranchname/) to abandon old terminology that doesn't make sense anymore.

In this PR, I've renamed all references to the `master` branch and replaced them by `main`. Once it's merged, Github has prepared a guide and automations to easily migrate all PRs, so this should be a seamless change: https://github.com/github/renaming

Bonus: I also removed the unused references to `master-mirror`