### PR TITLE
doc: Fix img url in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ The packages are published to `npm` under the prefix `@boostercloud/`, their pur
   - etc…
 
 This is a dependency graph that shows the dependencies among all packages, including the application using Booster:
-![Booster packages dependencies](docs/img/packages-dependencies.png)
+![Booster packages dependencies](https://raw.githubusercontent.com/boostercloud/booster/main/docs/img/packages-dependencies.png)
 
 # How Can I Contribute?
 


### PR DESCRIPTION
## Description
Currently, an image from CONTRIBUTING.md is not displayed on the new documentation website.

## Changes
 Fix img url in CONTRIBUTING.md

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
 