### PR TITLE
Feature/565&564 boost build and boost clean

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -660,13 +660,22 @@ At this point, we've:
 With this, you already know the basics to build event-driven, CQRS-based applications
 with Booster.
 
-Let's deploy our application to the cloud to see it working. It is as simple as running
+You can check that code compiles correctly by running the build command:
+
+```bash
+boost build
+```
+
+Now, let's deploy our application to the cloud to see it working. It is as simple as running
 the deploy command:
 
 ```bash
 boost deploy -e production
 ```
 
+> Deploy command automatically builds the project for you before performing updates in the cloud provider, 
+  so, build command it's not required beforehand.
+  
 > With `-e production` we are specifying which environment we want to deploy. We'll talk about them later.
 
 It will take a couple of minutes to deploy all the resources. Once finished, you will see

--- a/docs/README.md
+++ b/docs/README.md
@@ -666,6 +666,12 @@ You can check that code compiles correctly by running the build command:
 boost build
 ```
 
+You can also clean the compiled code by running:
+
+```bash
+boost clean
+```
+
 Now, let's deploy our application to the cloud to see it working. It is as simple as running
 the deploy command:
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,13 +1,15 @@
 import { Command, flags } from '@oclif/command'
-import { checkAndCompileProject } from '../services/config-service'
-import { BoosterConfig } from '@boostercloud/framework-types'
+import { compileProject } from '../services/config-service'
+import { checkCurrentDirIsABoosterProject } from '../services/project-checker'
 import { Script } from '../common/script'
 import Brand from '../common/brand'
 
 const runTasks = async (
-  compileAndLoad: Promise<BoosterConfig>
+  compileAndLoad: (ctx: string) => Promise<void>
 ): Promise<void> =>
-  Script.init(`boost ${Brand.dangerize('build')} 🚀`, compileAndLoad)
+  Script.init(`boost ${Brand.dangerize('build')} 🚀`, Promise.resolve(process.cwd()))
+    .step('Checking project structure',checkCurrentDirIsABoosterProject)
+    .step('Building project', compileAndLoad)
     .info('Build complete!')
     .done()
 
@@ -19,6 +21,6 @@ export default class Build extends Command {
   }
 
   public async run(): Promise<void> {
-    await runTasks(checkAndCompileProject(process.cwd()))
+    await runTasks((ctx: string) => compileProject(process.cwd()))
   }
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,0 +1,31 @@
+import { Command, flags } from '@oclif/command'
+import {
+  //cleanDeploymentSandbox,
+  compileProjectAndLoadConfig,
+  //createDeploymentSandbox,
+} from '../services/config-service'
+import { BoosterConfig } from '@boostercloud/framework-types'
+import { Script } from '../common/script'
+import Brand from '../common/brand'
+
+const runTasks = async (
+  compileAndLoad: Promise<BoosterConfig>
+): Promise<void> =>
+  Script.init(`boost ${Brand.dangerize('build')} 🚀`, compileAndLoad)
+    //.step('Cleaning up deployment files', cleanDeploymentSandbox)
+    .info('Build complete!')
+    .done()
+
+export default class Build extends Command {
+  public static description = 'Build the current application as configured in your `index.ts` file.'
+
+  public static flags = {
+    help: flags.help({ char: 'h' })
+  }
+
+  public async run(): Promise<void> {
+    //const deploymentProjectPath = await createDeploymentSandbox()
+    //await runTasks(compileProjectAndLoadConfig(deploymentProjectPath))
+    await runTasks(compileProjectAndLoadConfig(process.cwd()))
+  }
+}

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,9 +1,5 @@
 import { Command, flags } from '@oclif/command'
-import {
-  //cleanDeploymentSandbox,
-  compileProjectAndLoadConfig,
-  //createDeploymentSandbox,
-} from '../services/config-service'
+import { checkAndCompileProject } from '../services/config-service'
 import { BoosterConfig } from '@boostercloud/framework-types'
 import { Script } from '../common/script'
 import Brand from '../common/brand'
@@ -12,7 +8,6 @@ const runTasks = async (
   compileAndLoad: Promise<BoosterConfig>
 ): Promise<void> =>
   Script.init(`boost ${Brand.dangerize('build')} 🚀`, compileAndLoad)
-    //.step('Cleaning up deployment files', cleanDeploymentSandbox)
     .info('Build complete!')
     .done()
 
@@ -24,8 +19,6 @@ export default class Build extends Command {
   }
 
   public async run(): Promise<void> {
-    //const deploymentProjectPath = await createDeploymentSandbox()
-    //await runTasks(compileProjectAndLoadConfig(deploymentProjectPath))
-    await runTasks(compileProjectAndLoadConfig(process.cwd()))
+    await runTasks(checkAndCompileProject(process.cwd()))
   }
 }

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -7,7 +7,7 @@ import Brand from '../common/brand'
 const runTasks = async (
   clean: (ctx: string) => Promise<void>
 ): Promise<void> =>
-  Script.init(`boost ${Brand.dangerize('build')} 🚀`, Promise.resolve(process.cwd()))
+  Script.init(`boost ${Brand.dangerize('clean')} 🚀`, Promise.resolve(process.cwd()))
     .step('Checking project structure',checkCurrentDirIsABoosterProject)
     .step('Cleaning project', clean)
     .info('Clean complete!')

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -1,0 +1,26 @@
+import { Command, flags } from '@oclif/command'
+import { cleanProject } from '../services/config-service'
+import { checkCurrentDirIsABoosterProject } from '../services/project-checker'
+import { Script } from '../common/script'
+import Brand from '../common/brand'
+
+const runTasks = async (
+  clean: (ctx: string) => Promise<void>
+): Promise<void> =>
+  Script.init(`boost ${Brand.dangerize('build')} 🚀`, Promise.resolve(process.cwd()))
+    .step('Checking project structure',checkCurrentDirIsABoosterProject)
+    .step('Cleaning project', clean)
+    .info('Clean complete!')
+    .done()
+
+export default class Clean extends Command {
+  public static description = 'Clean the current application as configured in your `index.ts` file.'
+
+  public static flags = {
+    help: flags.help({ char: 'h' })
+  }
+
+  public async run(): Promise<void> {
+    await runTasks((ctx: string) => cleanProject(process.cwd()))
+  }
+}

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -26,13 +26,7 @@ export async function compileProjectAndLoadConfig(userProjectPath: string): Prom
   return readProjectConfig(userProjectPath)
 }
 
-export async function checkAndCompileProject(userProjectPath: string): Promise<BoosterConfig> {
-  await checkItIsABoosterProject(userProjectPath)
-  await compileProject(userProjectPath)
-  return new BoosterConfig('build')
-}
-
-async function compileProject(projectPath: string): Promise<void> {
+export async function compileProject(projectPath: string): Promise<void> {
   try {
     await exec('npm run clean && npm run compile', { cwd: projectPath })
   } catch (e) {

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -26,6 +26,12 @@ export async function compileProjectAndLoadConfig(userProjectPath: string): Prom
   return readProjectConfig(userProjectPath)
 }
 
+export async function checkAndCompileProject(userProjectPath: string): Promise<BoosterConfig> {
+  await checkItIsABoosterProject(userProjectPath)
+  await compileProject(userProjectPath)
+  return new BoosterConfig('build')
+}
+
 async function compileProject(projectPath: string): Promise<void> {
   try {
     await exec('npm run clean && npm run compile', { cwd: projectPath })

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -34,6 +34,14 @@ export async function compileProject(projectPath: string): Promise<void> {
   }
 }
 
+export async function cleanProject(projectPath: string): Promise<void> {
+  try {
+    await exec('npm run clean', { cwd: projectPath })
+  } catch (e) {
+    throw wrapExecError(e, 'Error cleaning project')
+  }
+}
+
 function readProjectConfig(userProjectPath: string): Promise<BoosterConfig> {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const userProject = loadUserProject(userProjectPath)

--- a/packages/cli/test/commands/build.test.ts
+++ b/packages/cli/test/commands/build.test.ts
@@ -7,6 +7,8 @@ describe('build', () => {
     describe('Build class', () => {
         beforeEach(() => {
             replace(configService,'compileProjectAndLoadConfig', fake.resolves({}))
+            //replace(oraLogger, 'info', fake.resolves({}))
+            //replace(oraLogger, 'start', fake.resolves({}))
         })
 
         afterEach(() => {
@@ -14,6 +16,7 @@ describe('build', () => {
         })
 
         it('runs the command', async () => {
+            //await new Build.default([], {} as IConfig).run()
             expect(1).to.eq(1)
         })
     })

--- a/packages/cli/test/commands/build.test.ts
+++ b/packages/cli/test/commands/build.test.ts
@@ -2,13 +2,15 @@ import { expect } from '../expect'
 import { restore, fake, replace } from 'sinon'
 import * as Build from '../../src/commands/build'
 import * as configService from '../../src/services/config-service'
+import * as projectChecker from '../../src/services/project-checker'
 import { oraLogger } from '../../src/services/logger'
 import { IConfig } from '@oclif/config'
 
 describe('build', () => {
     describe('Build class', () => {
         beforeEach(() => {
-            replace(configService,'checkAndCompileProject', fake.resolves({}))
+            replace(configService,'compileProject', fake.resolves({}))
+            replace(projectChecker,'checkCurrentDirIsABoosterProject', fake.resolves({}))
             replace(oraLogger, 'info', fake.resolves({}))
             replace(oraLogger, 'start', fake.resolves({}))
         })
@@ -19,7 +21,10 @@ describe('build', () => {
 
         it('runs the command', async () => {
             await new Build.default([], {} as IConfig).run()
-            expect(configService.checkAndCompileProject).to.have.been.called
+            expect(projectChecker.checkCurrentDirIsABoosterProject).to.have.been.called
+            expect(configService.compileProject).to.have.been.called
+            expect(oraLogger.start).to.have.been.calledWithMatch('Checking project structure')
+            expect(oraLogger.start).to.have.been.calledWithMatch('Building project')
             expect(oraLogger.info).to.have.been.calledWithMatch('Build complete!')
         })
     })

--- a/packages/cli/test/commands/build.test.ts
+++ b/packages/cli/test/commands/build.test.ts
@@ -1,0 +1,20 @@
+import { expect } from '../expect'
+import { restore, fake, replace } from 'sinon'
+//import * as Build from '../../src/commands/build'
+import * as configService from '../../src/services/config-service'
+
+describe('build', () => {
+    describe('Build class', () => {
+        beforeEach(() => {
+            replace(configService,'compileProjectAndLoadConfig', fake.resolves({}))
+        })
+
+        afterEach(() => {
+            restore()
+        })
+
+        it('runs the command', async () => {
+            expect(1).to.eq(1)
+        })
+    })
+})

--- a/packages/cli/test/commands/build.test.ts
+++ b/packages/cli/test/commands/build.test.ts
@@ -1,14 +1,16 @@
 import { expect } from '../expect'
 import { restore, fake, replace } from 'sinon'
-//import * as Build from '../../src/commands/build'
+import * as Build from '../../src/commands/build'
 import * as configService from '../../src/services/config-service'
+import { oraLogger } from '../../src/services/logger'
+import { IConfig } from '@oclif/config'
 
 describe('build', () => {
     describe('Build class', () => {
         beforeEach(() => {
-            replace(configService,'compileProjectAndLoadConfig', fake.resolves({}))
-            //replace(oraLogger, 'info', fake.resolves({}))
-            //replace(oraLogger, 'start', fake.resolves({}))
+            replace(configService,'checkAndCompileProject', fake.resolves({}))
+            replace(oraLogger, 'info', fake.resolves({}))
+            replace(oraLogger, 'start', fake.resolves({}))
         })
 
         afterEach(() => {
@@ -16,8 +18,9 @@ describe('build', () => {
         })
 
         it('runs the command', async () => {
-            //await new Build.default([], {} as IConfig).run()
-            expect(1).to.eq(1)
+            await new Build.default([], {} as IConfig).run()
+            expect(configService.checkAndCompileProject).to.have.been.called
+            expect(oraLogger.info).to.have.been.calledWithMatch('Build complete!')
         })
     })
 })

--- a/packages/cli/test/commands/clean.test.ts
+++ b/packages/cli/test/commands/clean.test.ts
@@ -1,0 +1,31 @@
+import { expect } from '../expect'
+import { restore, fake, replace } from 'sinon'
+import * as Clean from '../../src/commands/clean'
+import * as configService from '../../src/services/config-service'
+import * as projectChecker from '../../src/services/project-checker'
+import { oraLogger } from '../../src/services/logger'
+import { IConfig } from '@oclif/config'
+
+describe('clean', () => {
+    describe('Clean class', () => {
+        beforeEach(() => {
+            replace(configService,'cleanProject', fake.resolves({}))
+            replace(projectChecker,'checkCurrentDirIsABoosterProject', fake.resolves({}))
+            replace(oraLogger, 'info', fake.resolves({}))
+            replace(oraLogger, 'start', fake.resolves({}))
+        })
+
+        afterEach(() => {
+            restore()
+        })
+
+        it('runs the command', async () => {
+            await new Clean.default([], {} as IConfig).run()
+            expect(projectChecker.checkCurrentDirIsABoosterProject).to.have.been.called
+            expect(configService.cleanProject).to.have.been.called
+            expect(oraLogger.start).to.have.been.calledWithMatch('Checking project structure')
+            expect(oraLogger.start).to.have.been.calledWithMatch('Cleaning project')
+            expect(oraLogger.info).to.have.been.calledWithMatch('Clean complete!')
+        })
+    })
+})

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -19,6 +19,29 @@ describe('configService', () => {
     restore()
   })
 
+  describe('checkAndCompileProject', () => {
+    let checkItIsABoosterProject: SinonStub
+
+    beforeEach(() => {
+      checkItIsABoosterProject = stub(projectChecker, 'checkItIsABoosterProject').resolves()
+    })
+
+    it('loads the config when the selected environment exists', async () => {
+      const config = new BoosterConfig('build')
+
+      const rewires = [
+        configService.__set__('compileProject', fake())
+      ]
+
+      replace(environment, 'currentEnvironment', fake.returns('test'))
+
+      await expect(configService.checkAndCompileProject(userProjectPath)).to.eventually.become(config)
+      expect(checkItIsABoosterProject).to.have.been.calledOnceWithExactly(userProjectPath)
+
+      rewires.forEach((fn) => fn())
+    })
+  })
+
   describe('compileProjectAndLoadConfig', () => {
     let checkItIsABoosterProject: SinonStub
 

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -32,6 +32,18 @@ describe('configService', () => {
     })
   })
 
+  describe('cleanProject', () => {
+
+    beforeEach(() => {
+      replace(childProcessPromise,'exec', fake.resolves({}))
+    })
+
+    it('runs the npm command', async () => {
+      await configService.cleanProject(userProjectPath)
+      expect(childProcessPromise.exec).to.have.been.calledWith('npm run clean')
+    })
+  })
+
   describe('compileProjectAndLoadConfig', () => {
     let checkItIsABoosterProject: SinonStub
 

--- a/packages/framework-integration-tests/integration/cli/cli.build.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.build.integration.ts
@@ -1,0 +1,40 @@
+import * as path from 'path'
+import { expect } from 'chai'
+import { sandboxPathFor, removeFolders, fileExists } from '../helper/fileHelper'
+import { exec } from 'child-process-promise'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../cli/src/common/sandbox'
+
+describe('Build', () => {
+  let buildSandboxDir: string
+
+  before(async () => {
+    buildSandboxDir = createSandboxProject(sandboxPathFor('build'))
+  })
+
+  after(() => {
+    removeFolders([buildSandboxDir])
+  })
+
+  const cliPath = path.join('..', '..', 'cli', 'bin', 'run')
+
+  context('Valid build', () => {
+    it('should build the project', async () => {
+      
+      const expectedOutputRegex = new RegExp(
+        ['boost build', 'Checking project structure', 'Building project', 'Build complete'].join('(.|\n)*')
+      )
+
+      const { stdout } = await exec(`${cliPath} build`, { cwd: buildSandboxDir })
+
+      expect(stdout).to.match(expectedOutputRegex)
+      expect(fileExists(path.join(buildSandboxDir,'dist','index.js'))).to.be.true
+      expect(fileExists(path.join(buildSandboxDir,'dist','index.d.ts'))).to.be.true
+      expect(fileExists(path.join(buildSandboxDir,'dist','roles.js'))).to.be.true
+      expect(fileExists(path.join(buildSandboxDir,'dist','roles.d.ts'))).to.be.true
+      expect(fileExists(path.join(buildSandboxDir,'dist','config','config.js'))).to.be.true
+      expect(fileExists(path.join(buildSandboxDir,'dist','config','config.d.ts'))).to.be.true
+    })
+  })
+})

--- a/packages/framework-integration-tests/integration/cli/cli.clean.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.clean.integration.ts
@@ -21,21 +21,11 @@ describe('Clean', () => {
 
   context('Valid clean', () => {
     it('should clean the project after build', async () => {
-      
-    //   const expectedBuildOutputRegex = new RegExp(
-    //     ['boost build', 'Checking project structure', 'Building project', 'Build complete'].join('(.|\n)*')
-    //   )
-
+    
       await exec(`${cliPath} build`, { cwd: cleanSandboxDir })
       
       expect(fileExists(path.join(cleanSandboxDir,'dist'))).to.be.true
-      expect(fileExists(path.join(cleanSandboxDir,'dist','index.js'))).to.be.true
-      expect(fileExists(path.join(cleanSandboxDir,'dist','index.d.ts'))).to.be.true
-      expect(fileExists(path.join(cleanSandboxDir,'dist','roles.js'))).to.be.true
-      expect(fileExists(path.join(cleanSandboxDir,'dist','roles.d.ts'))).to.be.true
-      expect(fileExists(path.join(cleanSandboxDir,'dist','config','config.js'))).to.be.true
-      expect(fileExists(path.join(cleanSandboxDir,'dist','config','config.d.ts'))).to.be.true
-
+      
       const expectedCleanOutputRegex = new RegExp(
         ['boost clean', 'Checking project structure', 'Cleaning project', 'Clean complete'].join('(.|\n)*')
       )

--- a/packages/framework-integration-tests/integration/cli/cli.clean.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.clean.integration.ts
@@ -34,7 +34,6 @@ describe('Clean', () => {
 
       expect(stdout).to.match(expectedCleanOutputRegex)
       expect(fileExists(path.join(cleanSandboxDir,'dist'))).to.be.false
-
     })
   })
 })

--- a/packages/framework-integration-tests/integration/cli/cli.clean.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.clean.integration.ts
@@ -1,0 +1,50 @@
+import * as path from 'path'
+import { expect } from 'chai'
+import { sandboxPathFor, removeFolders, fileExists } from '../helper/fileHelper'
+import { exec } from 'child-process-promise'
+// Imported from another package to avoid duplication
+// It is OK-ish, since integration tests are always run in the context of the whole monorepo
+import { createSandboxProject } from '../../../cli/src/common/sandbox'
+
+describe('Clean', () => {
+  let cleanSandboxDir: string
+
+  before(async () => {
+    cleanSandboxDir = createSandboxProject(sandboxPathFor('clean'))
+  })
+
+  after(() => {
+    removeFolders([cleanSandboxDir])
+  })
+
+  const cliPath = path.join('..', '..', 'cli', 'bin', 'run')
+
+  context('Valid clean', () => {
+    it('should clean the project after build', async () => {
+      
+    //   const expectedBuildOutputRegex = new RegExp(
+    //     ['boost build', 'Checking project structure', 'Building project', 'Build complete'].join('(.|\n)*')
+    //   )
+
+      await exec(`${cliPath} build`, { cwd: cleanSandboxDir })
+      
+      expect(fileExists(path.join(cleanSandboxDir,'dist'))).to.be.true
+      expect(fileExists(path.join(cleanSandboxDir,'dist','index.js'))).to.be.true
+      expect(fileExists(path.join(cleanSandboxDir,'dist','index.d.ts'))).to.be.true
+      expect(fileExists(path.join(cleanSandboxDir,'dist','roles.js'))).to.be.true
+      expect(fileExists(path.join(cleanSandboxDir,'dist','roles.d.ts'))).to.be.true
+      expect(fileExists(path.join(cleanSandboxDir,'dist','config','config.js'))).to.be.true
+      expect(fileExists(path.join(cleanSandboxDir,'dist','config','config.d.ts'))).to.be.true
+
+      const expectedCleanOutputRegex = new RegExp(
+        ['boost clean', 'Checking project structure', 'Cleaning project', 'Clean complete'].join('(.|\n)*')
+      )
+
+      const { stdout } = await exec(`${cliPath} clean`, { cwd: cleanSandboxDir })
+
+      expect(stdout).to.match(expectedCleanOutputRegex)
+      expect(fileExists(path.join(cleanSandboxDir,'dist'))).to.be.false
+
+    })
+  })
+})


### PR DESCRIPTION
## Description
I have created the `boost build` command, which compiles the entire project without deploying. This will allow programmers to check if the code compiles without deploying to any environment. 
I have also created the `boost clean` command, which cleans the built project.

Closes #565 and #564 

## Changes
- I created the Build Command class and its unit and integration tests
- I created the Clean Command class and its unit and integration tests

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
## Additional information
