### PR TITLE
FIX _ redis key separator bug for ids with _

### DIFF
--- a/packages/framework-provider-kubernetes/src/services/event-registry.ts
+++ b/packages/framework-provider-kubernetes/src/services/event-registry.ts
@@ -71,6 +71,6 @@ export class EventRegistry {
       event.createdAt, // timespan
       UUID.generate(), // hash to make key unique
     ]
-    return keyParts.join('_')
+    return keyParts.join(RedisAdapter.keySeparator)
   }
 }

--- a/packages/framework-provider-kubernetes/src/services/read-model-registry.ts
+++ b/packages/framework-provider-kubernetes/src/services/read-model-registry.ts
@@ -48,7 +48,7 @@ export class ReadModelRegistry {
         return []
       }
     } else {
-      const keys = await this.redis.keys(`rm_${readModelName}_*`, logger)
+      const keys = await this.redis.keys(['rm',readModelName,'*'].join(RedisAdapter.keySeparator), logger)
       l(`Obtainer following keys for query: ${keys}`)
       const results: ReadModelInterface[] = []
       await Promise.all(
@@ -86,6 +86,6 @@ export class ReadModelRegistry {
       typeName, //readModel type name
       id, //readModel id
     ]
-    return keyParts.join('_')
+    return keyParts.join(RedisAdapter.keySeparator)
   }
 }

--- a/packages/framework-provider-kubernetes/src/services/redis-adapter.ts
+++ b/packages/framework-provider-kubernetes/src/services/redis-adapter.ts
@@ -3,6 +3,8 @@ import fetch from 'node-fetch'
 import * as redis from 'redis'
 
 export class RedisAdapter {
+  public static keySeparator: string = '_____'
+
   private _client?: redis.RedisClient
   constructor(readonly daprUrl: string, readonly redisUrl: string) {}
 
@@ -65,4 +67,5 @@ export class RedisAdapter {
     logger.debug(response)
     logger.debug('END RedisAdapter setViaRedis')
   }
+
 }


### PR DESCRIPTION
## Description
fixes the bug that occur when user uses _ on IDs

## Changes
- Use a more appropriate separator for Redis keys

## Checks
- [x] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
 
## Additional information
