### PR TITLE
Refactor: Moved BoosterConfig validation to the core package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,6 @@
   },
   "bugs": "https://github.com/boostercloud/booster/issues",
   "dependencies": {
-    "@boostercloud/framework-core": "^0.11.5",
     "@boostercloud/framework-types": "^0.11.5",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -3,8 +3,6 @@ import { expect } from '../expect'
 import { fancy } from 'fancy-test'
 import { restore, fake, replace } from 'sinon'
 import { ProviderLibrary, Logger, BoosterConfig } from '@boostercloud/framework-types'
-import { test } from '@oclif/test'
-import * as Deploy from '../../src/commands/deploy'
 import * as providerService from '../../src/services/provider-service'
 import { oraLogger } from '../../src/services/logger'
 import { IConfig } from '@oclif/config'
@@ -83,38 +81,27 @@ describe('deploy', () => {
     })
   })
 
-  describe('run', () => {
-    context('when no environment provided', async () => {
-      test
-        .stdout()
-        .command(['deploy'])
-        .it('shows no environment provided error', (ctx) => {
-          expect(ctx.stdout).to.match(/No environment set/)
-        })
-    })
-  })
-
   describe('deploy class', () => {
     beforeEach(() => {
       const config = new BoosterConfig('fake_environment')
-      replace(configService,'compileProjectAndLoadConfig', fake.resolves(config))
-      replace(providerService,'deployToCloudProvider', fake.resolves({}))
-      replace(configService,'createDeploymentSandbox', fake.returns('fake/path'))
-      replace(configService,'cleanDeploymentSandbox', fake.resolves({}))
-      replace(projectChecker,'checkCurrentDirBoosterVersion', fake.resolves({}))
-      replace(oraLogger,'fail', fake.resolves({}))
+      replace(configService, 'compileProjectAndLoadConfig', fake.resolves(config))
+      replace(providerService, 'deployToCloudProvider', fake.resolves({}))
+      replace(configService, 'createDeploymentSandbox', fake.returns('fake/path'))
+      replace(configService, 'cleanDeploymentSandbox', fake.resolves({}))
+      replace(projectChecker, 'checkCurrentDirBoosterVersion', fake.resolves({}))
+      replace(oraLogger, 'fail', fake.resolves({}))
       replace(oraLogger, 'info', fake.resolves({}))
       replace(oraLogger, 'start', fake.resolves({}))
       replace(oraLogger, 'succeed', fake.resolves({}))
     })
 
     it('init calls checkCurrentDirBoosterVersion', async () => {
-      await new Deploy.default([], {} as IConfig).init()
+      await new deploy.default([], {} as IConfig).init()
       expect(projectChecker.checkCurrentDirBoosterVersion).to.have.been.called
     })
 
     it('without flags', async () => {
-      await new Deploy.default([], {} as IConfig).run()
+      await new deploy.default([], {} as IConfig).run()
 
       expect(configService.compileProjectAndLoadConfig).to.have.not.been.called
       expect(providerService.deployToCloudProvider).to.have.not.been.called
@@ -125,7 +112,7 @@ describe('deploy', () => {
       let exceptionThrown = false
       let exceptionMessage = ''
       try {
-        await new Deploy.default(['-e'], {} as IConfig).run()
+        await new deploy.default(['-e'], {} as IConfig).run()
       } catch (e) {
         exceptionThrown = true
         exceptionMessage = e.message
@@ -140,7 +127,7 @@ describe('deploy', () => {
       let exceptionThrown = false
       let exceptionMessage = ''
       try {
-        await new Deploy.default(['--environment'], {} as IConfig).run()
+        await new deploy.default(['--environment'], {} as IConfig).run()
       } catch (e) {
         exceptionThrown = true
         exceptionMessage = e.message
@@ -152,10 +139,9 @@ describe('deploy', () => {
     })
 
     describe('inside a booster project', () => {
-
       it('entering correct environment', async () => {
-        await new Deploy.default(['-e','fake_environment'], {} as IConfig).run()
-  
+        await new deploy.default(['-e', 'fake_environment'], {} as IConfig).run()
+
         expect(configService.compileProjectAndLoadConfig).to.have.been.called
         expect(providerService.deployToCloudProvider).to.have.been.called
         expect(oraLogger.info).to.have.been.calledWithMatch('Deployment complete!')
@@ -165,8 +151,8 @@ describe('deploy', () => {
         let exceptionThrown = false
         let exceptionMessage = ''
         try {
-          await new Deploy.default(['-e','fake_environment','--nonexistingoption'], {} as IConfig).run()
-        } catch(e) {
+          await new deploy.default(['-e', 'fake_environment', '--nonexistingoption'], {} as IConfig).run()
+        } catch (e) {
           exceptionThrown = true
           exceptionMessage = e.message
         }
@@ -176,7 +162,6 @@ describe('deploy', () => {
         expect(providerService.deployToCloudProvider).to.have.not.been.called
         expect(oraLogger.info).to.have.not.been.calledWithMatch('Deployment complete!')
       })
-
     })
   })
 })

--- a/packages/cli/test/commands/nuke.test.ts
+++ b/packages/cli/test/commands/nuke.test.ts
@@ -4,11 +4,9 @@ import { fancy } from 'fancy-test'
 import { restore, replace, fake } from 'sinon'
 import Prompter from '../../src/services/user-prompt'
 import { ProviderLibrary, Logger, BoosterConfig } from '@boostercloud/framework-types'
-import * as Nuke from '../../src/commands/nuke'
 import * as providerService from '../../src/services/provider-service'
 import { oraLogger } from '../../src/services/logger'
 import { IConfig } from '@oclif/config'
-import { test } from '@oclif/test'
 import * as environment from '../../src/services/environment'
 import * as configService from '../../src/services/config-service'
 import * as projectChecker from '../../src/services/project-checker'
@@ -116,37 +114,25 @@ describe('nuke', () => {
     })
   })
 
-  describe('run', () => {
-    context('when no environment provided', async () => {
-      test
-        .stdout()
-        .command(['nuke'])
-        .it('shows no environment provided error', (ctx) => {
-          expect(ctx.stdout).to.match(/No environment set/)
-        })
-    })
-  })
-
   describe('command class', () => {
-    
     beforeEach(() => {
-        const config = new BoosterConfig('fake_environment')
-        replace(configService,'compileProjectAndLoadConfig', fake.resolves(config))
-        replace(providerService,'nukeCloudProviderResources', fake.resolves({}))
-        replace(projectChecker,'checkCurrentDirBoosterVersion', fake.resolves({}))
-        replace(oraLogger,'fail', fake.resolves({}))
-        replace(oraLogger, 'info', fake.resolves({}))
-        replace(oraLogger, 'start', fake.resolves({}))
-        replace(oraLogger, 'succeed', fake.resolves({}))
+      const config = new BoosterConfig('fake_environment')
+      replace(configService, 'compileProjectAndLoadConfig', fake.resolves(config))
+      replace(providerService, 'nukeCloudProviderResources', fake.resolves({}))
+      replace(projectChecker, 'checkCurrentDirBoosterVersion', fake.resolves({}))
+      replace(oraLogger, 'fail', fake.resolves({}))
+      replace(oraLogger, 'info', fake.resolves({}))
+      replace(oraLogger, 'start', fake.resolves({}))
+      replace(oraLogger, 'succeed', fake.resolves({}))
     })
 
     it('init calls checkCurrentDirBoosterVersion', async () => {
-      await new Nuke.default([], {} as IConfig).init()
+      await new nuke.default([], {} as IConfig).init()
       expect(projectChecker.checkCurrentDirBoosterVersion).to.have.been.called
     })
 
     it('without flags', async () => {
-      await new Nuke.default([], {} as IConfig).run()
+      await new nuke.default([], {} as IConfig).run()
 
       expect(configService.compileProjectAndLoadConfig).to.have.not.been.called
       expect(providerService.nukeCloudProviderResources).to.have.not.been.called
@@ -154,25 +140,25 @@ describe('nuke', () => {
     })
 
     it('with -e flag incomplete', async () => {
-        let exceptionThrown = false
-        let exceptionMessage = ''
-        try {
-          await new Nuke.default(['-e'], {} as IConfig).run()
-        } catch (e) {
-          exceptionThrown = true
-          exceptionMessage = e.message
-        }
-        expect(exceptionThrown).to.be.equal(true)
-        expect(exceptionMessage).to.to.contain('--environment expects a value')
-        expect(configService.compileProjectAndLoadConfig).to.have.not.been.called
-        expect(providerService.nukeCloudProviderResources).to.have.not.been.called
+      let exceptionThrown = false
+      let exceptionMessage = ''
+      try {
+        await new nuke.default(['-e'], {} as IConfig).run()
+      } catch (e) {
+        exceptionThrown = true
+        exceptionMessage = e.message
+      }
+      expect(exceptionThrown).to.be.equal(true)
+      expect(exceptionMessage).to.to.contain('--environment expects a value')
+      expect(configService.compileProjectAndLoadConfig).to.have.not.been.called
+      expect(providerService.nukeCloudProviderResources).to.have.not.been.called
     })
 
     it('with --environment flag incomplete', async () => {
       let exceptionThrown = false
       let exceptionMessage = ''
       try {
-        await new Nuke.default(['--environment'], {} as IConfig).run()
+        await new nuke.default(['--environment'], {} as IConfig).run()
       } catch (e) {
         exceptionThrown = true
         exceptionMessage = e.message
@@ -184,26 +170,25 @@ describe('nuke', () => {
     })
 
     describe('inside a booster project', () => {
-    
       it('entering correct environment and application name', async () => {
-        replace(Prompter.prototype,'defaultOrPrompt', fake.resolves('new-booster-app'))
-        await new Nuke.default(['-e','fake_environment'], {} as IConfig).run()
-  
+        replace(Prompter.prototype, 'defaultOrPrompt', fake.resolves('new-booster-app'))
+        await new nuke.default(['-e', 'fake_environment'], {} as IConfig).run()
+
         expect(configService.compileProjectAndLoadConfig).to.have.been.called
         expect(providerService.nukeCloudProviderResources).to.have.been.called
         expect(oraLogger.info).to.have.been.calledWithMatch('Removal complete!')
       })
 
       it('entering correct environment and --force flag', async () => {
-        await new Nuke.default(['-e','fake_environment','--force'], {} as IConfig).run()
-  
+        await new nuke.default(['-e', 'fake_environment', '--force'], {} as IConfig).run()
+
         expect(configService.compileProjectAndLoadConfig).to.have.been.called
         expect(providerService.nukeCloudProviderResources).to.have.been.called
         expect(oraLogger.info).to.have.been.calledWithMatch('Removal complete!')
       })
 
       it('entering correct environment and -f flag', async () => {
-        await new Nuke.default(['-e','fake_environment','-f'], {} as IConfig).run()
+        await new nuke.default(['-e', 'fake_environment', '-f'], {} as IConfig).run()
 
         expect(configService.compileProjectAndLoadConfig).to.have.been.called
         expect(providerService.nukeCloudProviderResources).to.have.been.called
@@ -211,12 +196,12 @@ describe('nuke', () => {
       })
 
       it('entering correct environment but a wrong application name', async () => {
-        replace(Prompter.prototype,'defaultOrPrompt', fake.resolves('fake app 2'))
+        replace(Prompter.prototype, 'defaultOrPrompt', fake.resolves('fake app 2'))
         let exceptionThrown = false
         let exceptionMessage = ''
         try {
-          await new Nuke.default(['-e','fake_environment'], {} as IConfig).run()
-        } catch(e) {
+          await new nuke.default(['-e', 'fake_environment'], {} as IConfig).run()
+        } catch (e) {
           exceptionThrown = true
           exceptionMessage = e.message
         }
@@ -231,8 +216,8 @@ describe('nuke', () => {
         let exceptionThrown = false
         let exceptionMessage = ''
         try {
-          await new Nuke.default(['-e','fake_environment','--nonexistingoption'], {} as IConfig).run()
-        } catch(e) {
+          await new nuke.default(['-e', 'fake_environment', '--nonexistingoption'], {} as IConfig).run()
+        } catch (e) {
           exceptionThrown = true
           exceptionMessage = e.message
         }
@@ -243,8 +228,8 @@ describe('nuke', () => {
       })
 
       it('without defining environment and --force', async () => {
-        await new Nuke.default(['--force'], {} as IConfig).run()
-  
+        await new nuke.default(['--force'], {} as IConfig).run()
+
         expect(providerService.nukeCloudProviderResources).to.have.not.been.called
         expect(oraLogger.fail).to.have.been.calledWithMatch(/No environment set/)
       })

--- a/packages/cli/test/commands/start.test.ts
+++ b/packages/cli/test/commands/start.test.ts
@@ -2,11 +2,9 @@ import { expect } from '../expect'
 import { restore, fake, replace } from 'sinon'
 import rewire = require('rewire')
 import { ProviderLibrary, BoosterConfig } from '@boostercloud/framework-types'
-import * as Start from '../../src/commands/start'
 import * as providerService from '../../src/services/provider-service'
 import { oraLogger } from '../../src/services/logger'
 import { IConfig } from '@oclif/config'
-import { test } from '@oclif/test'
 import * as environment from '../../src/services/environment'
 import * as configService from '../../src/services/config-service'
 import * as projectChecker from '../../src/services/project-checker'
@@ -15,7 +13,6 @@ const start = rewire('../../src/commands/start')
 const runTasks = start.__get__('runTasks')
 
 describe('start', () => {
-
   beforeEach(() => {
     delete process.env.BOOSTER_ENV
   })
@@ -42,36 +39,25 @@ describe('start', () => {
     })
   })
 
-  describe('run', () => {
-    context('when no environment provided', async () => {
-      test
-        .stdout()
-        .command(['start'])
-        .it('shows no environment provided error', (ctx) => {
-          expect(ctx.stdout).to.match(/No environment set/)
-        })
-    })
-  })
-
   describe('start class', () => {
     beforeEach(() => {
       const config = new BoosterConfig('fake_environment')
-      replace(configService,'compileProjectAndLoadConfig', fake.resolves(config))
-      replace(providerService,'startProvider', fake.resolves({}))
-      replace(projectChecker,'checkCurrentDirBoosterVersion', fake.resolves({}))
-      replace(oraLogger,'fail', fake.resolves({}))
+      replace(configService, 'compileProjectAndLoadConfig', fake.resolves(config))
+      replace(providerService, 'startProvider', fake.resolves({}))
+      replace(projectChecker, 'checkCurrentDirBoosterVersion', fake.resolves({}))
+      replace(oraLogger, 'fail', fake.resolves({}))
       replace(oraLogger, 'info', fake.resolves({}))
       replace(oraLogger, 'start', fake.resolves({}))
       replace(oraLogger, 'succeed', fake.resolves({}))
     })
 
     it('init calls checkCurrentDirBoosterVersion', async () => {
-      await new Start.default([], {} as IConfig).init()
+      await new start.default([], {} as IConfig).init()
       expect(projectChecker.checkCurrentDirBoosterVersion).to.have.been.called
     })
 
     it('without flags', async () => {
-      await new Start.default([], {} as IConfig).run()
+      await new start.default([], {} as IConfig).run()
 
       expect(configService.compileProjectAndLoadConfig).to.have.not.been.called
       expect(providerService.startProvider).to.have.not.been.called
@@ -82,7 +68,7 @@ describe('start', () => {
       let exceptionThrown = false
       let exceptionMessage = ''
       try {
-        await new Start.default(['-e'], {} as IConfig).run()
+        await new start.default(['-e'], {} as IConfig).run()
       } catch (e) {
         exceptionThrown = true
         exceptionMessage = e.message
@@ -97,7 +83,7 @@ describe('start', () => {
       let exceptionThrown = false
       let exceptionMessage = ''
       try {
-        await new Start.default(['--environment'], {} as IConfig).run()
+        await new start.default(['--environment'], {} as IConfig).run()
       } catch (e) {
         exceptionThrown = true
         exceptionMessage = e.message
@@ -109,26 +95,25 @@ describe('start', () => {
     })
 
     describe('inside a booster project', () => {
-    
       it('entering correct environment', async () => {
-        await new Start.default(['-e','fake_environment'], {} as IConfig).run()
-  
+        await new start.default(['-e', 'fake_environment'], {} as IConfig).run()
+
         expect(configService.compileProjectAndLoadConfig).to.have.been.called
         expect(providerService.startProvider).to.have.been.called
         expect(oraLogger.start).to.have.been.calledWithMatch(/Starting debug server on port/)
       })
 
       it('entering correct environment and --port flag', async () => {
-        await new Start.default(['-e','fake_environment','--port','5000'], {} as IConfig).run()
-  
+        await new start.default(['-e', 'fake_environment', '--port', '5000'], {} as IConfig).run()
+
         expect(configService.compileProjectAndLoadConfig).to.have.been.called
         expect(providerService.startProvider).to.have.been.called
         expect(oraLogger.start).to.have.been.calledWithMatch(/Starting debug server on port 5000/)
       })
 
       it('entering correct environment and -p flag', async () => {
-        await new Start.default(['-e','fake_environment','-p','5000'], {} as IConfig).run()
-  
+        await new start.default(['-e', 'fake_environment', '-p', '5000'], {} as IConfig).run()
+
         expect(configService.compileProjectAndLoadConfig).to.have.been.called
         expect(providerService.startProvider).to.have.been.called
         expect(oraLogger.start).to.have.been.calledWithMatch(/Starting debug server on port 5000/)
@@ -138,8 +123,8 @@ describe('start', () => {
         let exceptionThrown = false
         let exceptionMessage = ''
         try {
-          await new Start.default(['-e','fake_environment','--nonexistingoption'], {} as IConfig).run()
-        } catch(e) {
+          await new start.default(['-e', 'fake_environment', '--nonexistingoption'], {} as IConfig).run()
+        } catch (e) {
           exceptionThrown = true
           exceptionMessage = e.message
         }
@@ -154,8 +139,8 @@ describe('start', () => {
         let exceptionThrown = false
         let exceptionMessage = ''
         try {
-          await new Start.default(['-e','fake_environment','--port'], {} as IConfig).run()
-        } catch(e) {
+          await new start.default(['-e', 'fake_environment', '--port'], {} as IConfig).run()
+        } catch (e) {
           exceptionThrown = true
           exceptionMessage = e.message
         }
@@ -170,8 +155,8 @@ describe('start', () => {
         let exceptionThrown = false
         let exceptionMessage = ''
         try {
-          await new Start.default(['-e','fake_environment','-p'], {} as IConfig).run()
-        } catch(e) {
+          await new start.default(['-e', 'fake_environment', '-p'], {} as IConfig).run()
+        } catch (e) {
           exceptionThrown = true
           exceptionMessage = e.message
         }
@@ -183,8 +168,8 @@ describe('start', () => {
       })
 
       it('without defining environment and -p', async () => {
-        await new Start.default(['-p','5000'], {} as IConfig).run()
-  
+        await new start.default(['-p', '5000'], {} as IConfig).run()
+
         expect(configService.compileProjectAndLoadConfig).to.have.not.been.called
         expect(providerService.startProvider).to.have.not.been.called
         expect(oraLogger.fail).to.have.been.calledWithMatch(/No environment set/)

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -21,9 +21,8 @@ describe('configService', () => {
   })
 
   describe('compileProject', () => {
-
     beforeEach(() => {
-      replace(childProcessPromise,'exec', fake.resolves({}))
+      replace(childProcessPromise, 'exec', fake.resolves({}))
     })
 
     it('runs the npm command', async () => {
@@ -33,9 +32,8 @@ describe('configService', () => {
   })
 
   describe('cleanProject', () => {
-
     beforeEach(() => {
-      replace(childProcessPromise,'exec', fake.resolves({}))
+      replace(childProcessPromise, 'exec', fake.resolves({}))
     })
 
     it('runs the npm command', async () => {

--- a/packages/framework-core/package.json
+++ b/packages/framework-core/package.json
@@ -55,6 +55,7 @@
     "mock-jwks": "^0.3.1",
     "nock": "^13.0.4",
     "sinon": "9.2.3",
-    "sinon-chai": "3.5.0"
+    "sinon-chai": "3.5.0",
+    "rewire": "5.0.0"
   }
 }

--- a/packages/framework-core/src/booster-app.ts
+++ b/packages/framework-core/src/booster-app.ts
@@ -10,6 +10,7 @@ import {
 import { Importer } from './importer'
 import { buildLogger } from './booster-logger'
 import { fetchEntitySnapshot } from './entity-snapshot-fetcher'
+import { ConfigValidator } from './services/config-validator'
 
 /**
  * Static (singleton) class that provides access to the logger, the config,
@@ -57,7 +58,7 @@ export class BoosterApp {
     this.config.userProjectRootPath = projectRootPath
     this.logger = buildLogger(this.config.logLevel)
     Importer.importUserProjectFiles(codeRootPath)
-    this.config.validate()
+    ConfigValidator.validate(this.config)
   }
 
   /**

--- a/packages/framework-core/src/services/config-validator.ts
+++ b/packages/framework-core/src/services/config-validator.ts
@@ -1,0 +1,31 @@
+import { BoosterConfig, MigrationMetadata } from '@boostercloud/framework-types'
+
+export class ConfigValidator {
+  /** Validates a BoosterConfig object */
+  public static validate(config: BoosterConfig): void {
+    validateAllMigrations(config)
+  }
+}
+
+function validateAllMigrations(config: BoosterConfig): void {
+  for (const conceptName in config.migrations) {
+    validateConceptMigrations(config, conceptName, config.migrations[conceptName])
+  }
+}
+
+function validateConceptMigrations(
+  config: BoosterConfig,
+  conceptName: string,
+  migrations: Map<number, MigrationMetadata>
+): void {
+  // Check that migrations are defined consecutively. In other words, there are no gaps between the version numbers
+  const currentVersion = config.currentVersionFor(conceptName)
+  for (let toVersion = 2; toVersion <= currentVersion; toVersion++) {
+    if (!migrations.has(toVersion)) {
+      throw new Error(
+        `Migrations for '${conceptName}' are invalid: they are missing a migration with toVersion=${toVersion}. ` +
+          `There must be a migration for '${conceptName}' for every version in the range [2..${currentVersion}]`
+      )
+    }
+  }
+}

--- a/packages/framework-core/test/services/config-validator.test.ts
+++ b/packages/framework-core/test/services/config-validator.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { BoosterConfig, ProviderLibrary } from '@boostercloud/framework-types'
+import { expect } from '../expect'
+import { fake } from 'sinon'
+
+const rewire = require('rewire')
+const configValidator = rewire('../../src/services/config-validator')
+
+describe('ConfigValidator', () => {
+  describe('validate', () => {
+    it('validates migrations', () => {
+      const fakeValidateAllMigrations = fake()
+      const unsetfakeValidateAllMigrations = configValidator.__set__('validateAllMigrations', fakeValidateAllMigrations)
+      const fakeConfig = { an: 'object' }
+
+      configValidator.ConfigValidator.validate(fakeConfig)
+
+      expect(fakeValidateAllMigrations).to.have.been.calledOnceWith(fakeConfig)
+      unsetfakeValidateAllMigrations()
+    })
+  })
+
+  describe('validateAllMigrations', () => {
+    it('validates each concept migrations', () => {
+      const fakeValidateConceptMigrations = fake()
+      const unsetFakeValidateConceptMigrations = configValidator.__set__(
+        'validateConceptMigrations',
+        fakeValidateConceptMigrations
+      )
+
+      const fakeOneClassMetadata = { one: 'object' }
+      const fakeAnotherClassMetadata = { another: 'object' }
+      const fakeConfig = {
+        migrations: {
+          OneClass: fakeOneClassMetadata,
+          AnotherClass: fakeAnotherClassMetadata,
+        },
+      }
+
+      const validateAllMigrations = configValidator.__get__('validateAllMigrations')
+      validateAllMigrations(fakeConfig)
+
+      expect(fakeValidateConceptMigrations).to.have.been.calledTwice
+      expect(fakeValidateConceptMigrations).to.have.been.calledWith(fakeConfig, 'OneClass', fakeOneClassMetadata)
+      expect(fakeValidateConceptMigrations).to.have.been.calledWith(
+        fakeConfig,
+        'AnotherClass',
+        fakeAnotherClassMetadata
+      )
+
+      unsetFakeValidateConceptMigrations()
+    })
+  })
+
+  describe('validateConceptMigrations', () => {
+    it('throws when there are gaps in the migration versions for a concept', () => {
+      const config = new BoosterConfig('test')
+      config.provider = {} as ProviderLibrary
+      const migrations = new Map()
+      migrations.set(3, {} as any)
+      migrations.set(2, {} as any)
+      migrations.set(5, {} as any)
+      config.migrations['concept'] = migrations
+
+      const validateConceptMigrations = configValidator.__get__('validateConceptMigrations')
+      expect(() => validateConceptMigrations(config, 'concept', migrations)).to.throw(
+        /Migrations for 'concept' are invalid/
+      )
+    })
+
+    it('does not throw when there are no gaps in the migration versions for a concept', () => {
+      const config = new BoosterConfig('test')
+      config.provider = {} as ProviderLibrary
+      const migrations = new Map()
+      migrations.set(4, {} as any)
+      migrations.set(2, {} as any)
+      migrations.set(3, {} as any)
+      config.migrations['concept'] = migrations
+
+      const validateConceptMigrations = configValidator.__get__('validateConceptMigrations')
+      expect(() => validateConceptMigrations(config, 'concept', migrations)).to.not.throw()
+    })
+  })
+})

--- a/packages/framework-types/src/booster-config.ts
+++ b/packages/framework-types/src/booster-config.ts
@@ -96,10 +96,6 @@ export class BoosterConfig {
     return Math.max(...migrations.keys())
   }
 
-  public validate(): void {
-    this.validateAllMigrations()
-  }
-
   public get provider(): ProviderLibrary {
     if (!this._provider) throw new Error('It is required to set a valid provider runtime in your configuration files')
     return this._provider
@@ -140,25 +136,6 @@ export class BoosterConfig {
 
   public set tokenVerifier(tokenVerifier: { issuer: string; jwksUri: string } | undefined) {
     this._tokenVerifier = tokenVerifier
-  }
-
-  private validateAllMigrations(): void {
-    for (const conceptName in this.migrations) {
-      this.validateConceptMigrations(conceptName, this.migrations[conceptName])
-    }
-  }
-
-  private validateConceptMigrations(conceptName: string, migrations: Map<number, MigrationMetadata>): void {
-    // Check that migrations are defined consecutively. In other words, there are no gaps between the version numbers
-    const currentVersion = this.currentVersionFor(conceptName)
-    for (let toVersion = 2; toVersion <= currentVersion; toVersion++) {
-      if (!migrations.has(toVersion)) {
-        throw new Error(
-          `Migrations for '${conceptName}' are invalid: they are missing a migration with toVersion=${toVersion}. ` +
-            `There must be a migration for '${conceptName}' for every version in the range [2..${currentVersion}]`
-        )
-      }
-    }
   }
 }
 

--- a/packages/framework-types/src/index.ts
+++ b/packages/framework-types/src/index.ts
@@ -1,6 +1,6 @@
 export * from './provider'
 export * from './envelope'
-export * from './config'
+export * from './booster-config'
 export * from './concepts'
 export * from './typelevel'
 export * from './logger'

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -8,7 +8,7 @@ import {
   GraphQLRequestEnvelopeError,
   ScheduledCommandEnvelope,
 } from './envelope'
-import { BoosterConfig } from './config'
+import { BoosterConfig } from './booster-config'
 import { Logger } from './logger'
 import { ReadModelInterface, UUID } from './concepts'
 import { FilterFor } from './searcher'

--- a/packages/framework-types/test/config.test.ts
+++ b/packages/framework-types/test/config.test.ts
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as fc from 'fast-check'
-import { BoosterConfig } from '../src'
+import { BoosterConfig, ProviderLibrary } from '../src'
 import { expect } from './expect'
 import { MigrationMetadata } from '../src/concepts'
-import { ProviderLibrary } from '../src'
 
 describe('the config type', () => {
   describe('resourceNames', () => {
@@ -94,32 +93,6 @@ describe('the config type', () => {
       config.migrations['concept'] = migrations
 
       expect(config.currentVersionFor('concept')).to.be.equal(3)
-    })
-  })
-
-  describe('validate', () => {
-    it('throws when there are gaps in the migration versions for a concept', () => {
-      const config = new BoosterConfig('test')
-      config.provider = {} as ProviderLibrary
-      const migrations = new Map()
-      migrations.set(3, {} as any)
-      migrations.set(2, {} as any)
-      migrations.set(5, {} as any)
-      config.migrations['concept'] = migrations
-
-      expect(() => config.validate()).to.throw(/Migrations for 'concept' are invalid/)
-    })
-
-    it('does not throw when there are no gaps in the migration versions for a concept', () => {
-      const config = new BoosterConfig('test')
-      config.provider = {} as ProviderLibrary
-      const migrations = new Map()
-      migrations.set(4, {} as any)
-      migrations.set(2, {} as any)
-      migrations.set(3, {} as any)
-      config.migrations['concept'] = migrations
-
-      expect(() => config.validate()).to.not.throw()
     })
   })
 


### PR DESCRIPTION
## Description

Following up with the changes in PR #612 and the plan described in #610, this PR moves the validation of `BoosterConfig` objects to a separate class in the core package.

The final goal of #612 is transforming `BoosterConfig` into a plain interface built of other interfaces and serializable types to fully decouple the type inference processes from the deployment process.

## Changes
- [x] Removed the core package from cli's dependencies
- [x] Moved the methods related to config validation to the core package
- [x] Fixed the tests

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
 
# Aditional information

This PR depends on the changes made in PR #612, so it shouldn't be merged in `main` until that PR is merged.