### PR TITLE
Fix/631 deleteAllSubscriptions pagination

### DIFF
--- a/packages/framework-integration-tests/integration/providers/aws/functionality/events.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/aws/functionality/events.integration.ts
@@ -81,7 +81,7 @@ describe('events', async () => {
     expect(response?.data?.ChangeMultipleCartItems).to.be.true
 
     // Verify number of events
-    const expectedEventItemsCount = eventsCount + 1
+    const expectedEventItemsCount = eventsCount + eventsToCreate
     await waitForIt(
       () => countEventItems(),
       (newEventsCount) => {
@@ -100,8 +100,7 @@ describe('events', async () => {
       expect(event.entityTypeName_entityID_kind).to.be.equal(`Cart-${mockCartId}-event`)
       const productIdNumber = parseInt(event.value.productId)
       expect(productIdNumber).to.be.gte(0)
-      expect(productIdNumber).to.be.lessThan(eventsCount)
-      expect(productIdNumber).to.be.lessThan(eventsCount)
+      expect(productIdNumber).to.be.lessThan(eventsToCreate)
       expect(event.value.cartId).to.be.equal(mockCartId)
       expect(event.value.quantity).to.be.equal(1)
       expect(event.kind).to.be.equal('event')

--- a/packages/framework-provider-aws/src/constants.ts
+++ b/packages/framework-provider-aws/src/constants.ts
@@ -25,3 +25,4 @@ export const environmentVarNames = {
 } as const
 
 export const dynamoDbBatchWriteLimit = 25
+export const dynamoDbBatchGetLimit = 100

--- a/packages/framework-provider-aws/src/library/keys-helper.ts
+++ b/packages/framework-provider-aws/src/library/keys-helper.ts
@@ -1,0 +1,32 @@
+import { EventEnvelope, UUID } from '@boostercloud/framework-types'
+
+export function partitionKeyForEvent(
+  entityTypeName: string,
+  entityID: UUID,
+  kind: EventEnvelope['kind'] = 'event'
+): string {
+  return `${entityTypeName}-${entityID}-${kind}`
+}
+
+const sortingKeyEncodingSeparator = '__'
+
+export function encodeEventStoreSortingKey(decodedSortingKey: string): string {
+  return `${decodedSortingKey}${sortingKeyEncodingSeparator}${UUID.generate()}`
+}
+export function decodeEventStoreSortingKey(encodedSortingKey: string): string {
+  return encodedSortingKey.split(sortingKeyEncodingSeparator)[0]
+}
+
+export function modifyEventsDecodingSortingKeys(...events: Array<EventEnvelope>): void {
+  for (const event of events) {
+    event.createdAt = decodeEventStoreSortingKey(event.createdAt)
+  }
+}
+
+export function partitionKeyForIndexByEntity(entityTypeName: string, kind: EventEnvelope['kind']): string {
+  return `${entityTypeName}-${kind}`
+}
+
+export function sortKeyForSubscription(connectionID: string, subscriptionID: string): string {
+  return `${connectionID}-${subscriptionID}`
+}

--- a/packages/framework-provider-aws/src/pagination-helpers.ts
+++ b/packages/framework-provider-aws/src/pagination-helpers.ts
@@ -1,14 +1,4 @@
 /**
- * Waits for `milliseconds`, calls `callback`, and returns the value
- * @param callback callback to return the value from
- * @param milliseconds milliseconds to wait before calling the callback
- */
-export const waitAndReturn = <TResult>(callback: () => TResult, milliseconds: number): Promise<TResult> =>
-  new Promise((resolve) => {
-    setTimeout(() => resolve(callback()), milliseconds)
-  })
-
-/**
  * Splits an array in an array of chunks
  * @param chunkSize size of the chunks to split it
  * @param array array to split in chunks


### PR DESCRIPTION
## Description

Made deleting of subscriptions behave accordingly to DynamoDB limits. Also removed some `sleeps`

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] ~Updated documentation accordingly~ (No need to)
 
## Additional information

Closes #631 