### PR TITLE
Change name "Booster.fetchEntitySnapshot" by "Booster.entity"

### DIFF
--- a/packages/framework-core/src/booster.ts
+++ b/packages/framework-core/src/booster.ts
@@ -106,14 +106,22 @@ export class Booster {
 
   /**
    * Fetches the last known version of an entity
-   * @param entityName Name of the entity class
+   * @param entityClass Name of the entity class
    * @param entityID
    */
-  public static fetchEntitySnapshot<TEntity extends EntityInterface>(
+  public static entity<TEntity extends EntityInterface>(
     entityClass: Class<TEntity>,
     entityID: UUID
   ): Promise<TEntity | undefined> {
     return fetchEntitySnapshot(this.config, this.logger, entityClass, entityID)
+  }
+
+  /** @deprecated Use method "entity" instead */
+  public static fetchEntitySnapshot<TEntity extends EntityInterface>(
+    entityClass: Class<TEntity>,
+    entityID: UUID
+  ): Promise<TEntity | undefined> {
+    return this.entity(entityClass, entityID)
   }
 }
 


### PR DESCRIPTION
The new name is consistent with `Booster.readModel` and easier to understand, specially when showing code to others