### PR TITLE
PR from Fecony's contribution to ask for removing files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -462,8 +462,8 @@ The `new:command` generator creates a `create-post.ts` file in the `commands` fo
 ```text
 boosted-blog
 └── src
-    └── commands
-        └── create-post.ts
+    └── commands
+        └── create-post.ts
 ```
 
 As we mentioned before, commands are the input of our system. They're sent
@@ -512,8 +512,8 @@ The name of the file is the name of the event:
 ```text
 boosted-blog
 └── src
-    └── events
-        └── post-created.ts
+    └── events
+        └── post-created.ts
 ```
 
 All events in Booster must target an entity, so we need to implement an `entityID`
@@ -617,8 +617,8 @@ As you might guess, the read-model generator will create a file called
 ```text
 boosted-blog
 └── src
-    └── read-models
-        └── post-read-model.ts
+    └── read-models
+        └── post-read-model.ts
 ```
 
 There are two things to do when creating a read model:
@@ -907,11 +907,11 @@ The preferred way to create a command is by using the generator, e.g.
 boost new:command CreateProduct --fields sku:SKU displayName:string description:string price:Money
 ```
 
-The generator will automatically create a file called `create-product.ts` with a TypeScript class of the same name under the `commands` directory. You can still create (or modify) the command manually. Since the generator is not doing any _magic_, all you need is a class decorated as `@Command`. Anyway, we recommend you always to use the generator, because it handles the boilerplate code for you.
+The generator will automatically create a file called `create-product.ts` with a TypeScript class of the same name under the `commands` directory. You can still create (or modify) the command manually. Since the generator is not doing any _magic_, all you need is a class decorated as `@Command`. Anyway, we recommend you always to use the generator, because it handles the boilerplate code for you. 
 
 Note:
 
-> Generating a command with the same name as an already existing one will override its content. Soon, we will display a warning before overwriting anything.
+> Generating a command with the same name as an already existing one will prompt the user for confirmation
 
 #### The command handler function
 
@@ -1185,7 +1185,7 @@ That will generate a file called `stock-moved.ts` under the proper `<project-roo
 
 Note:
 
-> Generating an event with the same name as an already existing one will overwrite its content. Soon, we will display a warning before overwriting anything.
+> Generating an event with the same name as an already existing one will prompt the user for confirmation
 
 #### Registering events in the event store
 
@@ -1375,7 +1375,7 @@ The generator will automatically create a file called `product.ts` with a TypeSc
 
 Note:
 
-> Generating an entity with the same name as an already existing one will overwrite its content. Soon, we will display a warning before overwriting anything.
+> Generating an entity with the same name as an already existing one will prompt the user for confirmation
 
 #### The reducer function
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -907,11 +907,11 @@ The preferred way to create a command is by using the generator, e.g.
 boost new:command CreateProduct --fields sku:SKU displayName:string description:string price:Money
 ```
 
-The generator will automatically create a file called `create-product.ts` with a TypeScript class of the same name under the `commands` directory. You can still create (or modify) the command manually. Since the generator is not doing any _magic_, all you need is a class decorated as `@Command`. Anyway, we recommend you always to use the generator, because it handles the boilerplate code for you. 
+The generator will automatically create a file called `create-product.ts` with a TypeScript class of the same name under the `commands` directory. You can still create (or modify) the command manually. Since the generator is not doing any _magic_, all you need is a class decorated as `@Command`. Anyway, we recommend you always to use the generator, because it handles the boilerplate code for you.
 
 Note:
 
-> Generating a command with the same name as an already existing one will prompt the user for confirmation
+> Generating a command with the same name as an already existing one will prompt the user for confirmation.
 
 #### The command handler function
 
@@ -1185,7 +1185,7 @@ That will generate a file called `stock-moved.ts` under the proper `<project-roo
 
 Note:
 
-> Generating an event with the same name as an already existing one will prompt the user for confirmation
+> Generating an event with the same name as an already existing one will prompt the user for confirmation.
 
 #### Registering events in the event store
 
@@ -1375,7 +1375,7 @@ The generator will automatically create a file called `product.ts` with a TypeSc
 
 Note:
 
-> Generating an entity with the same name as an already existing one will prompt the user for confirmation
+> Generating an entity with the same name as an already existing one will prompt the user for confirmation.
 
 #### The reducer function
 

--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -11,6 +11,7 @@ import {
 import Prompter from '../../services/user-prompt'
 import { assertNameIsCorrect } from '../../services/provider-service'
 import { Provider } from '../../common/provider'
+import { checkProjectAlreadyExists } from '../../services/project-checker'
 
 export default class Project extends Command {
   public static description = 'create a new project from scratch'
@@ -63,13 +64,13 @@ export default class Project extends Command {
 
   public async run(): Promise<void> {
     const { args, flags } = this.parse(Project)
+    const { projectName } = args
+
     try {
-      if (!args.projectName) throw "You haven't provided a project name, but it is required, run with --help for usage"
-      assertNameIsCorrect(args.projectName)
-      const parsedFlags = {
-        projectName: args.projectName,
-        ...flags,
-      }
+      if (!projectName) throw "You haven't provided a project name, but it is required, run with --help for usage"
+      assertNameIsCorrect(projectName)
+      await checkProjectAlreadyExists(projectName)
+      const parsedFlags = { projectName, ...flags }
       await run(parsedFlags as Partial<ProjectInitializerConfig>, this.config.version)
     } catch (error) {
       console.error(error)

--- a/packages/cli/src/services/generator.ts
+++ b/packages/cli/src/services/generator.ts
@@ -1,12 +1,27 @@
 import * as path from 'path'
 import * as fs from 'fs-extra'
 import * as Mustache from 'mustache'
-import { Target } from './generator/target'
-import * as inflected from 'inflected'
+import { Target, FileDir } from './generator/target'
+import { classNameToFileName } from '../common/filenames'
+import { checkResourceExists } from './project-checker'
 
 export async function generate<TInfo>(target: Target<TInfo>): Promise<void> {
+  await checkResourceExists(target.name, target.placementDir, target.extension)
   const rendered = Mustache.render(target.template, target.info)
-  const fileName = inflected.dasherize(inflected.underscore(target.name))
-  const renderPath = path.join(process.cwd(), target.placementDir, `${fileName}${target.extension}`)
+  const renderPath = filePath<TInfo>(target)
   await fs.outputFile(renderPath, rendered)
+}
+
+export function filePath<TInfo>(target: FileDir<TInfo>): string {
+  const fileName = classNameToFileName(target.name)
+  return path.join(process.cwd(), target.placementDir, `${fileName}${target.extension}`)
+}
+
+/**
+ * Split path string to get resource folder name
+ *
+ * @param resourcePath path string
+ */
+export function getResourceType(resourcePath: string): string {
+  return path.parse(resourcePath).name
 }

--- a/packages/cli/src/services/generator/target/index.ts
+++ b/packages/cli/src/services/generator/target/index.ts
@@ -8,3 +8,5 @@ export interface Target<TInfo> {
   template: string
   info: TInfo
 }
+
+export type FileDir<TInfo> = Pick<Target<TInfo>, 'placementDir' | 'name' | 'extension'>

--- a/packages/cli/src/services/project-checker.ts
+++ b/packages/cli/src/services/project-checker.ts
@@ -1,8 +1,14 @@
-import * as fs from 'fs-extra'
+import { readFileSync, existsSync, removeSync } from 'fs-extra'
 import * as path from 'path'
+import { projectDir, ProjectInitializerConfig } from './project-initializer'
+import Brand from '../common/brand'
+import { filePath, getResourceType } from './generator'
+import { classNameToFileName } from '../common/filenames'
+import Prompter from './user-prompt'
+import { oraLogger } from './logger'
 
 function checkIndexFileIsBooster(indexFilePath: string): void {
-  const contents = fs.readFileSync(indexFilePath)
+  const contents = readFileSync(indexFilePath)
   if (!contents.includes('Booster.start(')) {
     throw new Error(
       'The main application file does not start a Booster application. Verify you are in the right project'
@@ -26,5 +32,40 @@ export async function checkItIsABoosterProject(projectPath: string): Promise<voi
     throw new Error(
       `There was an error when recognizing the application. Make sure you are in the root path of a Booster project:\n${e.message}`
     )
+  }
+}
+
+export async function checkProjectAlreadyExists(name: string): Promise<void> {
+  const projectDirectoryPath = projectDir({ projectName: name } as ProjectInitializerConfig)
+  const projectDirectoryExists = existsSync(projectDirectoryPath)
+
+  if (projectDirectoryExists) {
+    await Prompter.confirmPrompt({
+      message: Brand.dangerize(`Project folder "${name}" already exists. Do you want to overwrite it?`),
+    }).then((confirm) => {
+      if (!confirm) throw new Error("The folder you're trying to use already exists. Please use another project name")
+      removeSync(projectDirectoryPath)
+    })
+  }
+}
+
+export async function checkResourceExists(name: string, placementDir: string, extension: string): Promise<void> {
+  const resourcePath = filePath({ name, placementDir, extension })
+  const resourceExists = existsSync(resourcePath)
+  const resourceName = classNameToFileName(name)
+  const resourceType = getResourceType(placementDir)
+
+  oraLogger.info(Brand.mellancholize('Checking if resource already exists...'))
+
+  if (resourceExists) {
+    await Prompter.confirmPrompt({
+      message: Brand.dangerize(`Resource: "${resourceName}${extension}" already exists. Do you want to overwrite it?`),
+    }).then((confirm) => {
+      if (!confirm)
+        throw new Error(
+          `The '${resourceType}' resource "${resourceName}${extension}" already exists. Please use another resource name`
+        )
+      removeSync(resourcePath)
+    })
   }
 }

--- a/packages/cli/src/services/project-initializer.ts
+++ b/packages/cli/src/services/project-initializer.ts
@@ -68,7 +68,7 @@ function renderToFile(templateData: ProjectInitializerConfig): (_: [Array<string
   }
 }
 
-function projectDir(config: ProjectInitializerConfig): string {
+export function projectDir(config: ProjectInitializerConfig): string {
   return path.join(process.cwd(), config.projectName)
 }
 

--- a/packages/cli/src/services/user-prompt.ts
+++ b/packages/cli/src/services/user-prompt.ts
@@ -22,4 +22,12 @@ export default class Prompter {
       return Promise.resolve(res['value'])
     }
   }
+
+  public static async confirmPrompt(promptParams: object): Promise<boolean> {
+    const confirm = await inquirer
+      .prompt([{ name: 'confirm', type: 'confirm', default: false, ...promptParams }])
+      .then(({ confirm }) => confirm)
+
+    return Promise.resolve(confirm)
+  }
 }

--- a/packages/cli/test/services/generator.test.ts
+++ b/packages/cli/test/services/generator.test.ts
@@ -32,9 +32,9 @@ describe('generate service', (): void => {
         }
         const rendered = Mustache.render(target.template, target.info)
 
-        generate(target)
+        await generate(target)
 
-        expect(fs.outputFile).to.have.been.calledWithMatch('src/commands/new-command.ts',rendered)
+        expect(fs.outputFile).to.have.been.calledWithMatch('src/commands/new-command.ts', rendered)
     })
 
     it('generates file for an entity', async () => {
@@ -52,8 +52,8 @@ describe('generate service', (): void => {
             info: info
         }
         const rendered = Mustache.render(target.template, target.info)
-        
-        generate(target)
+
+        await generate(target)
 
         expect(fs.outputFile).to.have.been.calledWithMatch('src/entities/new-entity.ts',rendered)
     })
@@ -72,8 +72,8 @@ describe('generate service', (): void => {
             info: info
         }
         const rendered = Mustache.render(target.template, target.info)
-        
-        generate(target)
+
+        await generate(target)
 
         expect(fs.outputFile).to.have.been.calledWithMatch('src/event-handlers/new-event-handler.ts',rendered)
     })
@@ -92,8 +92,8 @@ describe('generate service', (): void => {
             info: info
         }
         const rendered = Mustache.render(target.template, target.info)
-        
-        generate(target)
+
+        await generate(target)
 
         expect(fs.outputFile).to.have.been.calledWithMatch('src/events/new-event.ts',rendered)
     })
@@ -113,8 +113,8 @@ describe('generate service', (): void => {
             info: info
         }
         const rendered = Mustache.render(target.template, target.info)
-        
-        generate(target)
+
+        await generate(target)
 
         expect(fs.outputFile).to.have.been.calledWithMatch('src/read-models/new-read-model.ts',rendered)
     })
@@ -132,8 +132,8 @@ describe('generate service', (): void => {
             info: info
         }
         const rendered = Mustache.render(target.template, target.info)
-        
-        generate(target)
+
+        await generate(target)
 
         expect(fs.outputFile).to.have.been.calledWithMatch('src/scheduled-commands/new-scheduled-command.ts',rendered)
     })
@@ -152,8 +152,8 @@ describe('generate service', (): void => {
             info: info
         }
         const rendered = Mustache.render(target.template, target.info)
-        
-        generate(target)
+
+        await generate(target)
 
         expect(fs.outputFile).to.have.been.calledWithMatch('src/common/new-type.ts',rendered)
     })

--- a/packages/cli/test/services/project-checker.test.ts
+++ b/packages/cli/test/services/project-checker.test.ts
@@ -1,9 +1,21 @@
 import * as path from 'path'
-import { checkItIsABoosterProject, checkCurrentDirIsABoosterProject } from '../../src/services/project-checker'
-import { restore, replace, fake } from 'sinon'
+import {
+    checkItIsABoosterProject,
+    checkCurrentDirIsABoosterProject,
+    checkProjectAlreadyExists,
+    checkResourceExists,
+} from '../../src/services/project-checker'
+import { restore, replace, fake, spy, stub } from 'sinon'
 import { expect } from '../expect'
+import { oraLogger } from '../../src/services/logger'
+import * as fs from 'fs-extra'
+import { projectDir, ProjectInitializerConfig } from '../../src/services/project-initializer'
+import Prompter from '../../src/services/user-prompt'
 
 describe('project checker', (): void => {
+    beforeEach(() => {
+        replace(oraLogger,'info', fake.resolves({}))
+    })
 
     afterEach(() => {
         restore()
@@ -16,14 +28,14 @@ describe('project checker', (): void => {
             await checkCurrentDirIsABoosterProject().catch(() => exceptionThrown = true)
             expect(exceptionThrown).to.be.equal(false)
         })
-    
+
         it('is a Booster project with bad index.ts', async () => {
             replace(process,'cwd', fake.returns(path.join(process.cwd(),'test', 'fixtures', 'mock_project_bad_index')))
             let exceptionThrown = false
             await checkCurrentDirIsABoosterProject().catch(() => exceptionThrown = true)
             expect(exceptionThrown).to.be.equal(true)
         })
-    
+
         it('is not a Booster project', async () => {
             replace(process,'cwd', fake.returns(path.join(process.cwd(),'test', 'fixtures')))
             let exceptionThrown = false
@@ -39,19 +51,123 @@ describe('project checker', (): void => {
             await checkItIsABoosterProject(projectPath).catch(() => exceptionThrown = true)
             expect(exceptionThrown).to.be.equal(false)
         })
-    
+
         it('is a Booster project with bad index.ts', async () => {
             const projectPath = path.join(process.cwd(),'test', 'fixtures', 'mock_project_bad_index')
             let exceptionThrown = false
             await checkItIsABoosterProject(projectPath).catch(() => exceptionThrown = true)
             expect(exceptionThrown).to.be.equal(true)
         })
-    
+
         it('is not a Booster project', async () => {
             const projectPath = path.join(process.cwd(),'test', 'fixtures')
             let exceptionThrown = false
             await checkItIsABoosterProject(projectPath).catch(() => exceptionThrown = true)
             expect(exceptionThrown).to.be.equal(true)
+        })
+    })
+
+    describe('checkProjectAlreadyExists', (): void => {
+        it('should do nothing if project with given name does not exist', async () => {
+            const existsSyncStub = stub(fs, 'existsSync')
+            existsSyncStub.returns(false)
+            spy(Prompter, 'confirmPrompt')
+
+            const projectName = path.join('test', 'fixtures', 'mock_project_test')
+            const projectPath = projectDir({ projectName } as ProjectInitializerConfig)
+            await checkProjectAlreadyExists(projectName)
+
+            expect(fs.existsSync).to.have.been.calledWithMatch(projectPath)
+            expect(Prompter.confirmPrompt).not.to.have.been.called
+        })
+
+        it('should throw error when project exists and user refuses to overwrite it', async () => {
+            const existsSyncStub = stub(fs, 'existsSync')
+            existsSyncStub.returns(true)
+
+            const fakePrompter = fake.resolves(false)
+            replace(Prompter, 'confirmPrompt', fakePrompter)
+
+            const projectName = path.join('test', 'fixtures', 'mock_project_test')
+            const projectPath = projectDir({ projectName } as ProjectInitializerConfig)
+            let exceptionThrown = false
+            let exceptionMessage = ''
+
+            await checkProjectAlreadyExists(projectName).catch((e) => {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            })
+
+            expect(fs.existsSync).to.have.been.calledWithMatch(projectPath)
+            expect(Prompter.confirmPrompt).to.have.been.called
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.be.equal('The folder you\'re trying to use already exists. Please use another project name')
+        })
+
+        it('should remove project folder when project already exists and user agreed to overwrite it', async () => {
+            replace(fs, 'removeSync', fake.resolves({}))
+            const existsSyncStub = stub(fs, 'existsSync')
+            existsSyncStub.returns(true)
+
+            const fakePrompter = fake.resolves(true)
+            replace(Prompter, 'confirmPrompt', fakePrompter)
+
+            const projectName = path.join('test', 'fixtures', 'mock_project_test')
+            const projectPath = projectDir({ projectName } as ProjectInitializerConfig)
+
+            await checkProjectAlreadyExists(projectName)
+
+            expect(fs.removeSync).to.have.been.calledWithMatch(projectPath)
+        })
+    })
+
+    describe('checkResourceExists', (): void => {
+        it('should print info message and do nothing if resource doesn\'t exist', async () => {
+            const resourcePath = path.join('test', 'fixtures', 'mock_project', 'src', 'entities')
+            const existsSyncStub = stub(fs, 'existsSync')
+            existsSyncStub.returns(false)
+            spy(Prompter, 'confirmPrompt')
+
+            await checkResourceExists('TestResource', resourcePath, '.ts')
+
+            expect(oraLogger.info).to.have.been.calledWithMatch('Checking if resource already exists...')
+            expect(fs.existsSync).to.have.been.calledWithMatch(resourcePath)
+            expect(Prompter.confirmPrompt).not.to.have.been.called
+        })
+
+        it('should throw error when resource exists and user refuses to overwrite it', async () => {
+            const resourcePath = path.join('test', 'fixtures', 'mock_project', 'src', 'entities')
+            const fakePrompter = fake.resolves(false)
+            const existsSyncStub = stub(fs, 'existsSync')
+            let exceptionThrown = false
+            let exceptionMessage = ''
+
+            existsSyncStub.returns(true)
+            replace(Prompter, 'confirmPrompt', fakePrompter)
+
+            await checkResourceExists('TestResource', resourcePath, '.ts').catch((e) => {
+                exceptionThrown = true
+                exceptionMessage = e.message
+            })
+
+            expect(fs.existsSync).to.have.been.calledWithMatch(resourcePath)
+            expect(Prompter.confirmPrompt).to.have.been.called
+            expect(exceptionThrown).to.be.equal(true)
+            expect(exceptionMessage).to.be.equal( 'The \'entities\' resource "test-resource.ts" already exists. Please use another resource name')
+        })
+
+        it('should remove resource when it exists and user agreed to overwrite it', async () => {
+            const resourcePath = path.join('test', 'fixtures', 'mock_project', 'src', 'entities')
+            const fakePrompter = fake.resolves(true)
+            const existsSyncStub = stub(fs, 'existsSync')
+
+            existsSyncStub.returns(true)
+            replace(fs, 'removeSync', fake.resolves({}))
+            replace(Prompter, 'confirmPrompt', fakePrompter)
+
+            await checkResourceExists('TestResource', resourcePath, '.ts')
+
+            expect(fs.removeSync).to.have.been.calledWithMatch(resourcePath)
         })
     })
 })

--- a/packages/cli/test/services/user-prompt.test.ts
+++ b/packages/cli/test/services/user-prompt.test.ts
@@ -77,4 +77,11 @@ describe('user prompt', () => {
         const value = await new Prompter().defaultOrChoose(null,"Choose a value",['value1','value2','value3'])
         expect(value).to.equal('value2')
     })
+
+    it('confirmPrompt returns confirm boolean value', async () => {
+        const promptStub = stub(inquirer, 'prompt')
+        promptStub.resolves({ confirm: true })
+        const value = await Prompter.confirmPrompt({ message: 'Delete resource?'})
+        expect(value).to.be.true
+    })
 })

--- a/packages/framework-integration-tests/integration/cli/cli.event.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.event.integration.ts
@@ -1,6 +1,13 @@
 import * as path from 'path'
 import { expect } from 'chai'
-import { loadFixture, readFileContent, removeFolders, sandboxPathFor, writeFileContent } from '../helper/fileHelper'
+import {
+  loadFixture,
+  readFileContent,
+  removeFiles,
+  removeFolders,
+  sandboxPathFor,
+  writeFileContent
+} from '../helper/fileHelper'
 import { exec } from 'child-process-promise'
 // Imported from another package to avoid duplication
 // It is OK-ish, since integration tests are always run in the context of the whole monorepo
@@ -34,6 +41,7 @@ describe('Event', () => {
     describe('without fields', () => {
       it('should create new event', async () => {
         const FILE_CART_CHANGED_EVENT = `${eventSandboxDir}/src/events/cart-changed.ts`
+        removeFiles([FILE_CART_CHANGED_EVENT])
 
         await exec(`${cliPath} new:event CartChanged`, { cwd: eventSandboxDir })
 

--- a/packages/framework-integration-tests/integration/cli/cli.readmodel.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.readmodel.integration.ts
@@ -1,6 +1,13 @@
 import { expect } from 'chai'
 import * as path from 'path'
-import { loadFixture, readFileContent, removeFolders, sandboxPathFor, writeFileContent } from '../helper/fileHelper'
+import {
+  loadFixture,
+  readFileContent,
+  removeFiles,
+  removeFolders,
+  sandboxPathFor,
+  writeFileContent,
+} from '../helper/fileHelper'
 import { exec } from 'child-process-promise'
 // Imported from another package to avoid duplication
 // It is OK-ish, since integration tests are always run in the context of the whole monorepo
@@ -29,6 +36,7 @@ describe('Read model', () => {
     describe('without fields', () => {
       it('should create new read model', async () => {
         const FILE_CART_READ_MODEL = `${readModelSandboxDir}/src/read-models/cart-read-model.ts`
+        removeFiles([FILE_CART_READ_MODEL])
 
         const { stdout } = await exec(`${cliPath} new:read-model CartReadModel`, { cwd: readModelSandboxDir })
         expect(stdout).to.match(EXPECTED_OUTPUT_REGEX)


### PR DESCRIPTION
PR created on behalf of @Fecony and related to this external PR https://github.com/boostercloud/booster/pull/475

Check if project folder or resource already exist before generating new file. It will ask user if he wants to override existing file and continue or stop generating. If user agrees to override it file/project folder is removed. If declines then it will throw error for user to use different resource name. (See Images below) 

Closes https://github.com/boostercloud/booster/issues/305

## Changes
- Checks if project or file already exist.
- export `projectDir()`
- Adds `checkProjectAlreadyExists()` to check if project already exists in current directory.
- Adds `checkResourceExists()` to check if resource already exists.
- Unit tests for `checkProjectAlreadyExists()` and `checkResourceExists()` methods
- Adds `confirmPrompt()` which is used by `checkProjectAlreadyExists()` and `checkResourceExists()` to reuse same code
- Adds `filePath` function which was used in single method, to get path where resource should be generated. Is used for generation and to check if resource exists
- Adds `FileDir` type for `filePath` method to pick only required params `'placementDir' | 'name' | 'extension'`
- Adds `getResourceType()` to get resource name from path.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
## Additional information
> Preview of CLI new messages

<img width="941" alt="Screenshot 2020-10-21 at 23 12 36" src="https://user-images.githubusercontent.com/36774784/97086353-5aefc580-162b-11eb-825a-547f2d0a7da2.png">
<img width="941" alt="Screenshot 2020-10-21 at 23 12 40" src="https://user-images.githubusercontent.com/36774784/97086354-5c20f280-162b-11eb-90f3-303791f0dba5.png">
