### PR TITLE
Doc: fix markdown-toc markdown generation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,13 @@ Remember that if something here doesn't make sense, you can also propose a chang
   - [Running unit tests](#running-unit-tests)
   - [Running integration tests](#running-integration-tests)
   - [Github flow](#github-flow)
-  - [Test-driven approach](#test-driven-approach)
   - [Publishing your Pull Request](#publishing-your-pull-request)
   - [Branch naming conventions](#branch-naming-conventions)
   - [Commit message guidelines](#commit-message-guidelines)
+- [Code Style Guidelines](#code-style-guidelines)
+  - [Importing other files and libraries](#importing-other-files-and-libraries)
+  - [Functional style](#functional-style)
+  - [Use `const` and `let`](#use-const-and-let)
 
 <!-- tocstop -->
 
@@ -136,7 +139,7 @@ To start contributing to the project you would need to set up the project in you
 - Compile the project `lerna run compile`
 
 - Add your contribution
-  
+
 - Make sure everything works by executing the unit tests: `lerna run test`
 
 - Before making a PR you should run the `check-all-the-things` script:
@@ -333,3 +336,4 @@ a = a + b
 // Less Good
 var c = 0
 let d = 3 // Never updated
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "update-tocs": "npm run update-documentation-toc && npm run update-contributing-toc",
-    "update-documentation-toc": "markdown-toc -i --bullets=- --bullets=* --bullets=+ --maxdepth 4 docs/README.md",
+    "update-documentation-toc": "markdown-toc -i --maxdepth 4 docs/README.md",
     "update-contributing-toc": "markdown-toc -i --bullets=- --maxdepth 4 CONTRIBUTING.md"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "private": true,
   "scripts": {
     "update-tocs": "npm run update-documentation-toc && npm run update-contributing-toc",
-    "update-documentation-toc": "markdown-toc -i --maxdepth 4 docs/README.md",
-    "update-contributing-toc": "markdown-toc -i --maxdepth 4 CONTRIBUTING.md"
+    "update-documentation-toc": "markdown-toc -i --bullets=- --bullets=* --bullets=+ --maxdepth 4 docs/README.md",
+    "update-contributing-toc": "markdown-toc -i --bullets=- --maxdepth 4 CONTRIBUTING.md"
   },
   "devDependencies": {
     "@octokit/rest": "^17.0.0",


### PR DESCRIPTION
## Description
Fix markdown-toc markdown file generation. When running `npm run update-tocs` markdown list bullet style was changed, CONTRIBUTING.md file `-` list bullet style was changed to `*` since it is default bullet style.

> CONTRIBUTING.md missing links and not existing links where added/removed after running `npm run update-tocs`

## Changes
- Fixed bullet list generation
  - CONTRIBUTING.md has `-` bullet style. 
  - docs/README.md file uses 3 bullet styles for different nesting levels `-`, `*`, `+` 

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
## Additional information
