### PR TITLE
fix to allows service to get the ip from hostname

### DIFF
--- a/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/k8s-sdk/k8s-management.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/k8s-sdk/k8s-management.ts
@@ -42,11 +42,12 @@ export class K8sManagement {
   public async getAllServicesInNamespace(namespace: string): Promise<Array<Service>> {
     const response = await this.unwrapResponse(this.k8sClient.listNamespacedService(namespace))
     return response.items.map((item) => {
+
       return {
         name: item.metadata?.name,
         namespace: item.metadata?.namespace ?? 'default',
         labels: item.metadata?.labels ?? {},
-        ip: item.status?.loadBalancer?.ingress?.[0]?.ip ?? '',
+        ip: item.status?.loadBalancer?.ingress?.[0]?.ip ?? item.status?.loadBalancer?.ingress?.[0]?.hostname ?? '',
       }
     })
   }


### PR DESCRIPTION
## Description
In order to make the Kubernetes provider compatible with AWS EKS, we discovered that the services IP is provided using an AWS url rather than an IP. This IP is provided in a field called `hostname` under the ingress configuration. Previously we were using the property `ip` because Google Cloud clusters provide the service IP in this property. 

## Changes
In this PR we are simply adding the support to get the service URL from the hostname in case that the IP field is empty

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly (Not necessary)
 
## Additional information
