### PR TITLE
Remove all needle's timeout to 0

### DIFF
--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/utils.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/utils.ts
@@ -88,6 +88,10 @@ export async function deployFunctionPackage(
   password: string,
   functionAppName: string
 ): Promise<any> {
+  needle.defaults({
+    open_timeout: 0,
+  })
+
   return needle(
     'post',
     `https://${functionAppName}.scm.azurewebsites.net/api/zipDeploy`,


### PR DESCRIPTION
needle (the node http client we are using) has 3 different timeouts

- `open_timeout`: (or timeout) Returns error if connection takes longer than X milisecs to establish. Defaults to 10000 (10 secs). 0 means no timeout.
- `response_timeout`: Returns error if no response headers are received in X milisecs, counting from when the connection is opened. Defaults to 0 (no response timeout).
- `read_timeout`: Returns error if data transfer takes longer than X milisecs, once response headers are received. Defaults to 0 (no timeout).

As we can see by default `response_timeout` and `read_timeout` default values mean there is no timeout. That is not the case for `open_timeout` which has a default value of 10 seconds. 

I strongly suspect this was the issue when zip deployment the very few times it failed (the times were the API was not down of course which did happen last week) 

Let's change it to 0 so we don't have any kind of timeouts.  