### PR TITLE
Increase AWS limits to avoid errors on high load

### DIFF
--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/params.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/params.ts
@@ -21,7 +21,7 @@ export function lambda(
 ): Pick<FunctionProps, 'runtime' | 'timeout' | 'memorySize' | 'environment'> {
   return {
     runtime: Runtime.NODEJS_12_X,
-    timeout: Duration.minutes(1),
+    timeout: Duration.minutes(10),
     memorySize: 1024,
     environment: {
       BOOSTER_ENV: config.environmentName,
@@ -43,10 +43,11 @@ export function baseURLForAPI(
   return `${protocol}://${apiID}.execute-api.${stack.region}.${stack.urlSuffix}/${config.environmentName}/`
 }
 
-export function stream(): Pick<DynamoEventSourceProps, 'startingPosition' | 'batchSize'> {
+export function stream(): DynamoEventSourceProps {
   return {
     startingPosition: StartingPosition.TRIM_HORIZON,
-    batchSize: 100,
+    batchSize: 1000,
+    parallelizationFactor: 10,
   }
 }
 

--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/params.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/params.ts
@@ -21,7 +21,7 @@ export function lambda(
 ): Pick<FunctionProps, 'runtime' | 'timeout' | 'memorySize' | 'environment'> {
   return {
     runtime: Runtime.NODEJS_12_X,
-    timeout: Duration.minutes(10),
+    timeout: Duration.minutes(15),
     memorySize: 1024,
     environment: {
       BOOSTER_ENV: config.environmentName,


### PR DESCRIPTION
## Description
Thes changes avoid timeouts (and, thus, losing events) and increments the speed at which events are processed


## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~- [ ] Updated documentation accordingly~
 
