### PR TITLE
Fix: Reference error in publish GitHub action script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Discard all the changes after integration tests
         run: git stash
 
-      - uses: theam/actions/lerna-semantic-publish@main
+      - uses: theam/actions/lerna-semantic-publish@master
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_ACTION }}


### PR DESCRIPTION
I went too far with the search and replace when we switched to using the branch `main` as the production one in #591 