### PR TITLE
refactor searcher-adapter to use the new filters

### DIFF
--- a/packages/framework-provider-aws/test/library/read-models-searcher-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/read-models-searcher-adapter.test.ts
@@ -188,7 +188,7 @@ describe('Read models searcher adapter', () => {
       expect(database.scan).to.have.been.calledWithExactly(expectedInput)
     })
 
-    it('Thorw an error with non supported filters', async () => {
+    it('Throws an error with non supported filters', async () => {
       const unknownOperator = 'existsIn'
       const filters: FilterFor<any> = {
         id: { [unknownOperator]: 'test' },

--- a/packages/framework-provider-azure/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-azure/src/library/searcher-adapter.ts
@@ -8,8 +8,9 @@ export async function searchReadModel(
   readModelName: string,
   filters: FilterFor<unknown>
 ): Promise<Array<any>> {
+  const filterExpression = buildFilterExpression(filters)
   const querySpec: SqlQuerySpec = {
-    query: `SELECT * FROM c ${buildFilterExpression(filters)}`,
+    query: `SELECT * FROM c ${filterExpression !== '' ? `WHERE ${filterExpression}` : filterExpression}`,
     parameters: buildExpressionAttributeValues(filters),
   }
   logger.debug('Running search with the following params: \n', querySpec)
@@ -25,18 +26,26 @@ export async function searchReadModel(
   return resources ?? []
 }
 
-function buildFilterExpression(filters: FilterFor<any>): string {
-  const filterExpression = Object.entries(filters)
-    .map(([propName, filter]) => buildOperation(propName, filter))
+function buildFilterExpression(filters: FilterFor<any>, usedPlaceholders: Array<string> = []): string {
+  return Object.entries(filters)
+    .map(([propName, filter]) => {
+      switch (propName) {
+        case 'not':
+          return `NOT (${buildFilterExpression(filter as FilterFor<any>, usedPlaceholders)})`
+        case 'and':
+        case 'or':
+          return `(${(filter as Array<FilterFor<any>>)
+            .map((arrayFilter) => buildFilterExpression(arrayFilter, usedPlaceholders))
+            .join(` ${propName} `)})`
+        default:
+          return buildOperation(propName, filter, usedPlaceholders)
+      }
+    })
     .join(' AND ')
-  if (filterExpression !== '') {
-    return `WHERE ${filterExpression}`
-  }
-  return filterExpression
 }
 
-function buildOperation(propName: string, filter: Operation<any> = {}): string {
-  const holder = placeholderBuilderFor(propName)
+function buildOperation(propName: string, filter: Operation<any> = {}, usedPlaceholders: Array<string>): string {
+  const holder = placeholderBuilderFor(propName, usedPlaceholders)
   return Object.entries(filter)
     .map(([operation, value], index) => {
       switch (operation) {
@@ -58,31 +67,85 @@ function buildOperation(propName: string, filter: Operation<any> = {}): string {
             .join(',')})`
         case 'contains':
           return `CONTAINS(c["${propName}"], ${holder(index)})`
-        case 'begins-with':
+        case 'beginsWith':
           return `STARTSWITH(c["${propName}"], ${holder(index)})`
+        case 'includes':
+          return `CONTAINS(c["${propName}"], ${holder(index)})`
         default:
+          if (typeof value === 'object') {
+            return `c["${propName}"].${buildOperation(operation, value, usedPlaceholders)}`
+          }
           throw new InvalidParameterError(`Operator "${operation}" is not supported`)
       }
     })
     .join(' AND ')
 }
 
-function placeholderBuilderFor(propName: string): (valueIndex: number, valueSubIndex?: number) => string {
-  return (valueIndex: number, valueSubIndex?: number) =>
-    `@${propName}_${valueIndex}` + (typeof valueSubIndex === 'number' ? `_${valueSubIndex}` : '')
+function placeholderBuilderFor(
+  propName: string,
+  usedPlaceholders: Array<string>
+): (valueIndex: number, valueSubIndex?: number) => string {
+  return (valueIndex: number, valueSubIndex?: number) => {
+    const placeholder = `@${propName}_${valueIndex}` + (typeof valueSubIndex === 'number' ? `_${valueSubIndex}` : '')
+    if (usedPlaceholders.includes(placeholder)) return placeholderBuilderFor(propName, usedPlaceholders)(valueIndex + 1)
+    usedPlaceholders.push(placeholder)
+    return placeholder
+  }
 }
 
-function buildExpressionAttributeValues(filters: FilterFor<any>): Array<SqlParameter> {
-  const attributeValues: Array<SqlParameter> = []
+function buildExpressionAttributeValues(
+  filters: FilterFor<any>,
+  usedPlaceholders: Array<string> = []
+): Array<SqlParameter> {
+  let attributeValues: Array<SqlParameter> = []
   Object.entries(filters).forEach(([propName]) => {
-    const filter = filters[propName]
-    const holder = placeholderBuilderFor(propName)
-    Object.values(filter as any).forEach((value, index) => {
+    switch (propName) {
+      case 'not':
+        attributeValues = [
+          ...attributeValues,
+          ...buildExpressionAttributeValues(filters[propName] as FilterFor<any>, usedPlaceholders),
+        ]
+        break
+      case 'and':
+      case 'or':
+        for (const filter of filters[propName] as Array<FilterFor<any>>) {
+          attributeValues = [
+            ...attributeValues,
+            ...buildExpressionAttributeValues(filter as FilterFor<any>, usedPlaceholders),
+          ]
+        }
+        break
+      default:
+        attributeValues = [...attributeValues, ...buildAttributeValue(propName, filters[propName], usedPlaceholders)]
+        break
+    }
+  })
+  return attributeValues
+}
+
+function buildAttributeValue(
+  propName: string,
+  filter: Operation<any> = {},
+  usedPlaceholders: Array<string>
+): Array<SqlParameter> {
+  let attributeValues: Array<SqlParameter> = []
+  const holder = placeholderBuilderFor(propName, usedPlaceholders)
+  Object.entries(filter).forEach(([key, value], index) => {
+    if (Array.isArray(value)) {
+      value.forEach((element, subIndex) => {
+        attributeValues.push({
+          name: holder(index, subIndex),
+          value: element,
+        })
+      })
+    } else if (typeof value === 'object' && key !== 'includes') {
+      attributeValues = [...attributeValues, ...buildExpressionAttributeValues({ [key]: value }, usedPlaceholders)]
+    } else {
       attributeValues.push({
         name: holder(index),
         value: value as {},
       })
-    })
+    }
   })
   return attributeValues
 }

--- a/packages/framework-provider-azure/test/library/searcher-adapter.test.ts
+++ b/packages/framework-provider-azure/test/library/searcher-adapter.test.ts
@@ -3,7 +3,7 @@ import { expect } from '../expect'
 import { searchReadModel } from '../../src/library/searcher-adapter'
 import { createStubInstance, fake, match, restore, stub, SinonStubbedInstance } from 'sinon'
 import { CosmosClient } from '@azure/cosmos'
-import { BoosterConfig, FilterOld, Logger } from '@boostercloud/framework-types'
+import { BoosterConfig, FilterFor, Logger } from '@boostercloud/framework-types'
 import { random } from 'faker'
 
 describe('Searcher adapter', () => {
@@ -14,6 +14,25 @@ describe('Searcher adapter', () => {
     let mockReadModelName: string
 
     let mockCosmosDbClient: SinonStubbedInstance<CosmosClient>
+    class Money {
+      constructor(public cents: number, public currency: string) {}
+    }
+
+    class Item {
+      constructor(public sku: string, public price: Money) {}
+    }
+
+    class Product {
+      constructor(
+        readonly id: string,
+        readonly stock: number,
+        public mainItem: Item,
+        public items: Array<Item>,
+        public buyers: Array<string>,
+        public days: Array<number>,
+        public pairs: Array<Array<number>>
+      ) {}
+    }
 
     beforeEach(() => {
       mockConfig = new BoosterConfig('test')
@@ -60,10 +79,9 @@ describe('Searcher adapter', () => {
     })
 
     it('Executes a SQL query with filters in the read model table', async () => {
-      const filters: Record<string, FilterOld<any>> = {
-        propertyA: { operation: '=', values: [1] },
-        propertyB: { operation: '!=', values: ['a'] },
-        propertyC: { operation: 'between', values: [1, 100] },
+      const filters: FilterFor<Product> = {
+        id: { eq: '3', in: ['test1', 'test2', 'test3'] },
+        stock: { gt: 0, lte: 10 },
       }
 
       await searchReadModel(mockCosmosDbClient as any, mockConfig, mockLogger, mockReadModelName, filters)
@@ -79,37 +97,73 @@ describe('Searcher adapter', () => {
       ).to.have.been.calledWith(
         match({
           query:
-            'SELECT * FROM c WHERE c["propertyA"] = @propertyA_0 ' +
-            'AND c["propertyB"] <> @propertyB_0 ' +
-            'AND c["propertyC"] BETWEEN @propertyC_0 AND @propertyC_1',
+            'SELECT * FROM c WHERE ' +
+            'c["id"] = @id_0 AND c["id"] IN (@id_1_0,@id_1_1,@id_1_2) AND ' +
+            'c["stock"] > @stock_0 AND c["stock"] <= @stock_1',
           parameters: [
             {
-              name: '@propertyA_0',
-              value: 1,
+              name: '@id_0',
+              value: '3',
             },
             {
-              name: '@propertyB_0',
-              value: 'a',
+              name: '@id_1_0',
+              value: 'test1',
             },
             {
-              name: '@propertyC_0',
-              value: 1,
+              name: '@id_1_1',
+              value: 'test2',
             },
             {
-              name: '@propertyC_1',
-              value: 100,
+              name: '@id_1_2',
+              value: 'test3',
+            },
+            {
+              name: '@stock_0',
+              value: 0,
+            },
+            {
+              name: '@stock_1',
+              value: 10,
             },
           ],
         })
       )
     })
 
-    it('Supports comparison operators', async () => {
-      const filters: Record<string, FilterOld<any>> = {
-        propertyA: { operation: '<', values: [100] },
-        propertyB: { operation: '>', values: [0] },
-        propertyC: { operation: '>=', values: [0] },
-        propertyD: { operation: '<=', values: [100] },
+    it('Supports NOT filter combinator', async () => {
+      const filters: FilterFor<Product> = {
+        id: { contains: '3' },
+        not: { id: { eq: '333' } },
+      }
+
+      await searchReadModel(mockCosmosDbClient as any, mockConfig, mockLogger, mockReadModelName, filters)
+
+      expect(
+        mockCosmosDbClient
+          .database(mockConfig.resourceNames.applicationStack)
+          .container(`${mockConfig.resourceNames.applicationStack}-${mockReadModelName}`).items.query
+      ).to.have.been.calledWith(
+        match({
+          query: 'SELECT * FROM c WHERE CONTAINS(c["id"], @id_0) AND NOT (c["id"] = @id_1)',
+          parameters: [
+            {
+              name: '@id_0',
+              value: '3',
+            },
+            {
+              name: '@id_1',
+              value: '333',
+            },
+          ],
+        })
+      )
+    })
+
+    it('Supports AND & OR filter combinators', async () => {
+      const filters: FilterFor<Product> = {
+        id: { ne: 'test' },
+        or: [{ id: { beginsWith: '1' } }, { id: { beginsWith: '2' } }],
+        and: [{ id: { contains: '3' } }, { id: { contains: '4' } }],
       }
 
       await searchReadModel(mockCosmosDbClient as any, mockConfig, mockLogger, mockReadModelName, filters)
@@ -121,38 +175,43 @@ describe('Searcher adapter', () => {
       ).to.have.been.calledWith(
         match({
           query:
-            'SELECT * FROM c WHERE c["propertyA"] < @propertyA_0 ' +
-            'AND c["propertyB"] > @propertyB_0 ' +
-            'AND c["propertyC"] >= @propertyC_0 ' +
-            'AND c["propertyD"] <= @propertyD_0',
+            'SELECT * FROM c WHERE c["id"] <> @id_0 ' +
+            'AND (STARTSWITH(c["id"], @id_1) or STARTSWITH(c["id"], @id_2)) ' +
+            'AND (CONTAINS(c["id"], @id_3) and CONTAINS(c["id"], @id_4))',
           parameters: [
             {
-              name: '@propertyA_0',
-              value: 100,
+              name: '@id_0',
+              value: 'test',
             },
             {
-              name: '@propertyB_0',
-              value: 0,
+              name: '@id_1',
+              value: '1',
             },
             {
-              name: '@propertyC_0',
-              value: 0,
+              name: '@id_2',
+              value: '2',
             },
             {
-              name: '@propertyD_0',
-              value: 100,
+              name: '@id_3',
+              value: '3',
+            },
+            {
+              name: '@id_4',
+              value: '4',
             },
           ],
         })
       )
     })
 
-    it('Supports other operators', async () => {
-      const filters: Record<string, FilterOld<any>> = {
-        propertyA: { operation: 'in', values: [1, 2] },
-        propertyB: { operation: 'contains', values: ['a'] },
-        propertyC: { operation: 'not-contains', values: ['x'] },
-        propertyD: { operation: 'begins-with', values: ['a'] },
+    it('Supports nested properties filters', async () => {
+      const filters: FilterFor<Product> = {
+        mainItem: {
+          sku: { eq: 'test' },
+          price: {
+            cents: { gte: 1000, lt: 100000 },
+          },
+        },
       }
 
       await searchReadModel(mockCosmosDbClient as any, mockConfig, mockLogger, mockReadModelName, filters)
@@ -164,34 +223,65 @@ describe('Searcher adapter', () => {
       ).to.have.been.calledWith(
         match({
           query:
-            'SELECT * FROM c WHERE c["propertyA"] IN (@propertyA_0,@propertyA_1) ' +
-            'AND CONTAINS(c["propertyB"], @propertyB_0) ' +
-            'AND NOT CONTAINS(c["propertyC"], @propertyC_0) ' +
-            'AND STARTSWITH(c["propertyD"], @propertyD_0)',
+            'SELECT * FROM c WHERE c["mainItem"].c["sku"] = @sku_0 ' +
+            'AND c["mainItem"].c["price"].c["cents"] >= @cents_0 AND c["cents"] < @cents_1',
           parameters: [
             {
-              name: '@propertyA_0',
-              value: 1,
+              name: '@sku_0',
+              value: 'test',
             },
             {
-              name: '@propertyA_1',
+              name: '@cents_0',
+              value: 1000,
+            },
+            {
+              name: '@cents_1',
+              value: 100000,
+            },
+          ],
+        })
+      )
+    })
+
+    it('Supports array includes filter', async () => {
+      const filters: FilterFor<Product> = {
+        days: { includes: 2 },
+        items: { includes: { sku: 'test', price: { cents: 1000, currency: 'EUR' } } },
+      }
+
+      await searchReadModel(mockCosmosDbClient as any, mockConfig, mockLogger, mockReadModelName, filters)
+
+      expect(
+        mockCosmosDbClient
+          .database(mockConfig.resourceNames.applicationStack)
+          .container(`${mockConfig.resourceNames.applicationStack}-${mockReadModelName}`).items.query
+      ).to.have.been.calledWith(
+        match({
+          query: 'SELECT * FROM c WHERE CONTAINS(c["days"], @days_0) AND CONTAINS(c["items"], @items_0)',
+          parameters: [
+            {
+              name: '@days_0',
               value: 2,
             },
             {
-              name: '@propertyB_0',
-              value: 'a',
-            },
-            {
-              name: '@propertyC_0',
-              value: 'x',
-            },
-            {
-              name: '@propertyD_0',
-              value: 'a',
+              name: '@items_0',
+              value: { sku: 'test', price: { cents: 1000, currency: 'EUR' } },
             },
           ],
         })
       )
+    })
+
+    it('Throws an error with non supported filters', async () => {
+      const unknownOperator = 'existsIn'
+      const filters: FilterFor<any> = {
+        id: { [unknownOperator]: 'test' },
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      expect(
+        searchReadModel(mockCosmosDbClient as any, mockConfig, mockLogger, mockReadModelName, filters)
+      ).to.be.eventually.rejectedWith(`Operator "${unknownOperator}" is not supported`)
     })
   })
 })


### PR DESCRIPTION
## Description

Refactor to make Azure search filters compatible with the new version.

## Changes
Refactor to Azure provider `searcher-adapter.ts` file.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~- [ ] Updated documentation accordingly~ not necessary
 
## Additional information

~This just makes it compatible with the simple filters, the complex filters, Arrays filters, and the filter combinators like `and`, `or` and `not` are still pending. So it doesn't finish Azure at #601 yet.~ **I ended up adding them so the PR has support for all the filters.**