### PR TITLE
Extend Batch file Rocket: row event from event handler + add support for jsonl files

### DIFF
--- a/packages/rocket-batch-file-process-aws-infrastructure/README.md
+++ b/packages/rocket-batch-file-process-aws-infrastructure/README.md
@@ -2,19 +2,19 @@
 
 This package is a configurable Booster rocket for parallel batch file processing.
 First, it creates a source Object Storage (S3) and a Staging Object Storage(S3).
-Every time a new File is uploaded to the Source S3 Bucket, a new Lambda function will be triggered.
 
-This Lambda function will
+Every time a new File is uploaded to the Source S3 Bucket, a new Lambda function will be triggered that will:
 
-- Split the source file in smaller chunks. The chunk size is defined by the user as input parameter of the rocket.
+- Split the source file in smaller chunks. The `chunkSize` is defined by the user as input parameter of the rocket (See example below).
 - Persist the new formed chunk file in the Staging Bucket.
-- Persist a new event (containing fileUri and fileSize) for each chunk in the Event Store.
+- Persist a new event (only containing `fileUri` and `fileSize`) in the Events Store for each chunk created.
 
 Then, for every chunk file dropped in the Staging rocket a new Lambda function will be triggered that will:
 
-- Read each chunk file line by line and persist a new event in the Events Store for each row
+- Read each chunk file line by line and persist a new event in the Events Store for each row.
 
-This event is defined in the Booster application and can be consumed from the Event Handler for any kind of processing.
+This event is registered in the Booster application's store as a regular event. Then, you can create event handlers to perform any kind of processing.
+
 You drop your file, and you implement your logic based on an event representing a line of the file.
 
 *Disclaimer: Currently the rocket supports CSV and jsonl files.* 
@@ -40,14 +40,111 @@ Booster.configure('development', (config: BoosterConfig): void => {
     parameters: {
       config: {
         bucketName: 'test-bucket',
-        chunkSize: '2',
+        chunkSize: '100',
       },
       rowEvent: {
         entityId: 'id',
-        eventTypeName: 'RowAdded',
-        entityTypeName: 'RowEntity',
+        eventTypeName: 'AddressAdded',
+        entityTypeName: 'AddressEntity',
       },
     },
   }])
 })
+```
+Based on this example let's also define the `AddressAdded` event and the `AddressEntity` entity in your Booster project
+
+```typescript
+import { Event } from '@boostercloud/framework-core'
+import { UUID } from '@boostercloud/framework-types'
+
+@Event
+export class AddressAdded {
+  public constructor(
+    readonly id: UUID,
+    readonly firstName: string,
+    readonly lastName: string,
+    readonly address: string,
+    readonly city: string,
+    readonly state: string,
+    readonly postalCode: string
+  ) {}
+
+  public entityID(): UUID {
+    return this.id
+  }
+}
+```
+
+```typescript
+import { Entity, Reduces } from '@boostercloud/framework-core'
+import { AddressAdded } from '../events/address-added'
+import { UUID } from '@boostercloud/framework-types'
+
+@Entity
+export class AddressEntity {
+  public constructor(
+    public id: UUID,
+    readonly firstName: string,
+    readonly lastName: string,
+    readonly address: string,
+    readonly city: string,
+    readonly state: string,
+    readonly postalCode: string
+  ) {}
+
+  @Reduces(AddressAdded)
+  public static reduceAddressAdded(event: AddressAdded, currentAddressEntity?: AddressEntity): AddressEntity {
+    return new AddressEntity(
+      event.id,
+      event.firstName,
+      event.lastName,
+      event.address,
+      event.city,
+      event.state,
+      event.postalCode
+    )
+  }
+}
+```
+
+The attributes of the `AddressAdded` and `AddressEntity` classes are defined by the structure of the input file.
+This is an example of CSV file that will work with what we defined above:
+ 
+```csv
+id,firstName,lastName,address,city,state,postalCode
+1a,John,Doe,120 jefferson st.,Riverside, NJ, 08075
+2b,Jack,McGinnis,220 hobo Av.,Phila, PA,09119
+3c,"John ""Da Man""",Repici,120 Jefferson St.,Riverside, NJ,08075
+4d,Stephen,Tyler,"7452 Terrace ""At the Plaza"" road",SomeTown,SD, 91234
+5e,,Blankman,,SomeTown, SD, 00298
+6f,"Joan ""the bone"" Anne",Jet,"9th at Terrace plc",Desert City,CO,00123
+7g,Juan,Perez,120 jota st.,NY,NY,00678
+```
+
+The first row of the CSV file defines the headers of the schema and is a 1 to 1 match with the `AddressAdded` and `AddressEntity` attributes definition.
+
+If we were to use `jsonl` files instead of `csv`, this would be an example 
+
+```jsonl
+{"metadata":".."}
+{"id": "1a", "firstName": "John", "lastName": "Doe", "address": "120 jefferson st.", "city": "Riverside", "state": "NJ", "postalCode": "08075"}
+{"id": "2b", "firstName": "Jack", "lastName": "McGinnis", "address": "220 hobo Av.", "city": "Phila", "state": "PA", "postalCode": "09119"}
+```
+
+The first line of the jsonl file is also used to specify some metadata. 
+
+As a result the event handler will look as following
+
+```typescript
+import { EventHandler } from '@boostercloud/framework-core'
+import { Register } from '@boostercloud/framework-types'
+import { AddressAdded } from '../events/address-added'
+
+@EventHandler(AddressAdded)
+export class AddressEventHandler {
+  public static async handle(event: AddressAdded, register: Register): Promise<void> {
+    ...
+  }
+}
+
 ```

--- a/packages/rocket-batch-file-process-aws-infrastructure/package.json
+++ b/packages/rocket-batch-file-process-aws-infrastructure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boostercloud/rocket-batch-file-process-aws-infrastructure",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Booster rocket to batch process files.",
   "keywords": [
     "Booster",
@@ -36,8 +36,8 @@
     "lint": "eslint --ext '.js,.ts' **/*.ts",
     "fix-lint": "eslint --quiet --fix --ext '.js,.ts' **/*.ts",
     "compile": "tsc -b tsconfig.json",
-    "postcompile": "cp -R src/lambdas/node_modules dist/lambdas",
-    "postinstall": "npm --prefix src/lambdas install",
+    "postcompile": "cp -R src/file-splitter-lambda/node_modules dist/file-splitter-lambda && cp -R src/file-to-line-event-lambda/node_modules dist/file-to-line-event-lambda",
+    "postinstall": "npm --prefix src/file-splitter-lambda install && npm --prefix src/file-to-line-event-lambda install",
     "clean": "rimraf ./dist tsconfig.tsbuildinfo",
     "prepack": "tsc -b tsconfig.json",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""

--- a/packages/rocket-batch-file-process-aws-infrastructure/src/file-splitter-lambda/index.ts
+++ b/packages/rocket-batch-file-process-aws-infrastructure/src/file-splitter-lambda/index.ts
@@ -2,6 +2,8 @@ import { DynamoDB, S3 } from 'aws-sdk'
 import { S3Event } from 'aws-lambda'
 
 const stagingBucketName = process.env.STAGING_BUCKET_NAME!
+const CSV_FILE = 'csv'
+const JSONL_FILE = 'jsonl'
 
 export const handler = async (event: S3Event): Promise<void> => {
   const s3 = new S3()
@@ -16,18 +18,38 @@ export const handler = async (event: S3Event): Promise<void> => {
     Key: key,
   }
   const data = await s3.getObject(params).promise()
+  const fileExtension = key.split('.').pop()
+
+  if (fileExtension != CSV_FILE && fileExtension != JSONL_FILE) {
+    throw Error(`[ROCKET#batch-file] The provided fileExtension ${fileExtension} is not supported.`)
+  }
 
   if (data.Body) {
     const content = data.Body.toString()
 
     let chunkContent: string[] = []
-    const lines = content.split('\n')
-    let itr = 0
-    let fileNumber = 1
+    const rows = content.split('\n')
 
-    while (itr < lines.length) {
+    if (rows.length == 0) {
+      throw Error('[ROCKET#batch-file] The input file is empty.')
+    }
+
+    if (rows.length == 1) {
+      if (fileExtension == CSV_FILE) {
+        throw Error('[ROCKET#batch-file] Looks like the input CSV file only contains the headers row.')
+      } else {
+        throw Error('[ROCKET#batch-file] Looks like the input jsonl file only contains the first metadata row.')
+      }
+    }
+
+    let currentRowNumber = 0
+    let fileNumber = 1
+    const firstRow: string = rows.shift()!
+
+    while (currentRowNumber < rows.length) {
       if (chunkContent.length != 0 && chunkContent.length % Number(process.env.CHUNK_SIZE) == 0) {
         const partKey = `part-${fileNumber}-${key}`
+        chunkContent.unshift(firstRow)
 
         await saveFile(partKey, chunkContent)
         await saveEvent(partKey)
@@ -35,15 +57,16 @@ export const handler = async (event: S3Event): Promise<void> => {
         fileNumber = fileNumber + 1
         chunkContent = []
       }
-      if (lines[itr]) {
-        chunkContent.push(lines[itr])
+      if (rows[currentRowNumber]) {
+        chunkContent.push(rows[currentRowNumber])
       }
 
-      itr = itr + 1
+      currentRowNumber = currentRowNumber + 1
     }
 
     if (chunkContent.length != 0) {
       const partKey = `part-${fileNumber}-${key}`
+      chunkContent.unshift(firstRow)
 
       await saveFile(partKey, chunkContent)
       await saveEvent(partKey)

--- a/packages/rocket-batch-file-process-aws-infrastructure/src/file-splitter-lambda/package.json
+++ b/packages/rocket-batch-file-process-aws-infrastructure/src/file-splitter-lambda/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "file-splitter-lambda",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.ts",
+  "scripts": {
+    "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "uuid": "^8.3.2"
+  },
+  "bundledDependencies": [
+    "uuid"
+  ],
+  "dependencies": {
+    "tslib": "2.1.0",
+    "aws-sdk": "2.764.0",
+    "@types/aws-lambda": "8.10.48"
+  }
+}

--- a/packages/rocket-batch-file-process-aws-infrastructure/src/file-to-line-event-lambda/index.ts
+++ b/packages/rocket-batch-file-process-aws-infrastructure/src/file-to-line-event-lambda/index.ts
@@ -1,0 +1,90 @@
+import { S3Event } from 'aws-lambda'
+import { DynamoDB, S3 } from 'aws-sdk'
+
+const CSV_FILE = 'csv'
+const JSONL_FILE = 'jsonl'
+
+const s3 = new S3()
+const ddb = new DynamoDB.DocumentClient()
+const { v4: uuidv4 } = require('uuid')
+
+const ENTITY_ID_NAME = process.env.ENTITY_ID!
+
+export const handler = async (event: S3Event): Promise<void> => {
+  const {
+    bucket: { name },
+    object: { key },
+  } = event.Records[0].s3
+
+  const params = {
+    Bucket: name,
+    Key: key,
+  }
+
+  const data = await s3.getObject(params).promise()
+  if (data.Body) {
+    const fileExtension = key.split('.').pop()
+    const rows = data.Body.toString().split('\n')
+
+    if (fileExtension == CSV_FILE) {
+      await csvRowsToEvents(rows)
+    } else if (fileExtension == JSONL_FILE) {
+      await jsonlRowsToEvents(rows)
+    } else {
+      throw Error('File Format is not supported')
+    }
+  }
+}
+
+async function csvRowsToEvents(rows: string[]): Promise<void> {
+  const headers: string[] = rows.shift()!.split(',')
+  const indexOfEntityId = headers.indexOf(ENTITY_ID_NAME)
+
+  for (let rowNumber = 0; rowNumber < rows.length; rowNumber++) {
+    const rowValues: string[] = rows[rowNumber].split(',')
+    const entityIdValue = rowValues[indexOfEntityId]
+
+    let index = 0
+    const boosterEvent = {} as any
+
+    for (let headerNumber = 0; headerNumber < headers.length; headerNumber++) {
+      boosterEvent[headers[headerNumber]] = rowValues[index]
+      index++
+    }
+
+    await saveEvent(entityIdValue, boosterEvent)
+  }
+}
+
+async function jsonlRowsToEvents(rows: string[]): Promise<void> {
+  rows.shift()!
+
+  for (let rowNumber = 0; rowNumber < rows.length; rowNumber++) {
+    const boosterEvent = JSON.parse(rows[rowNumber])
+    const entityIdValue = boosterEvent[ENTITY_ID_NAME]
+    await saveEvent(entityIdValue, boosterEvent)
+  }
+}
+
+async function saveEvent(entityIdValue: string, boosterEvent: any): Promise<void> {
+  const params = {
+    TableName: process.env.EVENT_STORE_NAME!,
+    Item: {
+      createdAt: new Date().toISOString(),
+      entityID: entityIdValue,
+      entityTypeName: process.env.ENTITY_TYPE_NAME,
+      entityTypeName_entityID_kind: `${process.env.ENTITY_TYPE_NAME}-${entityIdValue}-event`,
+      kind: 'event',
+      requestID: uuidv4(),
+      typeName: process.env.TYPE_NAME,
+      value: boosterEvent,
+      version: 1,
+    },
+  }
+
+  try {
+    await ddb.put(params).promise()
+  } catch (e) {
+    console.log('[ROCKET#batch-file] An error occurred while performing a PutItem operation: ', e)
+  }
+}

--- a/packages/rocket-batch-file-process-aws-infrastructure/src/file-to-line-event-lambda/package.json
+++ b/packages/rocket-batch-file-process-aws-infrastructure/src/file-to-line-event-lambda/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lambdas",
+  "name": "file-to-line-lambda",
   "version": "1.0.0",
   "description": "",
   "main": "index.ts",


### PR DESCRIPTION
## Description
This PR extends the current Batch file rocket to the next level of abstraction.
As of now we used to receive a `FileAdded` event in the Event Handler representing the chunked file but we still needed to use the AWS sdk to open the file, split by "," if CSV file and etc.. logic that we can abstract to the rocket.
This PR does that. We receive an event representing a line of the file directly.

Also, add support for jsonl files
## Changes
New files.

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly
 
## Additional information
