### PR TITLE
Reduce DynamoDB timeout

### DIFF
--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -32,7 +32,12 @@ import {
 } from './library/connections-adapter'
 import { rawScheduledInputToEnvelope } from './library/scheduled-adapter'
 
-const dynamoDB: DynamoDB.DocumentClient = new DynamoDB.DocumentClient()
+const dynamoDB: DynamoDB.DocumentClient = new DynamoDB.DocumentClient({
+  maxRetries: 10,
+  httpOptions: {
+    timeout: 5000,
+  },
+})
 const userPool = new CognitoIdentityServiceProvider()
 
 interface HasInfrastructure {


### PR DESCRIPTION
## Description
The current timeout is 2 minutes which is too long and was causing some calls to take minutes to finish just because there was a socket error. Now, with a shorter timeout, the calls made with a socket in a bad state are retried much faster and the changes to succeed are higher within a shorter period of time

<details>
<summary>Click for more details about this issue</summary>
After a lot of investigation, we were seeing that simple DynamoDB calls (it doesn’t matter if it was “query”, “get” or “put”) were taking like 4 or 5 minutes to succeed. That was the root of the problem.
_But why did those take that long time??_

The AWS SDK has a built-in retry mechanism. When you do a DynamoDB call, for example, it will automatically redo the request if it gets an error that’s considered “retriable” (like a temporary network error). It keeps doing retries with an “exponential back-off algorithm”, meaning that it will wait  50ms before doing the first retry. If it fails again, it will wait twice that time, 100ms. If it fails again, it will wait 200ms, then 400ms, then 800ms, then 1,6 seconds, etc.

- “So that’s is the problem!!!” I thought
- “Nein, nein, nein!!!” the facts replied to me

It turned out that only 10 retries are attempted by default, and that’s 51 seconds in total. 
_Where did the rest of the time came from?_

**To the point:** Some DynamoDB calls (the 0,0001%) were done with an HTTP socket in a bad state (because these things happen randomly) and the request never reached DynamoDB. The socket timeout was 2 minutes, so the call is stuck that amount of time before returning an error (socket timeout error).

This means that in order for the first retry to occur, we needed to wait 2 minutes. Then, it could be that the second retry also finds the socket in a bad state (it is being reused by thousands of requests), so we wait 2 more minutes.

**This explains why a simple DynamoDB call occasionally took 4 or 5 minutes.**

### SOLUTION
Surprisingly, the solution was just to **reduce the timeout** to, for example, 5 seconds, instead of 2 minutes. This way we fail much earlier, the AWS SDK can do the next retry (with a new socket connection) sooner, and the chances to succeed are much higher.

### LESSONS LEARNED
a) _Networking things can fail randomly for no apparent reasons_. Even if there are no bugs, just because of network conditions.
b) _Timeouts are extremely important_. Any request should have a timeout. If not, it can get stuck because of point a) above and there is no way to stop it.
c) _Retries are a must in any request_. Due to points a) and b) you need to have a retry policy. Not having it is simply a bug, because any network request is expected to fail for no apparent reason. If you don’t have a retry policy, it is similar to having a switch in code with no default and you missed a case condition
d) Load tests are the most useful thing to find those kinds of errors you never think of.
</details>
