### PR TITLE
fix(local): move @types/nedb to dependencies

### DIFF
--- a/packages/framework-provider-local/package.json
+++ b/packages/framework-provider-local/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@boostercloud/framework-core": "^0.11.5",
     "@boostercloud/framework-types": "^0.11.5",
+    "@types/nedb": "^1.8.11",
     "nedb": "^1.8.0"
   },
   "scripts": {
@@ -39,7 +40,6 @@
   "devDependencies": {
     "@types/express": "4.17.2",
     "@types/faker": "5.1.5",
-    "@types/nedb": "^1.8.11",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "faker": "5.1.0",


### PR DESCRIPTION
## Description
Running the boost start -e <environment> command throws error about missing @types/nedb dependency as pointed out in the Issue https://github.com/boostercloud/booster/issues/623 

## Changes
One line change to move `@types/nedb` devDependency in local provider to dependencies block.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
## Additional information
Nothing to update in the documentation.

@NickSeagull will be testing this against a project.