### PR TITLE
fix(cli): update new:entity command flag

### DIFF
--- a/packages/cli/src/commands/new/entity.ts
+++ b/packages/cli/src/commands/new/entity.ts
@@ -28,7 +28,7 @@ export default class Entity extends BaseCommand {
       multiple: true,
     }),
     reduces: Oclif.flags.string({
-      char: 'p',
+      char: 'r',
       description: 'events that this entity will reduce to build its state',
       multiple: true,
     }),


### PR DESCRIPTION
## Description
This is a simple bug fix described in https://github.com/boostercloud/booster/issues/628 where the new:entity cli command flag needed an update.

## Changes
Changed the flag from p to r.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly.
 
## Additional information
I could not find anything in the documentation that needed an update as a result of this change.
