### PR TITLE
added configuration for deploy in multiple clusters

### DIFF
--- a/packages/framework-provider-kubernetes-infrastructure/src/index.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/index.ts
@@ -1,5 +1,5 @@
-import { deploy, nuke } from './infrastructure'
-
+import { deploy, nuke, BoosterK8sConfiguration } from './infrastructure'
+export { BoosterK8sConfiguration }
 export const Infrastructure = {
   deploy,
   nuke,

--- a/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/k8s-sdk/k8s-management.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/k8s-sdk/k8s-management.ts
@@ -338,6 +338,10 @@ export class K8sManagement {
     }
   }
 
+  public async setClusterContext(context: string): Promise<void> {
+    await this.execRawCommand(`config use-context ${context}`)
+  }
+
   /**
    * exec a raw kubectl command in your cluster, the user only need to write the command without the `kubectl`
    * for example: `kubectl apply -f file.yaml` will be `execRawCommand('apply -f file.yaml')`


### PR DESCRIPTION
The configuration for deploy in multiple clusters is the following:

 
![Screenshot 2021-03-23 at 23 53 04](https://user-images.githubusercontent.com/5313797/112233891-32e4ac80-8c33-11eb-944c-075de7f8ba2d.png)


Before moving from one cluster to another we need to delete de component folder, to avoid the bug that we have with non-existing eventstore
