### PR TITLE
Fix azure provider infra

### DIFF
--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/arm-templates/cosmos-db-account.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/arm-templates/cosmos-db-account.ts
@@ -46,7 +46,7 @@ export const template = {
         ipRangeFilter: '',
         dependsOn: [],
         capabilities: [],
-        enableFreeTier: true,
+        enableFreeTier: false,
       },
       resources: [
         {

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/index.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/index.ts
@@ -8,11 +8,9 @@ import {
   createWebSiteManagementClient,
 } from './setup'
 
-export const deploy = (configuration: BoosterConfig, logger: Logger): Promise<void> =>
-  deployApp(logger, configuration).catch(logger.error)
+export const deploy = (configuration: BoosterConfig, logger: Logger): Promise<void> => deployApp(logger, configuration)
 
-export const nuke = (configuration: BoosterConfig, logger: Logger): Promise<void> =>
-  nukeApp(logger, configuration).catch(logger.error)
+export const nuke = (configuration: BoosterConfig, logger: Logger): Promise<void> => nukeApp(logger, configuration)
 
 /**
  * Deploys the application in Azure

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/utils.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/utils.ts
@@ -45,13 +45,13 @@ export async function buildResource(
 }
 
 export async function packageAzureFunction(functionDefinitions: Array<FunctionDefinition>): Promise<any> {
-  const output = fs.createWriteStream(path.join(os.tmpdir(), 'example.zip'))
+  const output = fs.createWriteStream(path.join(os.tmpdir(), 'functionApp.zip'))
   const archive = archiver('zip', {
     zlib: { level: 9 }, // Sets the compression level.
   })
 
   archive.pipe(output)
-  archive.glob('**/*')
+  archive.directory('.deploy', false)
   functionDefinitions.forEach((functionDefinition: FunctionDefinition) => {
     archive.append(JSON.stringify(functionDefinition.config, null, 2), {
       name: functionDefinition.name + '/function.json',


### PR DESCRIPTION
## Description

It fixes some issues when trying to deploy a serverless Booster app into Azure.

## Changes

- The deployment zip file just contains the `.deploy/` directory content instead of all the root folder, so it's more than 10 times lighter. This avoids an issue where sometimes the upload was failing.

- Removed catch from the `deployApp` and `nukeApp` functions because it was not throwing the errors, so it was not possible to know when there was an issue.

- Disable CosmosDB free tier flag to be able to deploy several apps.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~- [ ] Updated documentation accordingly~ Not necessary
 
## Additional information

Azure Serverless deployments are working and allow performing GraphQL queries and mutations. 🚀