### PR TITLE
Use metadata-booster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14422,9 +14422,9 @@
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
 		},
 		"metadata-booster": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/metadata-booster/-/metadata-booster-0.2.0.tgz",
-			"integrity": "sha512-lUUOIz0lF3yJkx0IedaZlzrMNi7XsZmQMbm0urI8Wy7MgBebG/tBWdYigxziGsennLkRPASk36MAIdWl8ffWdQ=="
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/metadata-booster/-/metadata-booster-0.2.1.tgz",
+			"integrity": "sha512-UYBaVe9Sk1IPIRTVu2cuQ6OWD9D0sbDJfFyvC02Chb86Y3+JljZN0/J9gWnvTDwopfbDLfxHH2bEBUS9IoQJfQ=="
 		},
 		"methods": {
 			"version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14421,6 +14421,11 @@
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
 		},
+		"metadata-booster": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/metadata-booster/-/metadata-booster-0.2.0.tgz",
+			"integrity": "sha512-lUUOIz0lF3yJkx0IedaZlzrMNi7XsZmQMbm0urI8Wy7MgBebG/tBWdYigxziGsennLkRPASk36MAIdWl8ffWdQ=="
+		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -18175,6 +18180,14 @@
 				}
 			}
 		},
+		"ttypescript": {
+			"version": "1.5.12",
+			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
+			"requires": {
+				"resolve": ">=1.9.0"
+			}
+		},
 		"tunnel": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -18235,9 +18248,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.4.tgz",
-			"integrity": "sha512-9OL+r0KVHqsYVH7K18IBR9hhC82YwLNlpSZfQDupGcfg8goB9p/s/9Okcy+ztnTeHR2U68xq21/igW9xpoGTgA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prettier": "^1.19.1",
     "rimraf": "^3.0.0",
     "ts-node": "^8.6.2",
-    "typescript": "3.9.4",
+    "typescript": "4.1.5",
     "yargs": "^15.1.0"
   },
   "license": "Apache-2.0"

--- a/packages/cli/src/templates/project/package-json.ts
+++ b/packages/cli/src/templates/project/package-json.ts
@@ -25,7 +25,9 @@ export const template = `{
     "prettier": "^1.19.1",
     "typescript": "^3.9.3",
     "ts-node": "^8.6.2",
-    "@types/node": "^13.5.1"
+    "@types/node": "^13.5.1",
+    "ttypescript": "1.5.12",
+    "metadata-booster": "0.2.0"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -37,7 +39,7 @@ export const template = `{
   "scripts": {
     "lint:check": "eslint --ext '.js,.ts' **/*.ts",
     "lint:fix": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
-    "compile": "npx tsc -b tsconfig.json",
+    "compile": "npx ttsc -b tsconfig.json",
     "deploy": "boost deploy",
     "clean": "npx rimraf ./dist tsconfig.tsbuildinfo",
     "test": "npx nyc --extension .ts mocha --forbid-only \\"test/**/*.test.ts\\""

--- a/packages/cli/src/templates/project/tsconfig-json.ts
+++ b/packages/cli/src/templates/project/tsconfig-json.ts
@@ -14,7 +14,10 @@ export const template = `{
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "plugins": [
+      { "transform": "metadata-booster" }
+    ]
   },
   "include": [
     "src/**/*"

--- a/packages/framework-core/package.json
+++ b/packages/framework-core/package.json
@@ -55,6 +55,7 @@
     "mock-jwks": "^0.3.1",
     "nock": "^13.0.4",
     "sinon": "9.2.3",
-    "sinon-chai": "3.5.0"
+    "sinon-chai": "3.5.0",
+    "metadata-booster": "0.2.1"
   }
 }

--- a/packages/framework-core/src/decorators/metadata.ts
+++ b/packages/framework-core/src/decorators/metadata.ts
@@ -1,22 +1,14 @@
-import { PropertyMetadata, Class, AnyClass } from '@boostercloud/framework-types'
+import { Class } from '@boostercloud/framework-types'
+import { ClassMetadata, PropertyMetadata } from 'metadata-booster'
 import 'reflect-metadata'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getPropertiesMetadata(classType: Class<any>): Array<PropertyMetadata> {
-  const propertyNames = Object.getOwnPropertyNames(new classType())
-  const propertyTypes = Reflect.getMetadata('design:paramtypes', classType)
-  if (propertyNames.length != propertyTypes.length) {
+  const meta: ClassMetadata = Reflect.getMetadata('booster:typeinfo', classType)
+  if (!meta) {
     // eslint-disable-next-line prettier/prettier
-    throw new Error(`Could not get proper metadata information of ${classType.name}. While inspecting the class, the following properties were found:
-> ${propertyNames.join(', ')}
-But its constructor parameters have the following types:
-> ${propertyTypes.map((type: AnyClass) => type.name).join(', ')}
-They mismatch. Make sure you define all properties as "constructor parameter properties" (see https://www.typescriptlang.org/docs/handbook/classes.html#parameter-properties)
-`)
+    throw new Error(`Could not get proper metadata information of ${classType.name}`)
   }
 
-  return propertyNames.map((propertyName, index) => ({
-    name: propertyName,
-    type: propertyTypes[index],
-  }))
+  return meta.fields
 }

--- a/packages/framework-core/src/services/graphql/common.ts
+++ b/packages/framework-core/src/services/graphql/common.ts
@@ -1,7 +1,8 @@
 import { GraphQLList, GraphQLScalarType, GraphQLObjectType } from 'graphql/type/definition'
-import { AnyClass, PropertyMetadata, UserEnvelope, UUID, GraphQLOperation } from '@boostercloud/framework-types'
+import { AnyClass, UserEnvelope, UUID, GraphQLOperation } from '@boostercloud/framework-types'
 import { GraphQLFieldResolver } from 'graphql'
 import { ReadModelPubSub } from '../pub-sub/read-model-pub-sub'
+import { PropertyMetadata } from 'metadata-booster'
 
 export type TargetTypesMap = Record<string, TargetTypeMetadata>
 export interface TargetTypeMetadata {

--- a/packages/framework-core/src/services/graphql/graphql-query-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-query-generator.ts
@@ -9,20 +9,14 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLScalarType,
-  GraphQLString
+  GraphQLString,
 } from 'graphql'
 import { GraphQLNonInputType, ResolverBuilder, TargetTypeMetadata, TargetTypesMap } from './common'
 import { GraphQLTypeInformer } from './graphql-type-informer'
 import * as inflected from 'inflected'
 import { GraphQLJSONObject } from 'graphql-type-json'
-import {
-  AnyClass,
-  BooleanOperations,
-  NumberOperations,
-  PropertyMetadata,
-  StringOperations,
-  UUID,
-} from '@boostercloud/framework-types'
+import { AnyClass, BooleanOperations, NumberOperations, StringOperations, UUID } from '@boostercloud/framework-types'
+import { PropertyMetadata } from 'metadata-booster'
 
 export class GraphQLQueryGenerator {
   private generatedFiltersByTypeName: Record<string, GraphQLInputObjectType> = {}
@@ -38,13 +32,13 @@ export class GraphQLQueryGenerator {
   public generate(): GraphQLObjectType {
     const byIDQueries = this.generateByIDQueries()
     const filterQueries = this.generateFilterQueries()
-    const fields = {...byIDQueries, ...filterQueries}
+    const fields = { ...byIDQueries, ...filterQueries }
     if (Object.keys(fields).length === 0) {
       return new GraphQLObjectType({
         name: 'Query',
         fields: {
-          NoQueriesDefined: { type: GraphQLString }
-        }
+          NoQueriesDefined: { type: GraphQLString },
+        },
       })
     }
     return new GraphQLObjectType({
@@ -86,13 +80,13 @@ export class GraphQLQueryGenerator {
   public generateFilterArguments(typeMetadata: TargetTypeMetadata): GraphQLFieldConfigArgumentMap {
     const args: GraphQLFieldConfigArgumentMap = {}
     typeMetadata.properties.forEach((prop: PropertyMetadata) => {
-      const graphQLPropType = this.typeInformer.getGraphQLTypeFor(prop.type)
+      const graphQLPropType = this.typeInformer.getGraphQLTypeFor(prop.typeInfo.type)
       if (!this.canFilter(graphQLPropType)) {
         // TODO: We still don't handle filtering by complex properties
         return
       }
       args[prop.name] = {
-        type: this.generateFilterFor(prop.type),
+        type: this.generateFilterFor(prop.typeInfo.type),
       }
     })
     return args

--- a/packages/framework-core/src/services/graphql/graphql-type-informer.ts
+++ b/packages/framework-core/src/services/graphql/graphql-type-informer.ts
@@ -1,6 +1,6 @@
 import { GraphQLJSONObject } from 'graphql-type-json'
 import { GraphQLNonInputType, TargetTypeMetadata, TargetTypesMap } from './common'
-import { AnyClass, UUID, PropertyMetadata } from '@boostercloud/framework-types'
+import { AnyClass, UUID } from '@boostercloud/framework-types'
 import {
   GraphQLFieldConfigMap,
   GraphQLList,
@@ -18,6 +18,7 @@ import {
   GraphQLInterfaceType,
 } from 'graphql'
 import { GraphQLFieldMap, GraphQLInputFieldConfigMap } from 'graphql/type/definition'
+import { PropertyMetadata } from 'metadata-booster'
 
 export class GraphQLTypeInformer {
   private graphQLTypesByName: Record<string, GraphQLNonInputType> = {}
@@ -41,7 +42,7 @@ export class GraphQLTypeInformer {
   private metadataPropertiesToGraphQLFields(properties: Array<PropertyMetadata>): GraphQLFieldConfigMap<any, any> {
     const fields: GraphQLFieldConfigMap<any, any> = {}
     for (const prop of properties) {
-      fields[prop.name] = { type: this.getGraphQLTypeFor(prop.type) }
+      fields[prop.name] = { type: this.getGraphQLTypeFor(prop.typeInfo.type) }
     }
     return fields
   }

--- a/packages/framework-integration-tests/package.json
+++ b/packages/framework-integration-tests/package.json
@@ -34,7 +34,9 @@
     "faker": "5.1.0",
     "graphql-tag": "^2.10.3",
     "subscriptions-transport-ws": "^0.9.16",
-    "ws": "^7.3.0"
+    "ws": "^7.3.0",
+    "ttypescript": "1.5.12",
+    "metadata-booster": "0.2.0"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -46,7 +48,7 @@
     "watch:local": "nodemon --watch ../framework-provider-local/dist --watch ../framework-provider-local-infrastructure --watch dist --exec \"../cli/bin/run start -e local\"",
     "lint:check": "eslint --ext '.js,.ts' **/*.ts",
     "lint:fix": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
-    "compile": "tsc -b tsconfig.json",
+    "compile": "npx ttsc -b tsconfig.json",
     "clean": "npx rimraf ./dist tsconfig.tsbuildinfo",
     "integration": "npm run integration/cli && npm run integration/local && npm run integration/aws-deploy && npm run integration/aws-func && npm run integration/end-to-end && npm run integration/aws-nuke",
     "integration/aws-deploy": "AWS_SDK_LOAD_CONFIG=true mocha --forbid-only --exit --config \"integration/providers/aws/deployment/.mocharc.yml\" \"integration/providers/aws/deployment/**/*.integration.ts\"",

--- a/packages/framework-integration-tests/package.json
+++ b/packages/framework-integration-tests/package.json
@@ -36,7 +36,7 @@
     "subscriptions-transport-ws": "^0.9.16",
     "ws": "^7.3.0",
     "ttypescript": "1.5.12",
-    "metadata-booster": "0.2.0"
+    "metadata-booster": "0.2.1"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/framework-integration-tests/tsconfig.json
+++ b/packages/framework-integration-tests/tsconfig.json
@@ -14,7 +14,10 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "plugins": [
+      { "transform": "metadata-booster" }
+    ]
   },
   "include": [
     "src/**/*"

--- a/packages/framework-types/package.json
+++ b/packages/framework-types/package.json
@@ -40,6 +40,7 @@
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "fast-check": "^1.18.1",
-    "sinon-chai": "3.5.0"
+    "sinon-chai": "3.5.0",
+    "metadata-booster": "0.2.1"
   }
 }

--- a/packages/framework-types/src/concepts/command.ts
+++ b/packages/framework-types/src/concepts/command.ts
@@ -1,6 +1,7 @@
 import { Register } from './register'
-import { PropertyMetadata, Class } from '../typelevel'
+import { Class } from '../typelevel'
 import { RoleAccess } from './role'
+import { PropertyMetadata } from 'metadata-booster'
 
 export interface CommandInterface<TCommand = unknown> extends Class<TCommand> {
   // The command's type is `unknown` because the CommandInterface type specifies the

--- a/packages/framework-types/src/concepts/read-model.ts
+++ b/packages/framework-types/src/concepts/read-model.ts
@@ -1,5 +1,6 @@
 import { RoleAccess, UUID } from '.'
-import { Class, PropertyMetadata } from '../typelevel'
+import { Class } from '../typelevel'
+import { PropertyMetadata } from 'metadata-booster'
 
 export interface ReadModelInterface {
   id: UUID

--- a/packages/framework-types/src/typelevel.ts
+++ b/packages/framework-types/src/typelevel.ts
@@ -26,11 +26,6 @@ export interface Instance {
   }
 }
 
-export interface PropertyMetadata {
-  readonly name: string
-  readonly type: AnyClass
-}
-
 export function toClassTitle(instance: Instance): string {
   return instance.constructor.name
     .replace(/([A-Z])([a-z])/g, ' $1$2')


### PR DESCRIPTION
## Description
This PR uses a Typescript plugin (aka. "transformer") to generate extra metadata for any class. For more information about what metadata is generated, check the transformer README: https://github.com/boostercloud/metadata-booster

This is the result of a vacation-hack I did this Monday that turned to have very good results.

## Problem and motivation
During the development of Booster, we have faced several times the limitations that Javascript has with regard to its runtime reflection capabilities to know the types of the application types. This is expected because it is a non-typed language.
We expected Typescript to solve this but, as it is eventually compiled to Javascript, all types are also lost. However, by using the compiler option "emitDecoratorsMetadata" we could get _some_ information about types, and only of those that are decorated with a decorator.
So, if you decorate a class (as we do with Commands or ReadModels), you will only get the type of each parameter of its constructor. This brings the following limitations:
- If you declare a property that's not among the constructor parameters, you won't get anything about it.
- You don't get property names
- You don't get methods' metadata
- And the most limiting factor: if your property has a type that contains type parameters, you will only get the metadata of the enclosing type, not of its parameters.  So if the type is `Array<string>`, you will get just "Array"

All these limitations, especially the last one, impedes building the GraphQL schema correctly, blocking the progress of the framework in, mainly, two areas:
1. ReadModel searches and filtering
2. Allow commands to return anything, which in turn blocks the progress of a possible future of building CRUD-like applications with Booster Framework.

## Possible solutions without any plugin
We've started searching for solutions for this more than a year ago, but we didn't find anything compelling. This months @adriangmweb and me started searching for solutions again, as he is working on changes to the GraphQL schema, but the only one we found was to force the user to add a lot of decorators. This is an example of a possible solution using more decorators
```typescript
@Command(...)
class CreateUser {
  public constructor(
    readonly id: UUID,
    readonly name: string,
    @ElemTypes([String, Address]) // We need to make the user write the internal types of the Map
    readonly addresses: Map<string, Address>
    @ElemTypes(/* What do we put here? This would need to be recursive */)
    readonly groupedAddresses: Map<string, Array<Address>>
  ) {

  @Returns(User) // But what if it returns an array of users?
  public static handle(...): Promise<User> {
    // ...
  }
}

@HelperType // We need to decorate this class too, even if the decorator does nothing. If not, Typescript won't generate metadata
class Address {
  constructor(
    public firstName: string,
    public lastName: string,
    public country: string,
    @ElemTypes([State])
    public state: Set<State>,
    public postalCode: string,
    public address: string
  ) {}
}
```
So we would clutter the user project with a lot of superfluous decorators.

## Solution with the plugin
With the plugin "metadata-booster", there is no need for any decorator. It generates detailed metadata (including recursive type parameters like Promise<Map<String, Set<User>>>) for **all classes**, no matter if they are decorated or not. It also includes metadata for methods, so we would completely unblock the progress in the areas mentioned before.

## Drawbacks
Typescript still doesn't support plugins out of the box. They probably will, you can check the progress in [this issue](https://github.com/microsoft/TypeScript/issues/14419). The way to use it is through TTypescript. It is a wrapper that uses the official Typescript installation you have in your project but executing any plugin you have defined in your `tsconfig.json` file.

At first, I didn't like this, but after trying it, it turned it to be a tiny change in code, it works pretty well, and, more importantly, the Booster user won't notice it.

This PR contains the needed changes to use TTypescript and the plugin "metadata-booster" (changes only in the package.json and tsconfig.json files) and some other changes to adapt to the metadata structure the plugins uses.

## Checks
- [x] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
 
## Additional information
This PR would unblock the following tasks:
- 
