### PR TITLE
fix(azure): Azure cosmosDB error at deployment

### DIFF
--- a/packages/framework-core/test/helpers/promises.test.ts
+++ b/packages/framework-core/test/helpers/promises.test.ts
@@ -31,13 +31,13 @@ describe('the `Promises` helpers', () => {
       let successfulPromise2Finished = false
       const promises = [
         Promise.reject(rejectedReason),
-        new Promise((resolve) =>
+        new Promise<void>((resolve) =>
           setTimeout(() => {
             successfulPromise1Finished = true
             resolve()
           }, 100)
         ),
-        new Promise((resolve) =>
+        new Promise<void>((resolve) =>
           setTimeout(() => {
             successfulPromise2Finished = true
             resolve()

--- a/packages/framework-provider-azure/src/index.ts
+++ b/packages/framework-provider-azure/src/index.ts
@@ -68,10 +68,8 @@ export const Provider = (): ProviderLibrary => ({
     rawToEnvelope: undefined as any,
   },
   // ProviderInfrastructureGetter
-  infrastructure: () => {
-    console.log('puf')
-    return require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure
-  },
+  infrastructure: () =>
+    require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure,
 })
 
 function notImplemented(): void {}

--- a/packages/framework-provider-azure/src/index.ts
+++ b/packages/framework-provider-azure/src/index.ts
@@ -13,10 +13,12 @@ import { environmentVarNames } from './constants'
 import { fetchReadModel, storeReadModel } from './library/read-model-adapter'
 import { searchReadModel } from './library/searcher-adapter'
 
+let cosmosClient: CosmosClient
 if (typeof process.env[environmentVarNames.cosmosDbConnectionString] === 'undefined') {
-  throw new Error('No Cosmos DB connection string has been found')
+  cosmosClient = {} as any
+} else {
+  cosmosClient = new CosmosClient(process.env[environmentVarNames.cosmosDbConnectionString] as string)
 }
-const cosmosClient = new CosmosClient(process.env[environmentVarNames.cosmosDbConnectionString] as string)
 
 export const Provider = (): ProviderLibrary => ({
   // ProviderEventsLibrary
@@ -66,8 +68,10 @@ export const Provider = (): ProviderLibrary => ({
     rawToEnvelope: undefined as any,
   },
   // ProviderInfrastructureGetter
-  infrastructure: () =>
-    require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure,
+  infrastructure: () => {
+    console.log('puf')
+    return require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure
+  },
 })
 
 function notImplemented(): void {}


### PR DESCRIPTION
## Description

This fixes an error that doesn't allow deployments to Azure.

## Changes

It sets the `cosmosClient` to `{}` when the `cosmosDbConnectionString` environment variable doesn't exist because it's only supposed to exist at runtime.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~- [ ] Updated documentation accordingly~ Not necessary
 
## Additional information

Azure deployments are working now! 🚀