### PR TITLE
add searcher-adapter for redis db

### DIFF
--- a/packages/framework-provider-kubernetes/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-kubernetes/src/library/searcher-adapter.ts
@@ -1,0 +1,79 @@
+import { RedisAdapter } from './../services/redis-adapter'
+import {
+  BoosterConfig,
+  Logger,
+  InvalidParameterError,
+  FilterFor,
+  Operation,
+  ReadModelEnvelope,
+} from '@boostercloud/framework-types'
+
+export async function searchReadModel(
+  redis: RedisAdapter,
+  config: BoosterConfig,
+  logger: Logger,
+  readModelName: string,
+  filters: FilterFor<unknown>
+): Promise<Array<any>> {
+  logger.debug('Running search with the following filters: \n', filters)
+
+  const keys = await redis.keys(`rm_${readModelName}_*`, logger)
+  logger.debug(`Obtainer following keys for query: ${keys}`)
+  const results: Array<unknown> = []
+  await Promise.all(
+    keys.map(async (k: any) => {
+      const data = await redis.hget<ReadModelEnvelope>(k)
+      if (data?.value) {
+        results.push(data.value)
+      }
+    })
+  )
+  logger.debug(`Got ${results} envelopes, returning`)
+  if (!Object.keys(filters).length) return results
+
+  const [filtered] = filterResults(results, filters)
+  return filtered
+}
+
+function filterResults(results: Array<unknown>, filters: FilterFor<unknown> = {}): Array<any> {
+  return Object.entries(filters).map(([propName, filter]) => {
+    if (['and', 'or', 'not'].includes(propName)) {
+      throw new Error('Filter combinators not yet supported')
+    } else {
+      return filterByOperation(propName, results, filter)
+    }
+  })
+}
+
+function filterByOperation(propName: string, input: Array<any>, filter: Operation<any>): Array<unknown> {
+  const [res] = Object.entries(filter).map(([operation, value]) => {
+    switch (operation) {
+      case 'eq':
+        return input.filter((obj) => obj[propName] === value)
+      case 'ne':
+        return input.filter((obj) => obj[propName] !== value)
+      case 'lt':
+        return input.filter((obj) => obj[propName] < value)
+      case 'gt':
+        return input.filter((obj) => obj[propName] > value)
+      case 'gte':
+        return input.filter((obj) => obj[propName] >= value)
+      case 'lte':
+        return input.filter((obj) => obj[propName] <= value)
+      case 'in':
+        return input.filter((obj) => (value as Array<any>).includes(obj[propName]))
+      case 'contains':
+        return input.filter((obj) => (obj[propName] as string).includes(value))
+      case 'beginsWith':
+        return input.filter((obj) => (obj[propName] as string).startsWith(value))
+      case 'includes':
+        return input.filter((obj) => (obj[propName] as Array<any>).includes(value))
+      default:
+        if (typeof value === 'object') {
+          throw new InvalidParameterError('Complex properties operators not yet supported on K8s')
+        }
+        throw new InvalidParameterError(`Operator "${operation}" is not supported`)
+    }
+  })
+  return res
+}

--- a/packages/framework-provider-kubernetes/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-kubernetes/src/library/searcher-adapter.ts
@@ -17,11 +17,11 @@ export async function searchReadModel(
 ): Promise<Array<any>> {
   logger.debug('Running search with the following filters: \n', filters)
 
-  const keys = await redis.keys(`rm_${readModelName}_*`, logger)
+  const keys = await redis.keys(['rm', readModelName, '*'].join(RedisAdapter.keySeparator), logger)
   logger.debug(`Obtainer following keys for query: ${keys}`)
   const results: Array<unknown> = []
   await Promise.all(
-    keys.map(async (k: any) => {
+    keys.map(async (k: string) => {
       const data = await redis.hget<ReadModelEnvelope>(k)
       if (data?.value) {
         results.push(data.value)


### PR DESCRIPTION
## Description

Adds a ReadModel searcher-adapter which enables filtering queries on Redis.

## Changes

Added the searcher adapter file instead of using a function.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~- [ ] Updated documentation accordingly~ Not necessary
 
## Additional information

Complex filters are not yet supported.