### PR TITLE
added await for resource deployed into Kubernetes checking method. 

### DIFF
--- a/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/k8s-sdk/k8s-management.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/k8s-sdk/k8s-management.ts
@@ -216,7 +216,7 @@ export class K8sManagement {
       spec.metadata.annotations = spec.metadata.annotations || {}
       delete spec.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration']
       spec.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'] = JSON.stringify(spec)
-      const resourceExists = this.existsResourceSpec(spec)
+      const resourceExists = await this.existsResourceSpec(spec)
       let response: { body: KubernetesObject; response: IncomingMessage }
       if (resourceExists) {
         response = await client.replace(spec)


### PR DESCRIPTION
## Description
Added an `await` when checking against the Kubernetes cluster that a resource is already deployed. 
## Changes
added an `await` 🤷🏼 
## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly (not necessary)
 
## Additional information
