### PR TITLE
changes in k8s provider

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -37,6 +37,7 @@ export default class Deploy extends BaseCommand {
     const { flags } = this.parse(Deploy)
 
     if (initializeEnvironment(logger, flags.environment)) {
+      logger.info('Preparing the deploy 📦')
       const deploymentProjectPath = await createDeploymentSandbox()
       await runTasks(compileProjectAndLoadConfig(deploymentProjectPath), deployToCloudProvider)
     }

--- a/packages/framework-provider-kubernetes-infrastructure/src/helpers/logger.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/helpers/logger.ts
@@ -1,9 +1,21 @@
-import { Logger } from '@boostercloud/framework-types'
+import { Level, Logger } from '@boostercloud/framework-types'
 
-export const scopeLogger = (scope: string, logger: Logger): Logger => {
+export const scopeLogger = (scope: string, logger: Logger, level = Level.info): Logger => {
   const newLogger: Logger = { ...logger }
-  newLogger.debug = (...args: any[]) => logger.debug([`[${scope}]`, ...args].join(' '))
-  newLogger.info = (...args: any[]) => logger.info([`[${scope}]`, ...args].join(' '))
-  newLogger.error = (...args: any[]) => logger.error([`[${scope}]`, ...args].join(' '))
+  newLogger.debug = (...args: any[]) => {
+    if (level <= Level.debug) {
+      logger.debug([`[${scope}]`, ...args].join(' '))
+    }
+  }
+  newLogger.info = (...args: any[]) => {
+    if (level <= Level.info) {
+      logger.info([`[${scope}]`, ...args].join(' '))
+    }
+  }
+  newLogger.error = (...args: any[]) => {
+    if (level <= Level.error) {
+      logger.error([`[${scope}]`, ...args].join(' '))
+    }
+  }
   return newLogger
 }

--- a/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/utils.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/utils.ts
@@ -59,7 +59,7 @@ export async function createProjectZipFile(logger: Logger): Promise<string> {
   const archive = archiver('zip', { zlib: { level: 9 } })
   l.debug('Putting contents into zip file')
   archive.pipe(output)
-  archive.glob('**/*')
+  archive.directory('.deploy', false)
   await archive.finalize()
   return new Promise((resolve, reject) => {
     output.on('close', () => {

--- a/packages/framework-provider-kubernetes-infrastructure/test/infrastructure/deploy-manager.test.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/test/infrastructure/deploy-manager.test.ts
@@ -150,7 +150,8 @@ describe('User interaction during the deploy:', async () => {
   })
 
   it('allows verifying that the upload code works', async () => {
-    stub(k8sManager, 'waitForServiceToBeReady').resolves()
+    stub(k8sManager, 'waitForServiceToBeReady').resolves({ ip: 'http://ip_mock.com' })
+    replace(utils, 'waitForIt', fake.resolves(200))
     replace(utils, 'uploadFile', fake.resolves({ statusCode: 200 }))
     replace(utils, 'createProjectZipFile', fake.resolves('path'))
     await expect(deployManager.uploadUserCode()).to.eventually.be.fulfilled

--- a/packages/framework-provider-kubernetes/src/services/event-registry.ts
+++ b/packages/framework-provider-kubernetes/src/services/event-registry.ts
@@ -58,7 +58,7 @@ export class EventRegistry {
     if (result.length <= 0) {
       return null
     }
-    return result[0]
+    return result[result.length - 1]
   }
 
   private eventKey(event: EventEnvelope): string {


### PR DESCRIPTION
## Description
Some minor fixes for the K8s provider.

## Changes
- Fix get the latest snapshot to get the latest snapshot instead of the first (k8s provider)
- add a method to check that a service is already available pinging the public url to check that it is returning a 200 (k8s provider)
- defaulted the logger to info instead of debug to reduce the amount of info during the deployment (k8s provider)
- added a info message when we start to create the `.deploy` folder during the deploy (cli package)

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly (these changes don't affect documentation)

