### PR TITLE
Fecony/fix/620 fix resource name generation

### DIFF
--- a/packages/cli/src/common/filenames.ts
+++ b/packages/cli/src/common/filenames.ts
@@ -3,3 +3,7 @@ import * as inflected from 'inflected'
 export function classNameToFileName(name: string): string {
   return inflected.dasherize(inflected.underscore(name))
 }
+
+export function resourceNameToClassName(name: string): string {
+  return inflected.classify(inflected.underscore(inflected.parameterize(inflected.tableize(name))))
+}

--- a/packages/cli/src/services/generator.ts
+++ b/packages/cli/src/services/generator.ts
@@ -2,12 +2,12 @@ import * as path from 'path'
 import * as fs from 'fs-extra'
 import * as Mustache from 'mustache'
 import { Target, FileDir } from './generator/target'
-import { classNameToFileName } from '../common/filenames'
+import { classNameToFileName, resourceNameToClassName } from '../common/filenames'
 import { checkResourceExists } from './project-checker'
 
 export async function generate<TInfo>(target: Target<TInfo>): Promise<void> {
   await checkResourceExists(target.name, target.placementDir, target.extension)
-  const rendered = Mustache.render(target.template, target.info)
+  const rendered = Mustache.render(target.template, { ...target.info, name: resourceNameToClassName(target.name) })
   const renderPath = filePath<TInfo>(target)
   await fs.outputFile(renderPath, rendered)
 }

--- a/packages/cli/test/common/filenames.test.ts
+++ b/packages/cli/test/common/filenames.test.ts
@@ -1,0 +1,40 @@
+import { classNameToFileName, resourceNameToClassName } from '../../src/common/filenames'
+import { expect } from '../expect'
+
+describe('filenames', () => {
+  describe('resourceNameToClassName', () => {
+    it('creates correct class name', () => {
+      const generatedClassName = resourceNameToClassName('testResource')
+      expect(generatedClassName).to.equal('TestResource')
+    })
+
+    describe('generates correct class name when passed with invalid characters', () => {
+      it('resource name with space characters', () => {
+        const generatedClassName = resourceNameToClassName('test resource name')
+        expect(generatedClassName).to.equal('TestResourceName')
+      })
+
+      it('resource name with underline character', () => {
+        const generatedClassName = resourceNameToClassName('test_resource_name')
+        expect(generatedClassName).to.equal('TestResourceName')
+      })
+
+      it('resource name with dash character', () => {
+        const generatedClassName = resourceNameToClassName('test-resource-name')
+        expect(generatedClassName).to.equal('TestResourceName')
+      })
+    })
+  })
+
+  describe('classNameToFileName', () => {
+    it('transforms passed resource name to correct file name', () => {
+      const generatedClassName = classNameToFileName('testResource')
+      expect(generatedClassName).to.equal('test-resource')
+    })
+
+    it('transforms PascalCased resource name to correct file name', () => {
+      const generatedClassName = classNameToFileName('TestResource')
+      expect(generatedClassName).to.equal('test-resource')
+    })
+  })
+})

--- a/packages/cli/test/services/generator.test.ts
+++ b/packages/cli/test/services/generator.test.ts
@@ -7,163 +7,184 @@ import { generate } from '../../src/services/generator'
 import { templates } from '../../src/templates'
 import { restore, replace, fake } from 'sinon'
 import { expect } from '../expect'
+import { resourceNameToClassName } from '../../src/common/filenames'
 
 describe('generate service', (): void => {
+  beforeEach(() => {
+    replace(fs, 'outputFile', fake.resolves({}))
+    replace(projectChecker, 'checkResourceExists', fake.resolves({}))
+  })
 
-    beforeEach(() => {
-        replace(fs, 'outputFile', fake.resolves({}))
-        replace(projectChecker, 'checkResourceExists', fake.resolves({}))
-    })
+  afterEach(() => {
+    restore()
+  })
 
-    afterEach(() => {
-        restore()
-    })
+  it('generates file for a command', async () => {
+    type CommandInfo = HasName & HasFields
+    const info: CommandInfo = {
+      name: 'new-command',
+      fields: [
+        { name: 'name', type: 'string' },
+        { name: 'description', type: 'string' },
+      ],
+    }
 
-    it('generates file for a command', async () => {
-        type CommandInfo = HasName & HasFields
-        const info: CommandInfo = {
-            name: 'new-command',
-            fields: [{name: 'name', type: 'string'},{name: 'description', type: 'string'}]
-        }
-        const target: Target<CommandInfo> = {
-            name: info.name,
-            extension: '.ts',
-            placementDir: path.join('src', 'commands'),
-            template: templates.command,
-            info: info
-        }
-        const rendered = Mustache.render(target.template, target.info)
+    const target: Target<CommandInfo> = {
+      name: info.name,
+      extension: '.ts',
+      placementDir: path.join('src', 'commands'),
+      template: templates.command,
+      info: info,
+    }
+    const rendered = Mustache.render(target.template, { ...target.info, name: resourceNameToClassName(target.name) })
 
-        await generate(target)
+    await generate(target)
 
-        expect(fs.outputFile).to.have.been.calledWithMatch('src/commands/new-command.ts', rendered)
-        expect(projectChecker.checkResourceExists).to.have.been.called
-    })
+    expect(fs.outputFile).to.have.been.calledWithMatch('src/commands/new-command.ts', rendered)
+    expect(projectChecker.checkResourceExists).to.have.been.called
+  })
 
-    it('generates file for an entity', async () => {
-        type EntityInfo = HasName & HasFields & HasReaction
-        const info: EntityInfo = {
-            name: 'new-entity',
-            fields: [{name: 'name', type: 'string'},{name: 'description', type: 'string'}],
-            events: [{eventName: 'product-purchased'}]
-        }
-        const target: Target<EntityInfo> = {
-            name: info.name,
-            extension: '.ts',
-            placementDir: path.join('src', 'entities'),
-            template: templates.entity,
-            info: info
-        }
-        const rendered = Mustache.render(target.template, target.info)
+  it('generates file for an entity', async () => {
+    type EntityInfo = HasName & HasFields & HasReaction
+    const info: EntityInfo = {
+      name: 'new-entity',
+      fields: [
+        { name: 'name', type: 'string' },
+        { name: 'description', type: 'string' },
+      ],
+      events: [{ eventName: 'product-purchased' }],
+    }
+    const target: Target<EntityInfo> = {
+      name: info.name,
+      extension: '.ts',
+      placementDir: path.join('src', 'entities'),
+      template: templates.entity,
+      info: info,
+    }
+    const rendered = Mustache.render(target.template, { ...target.info, name: resourceNameToClassName(target.name) })
 
-        await generate(target)
+    await generate(target)
 
-        expect(fs.outputFile).to.have.been.calledWithMatch('src/entities/new-entity.ts',rendered)
-        expect(projectChecker.checkResourceExists).to.have.been.called
-    })
+    expect(fs.outputFile).to.have.been.calledWithMatch('src/entities/new-entity.ts', rendered)
+    expect(projectChecker.checkResourceExists).to.have.been.called
+  })
 
-    it('generates file for an event handler', async () => {
-        type EventHandlerInfo = HasName & HasEvent
-        const info: EventHandlerInfo = {
-            name: 'new-event-handler',
-            event: 'product-purchased'
-        }
-        const target: Target<EventHandlerInfo> = {
-            name: info.name,
-            extension: '.ts',
-            placementDir: path.join('src', 'event-handlers'),
-            template: templates.eventHandler,
-            info: info
-        }
-        const rendered = Mustache.render(target.template, target.info)
+  it('generates file for an event handler', async () => {
+    type EventHandlerInfo = HasName & HasEvent
+    const info: EventHandlerInfo = {
+      name: 'new-event-handler',
+      event: 'product-purchased',
+    }
 
-        await generate(target)
+    const target: Target<EventHandlerInfo> = {
+      name: info.name,
+      extension: '.ts',
+      placementDir: path.join('src', 'event-handlers'),
+      template: templates.eventHandler,
+      info: info,
+    }
+    const rendered = Mustache.render(target.template, { ...target.info, name: resourceNameToClassName(target.name) })
 
-        expect(fs.outputFile).to.have.been.calledWithMatch('src/event-handlers/new-event-handler.ts',rendered)
-        expect(projectChecker.checkResourceExists).to.have.been.called
-    })
+    await generate(target)
 
-    it('generates file for an event', async () => {
-        type EventInfo = HasName & HasFields
-        const info: EventInfo = {
-            name: 'new-event',
-            fields: [{name: 'name', type: 'string'},{name: 'description', type: 'string'}]
-        }
-        const target: Target<EventInfo> = {
-            name: info.name,
-            extension: '.ts',
-            placementDir: path.join('src', 'events'),
-            template: templates.event,
-            info: info
-        }
-        const rendered = Mustache.render(target.template, target.info)
+    expect(fs.outputFile).to.have.been.calledWithMatch('src/event-handlers/new-event-handler.ts', rendered)
+    expect(projectChecker.checkResourceExists).to.have.been.called
+  })
 
-        await generate(target)
+  it('generates file for an event', async () => {
+    type EventInfo = HasName & HasFields
+    const info: EventInfo = {
+      name: 'new-event',
+      fields: [
+        { name: 'name', type: 'string' },
+        { name: 'description', type: 'string' },
+      ],
+    }
 
-        expect(fs.outputFile).to.have.been.calledWithMatch('src/events/new-event.ts',rendered)
-        expect(projectChecker.checkResourceExists).to.have.been.called
-    })
+    const target: Target<EventInfo> = {
+      name: info.name,
+      extension: '.ts',
+      placementDir: path.join('src', 'events'),
+      template: templates.event,
+      info: info,
+    }
+    const rendered = Mustache.render(target.template, { ...target.info, name: resourceNameToClassName(target.name) })
 
-    it('generates file for a read model', async () => {
-        type ReadModelInfo = HasName & HasFields & HasProjections
-        const info: ReadModelInfo = {
-            name: 'new-read-model',
-            fields: [{name: 'name', type: 'string'},{name: 'description', type: 'string'}],
-            projections: [{entityName: 'account', entityId: 'id'}]
-        }
-        const target: Target<ReadModelInfo> = {
-            name: info.name,
-            extension: '.ts',
-            placementDir: path.join('src', 'read-models'),
-            template: templates.readModel,
-            info: info
-        }
-        const rendered = Mustache.render(target.template, target.info)
+    await generate(target)
 
-        await generate(target)
+    expect(fs.outputFile).to.have.been.calledWithMatch('src/events/new-event.ts', rendered)
+    expect(projectChecker.checkResourceExists).to.have.been.called
+  })
 
-        expect(fs.outputFile).to.have.been.calledWithMatch('src/read-models/new-read-model.ts',rendered)
-        expect(projectChecker.checkResourceExists).to.have.been.called
-    })
+  it('generates file for a read model', async () => {
+    type ReadModelInfo = HasName & HasFields & HasProjections
+    const info: ReadModelInfo = {
+      name: 'new-read-model',
+      fields: [
+        { name: 'name', type: 'string' },
+        { name: 'description', type: 'string' },
+      ],
+      projections: [{ entityName: 'account', entityId: 'id' }],
+    }
 
-    it('generates file for a scheduled command', async () => {
-        type ScheduledCommandInfo = HasName
-        const info: ScheduledCommandInfo = {
-            name: 'new-scheduled-command'
-        }
-        const target: Target<ScheduledCommandInfo> = {
-            name: info.name,
-            extension: '.ts',
-            placementDir: path.join('src', 'scheduled-commands'),
-            template: templates.scheduledCommand,
-            info: info
-        }
-        const rendered = Mustache.render(target.template, target.info)
+    const target: Target<ReadModelInfo> = {
+      name: info.name,
+      extension: '.ts',
+      placementDir: path.join('src', 'read-models'),
+      template: templates.readModel,
+      info: info,
+    }
+    const rendered = Mustache.render(target.template, { ...target.info, name: resourceNameToClassName(target.name) })
 
-        await generate(target)
+    await generate(target)
 
-        expect(fs.outputFile).to.have.been.calledWithMatch('src/scheduled-commands/new-scheduled-command.ts',rendered)
-        expect(projectChecker.checkResourceExists).to.have.been.called
-    })
+    expect(fs.outputFile).to.have.been.calledWithMatch('src/read-models/new-read-model.ts', rendered)
+    expect(projectChecker.checkResourceExists).to.have.been.called
+  })
 
-    it('generates file for a type', async () => {
-        type TypeInfo = HasName & HasFields
-        const info: TypeInfo = {
-            name: 'new-type',
-            fields: [{name: 'name', type: 'string'},{name: 'description', type: 'string'}],
-        }
-        const target: Target<TypeInfo> = {
-            name: info.name,
-            extension: '.ts',
-            placementDir: path.join('src', 'common'),
-            template: templates.type,
-            info: info
-        }
-        const rendered = Mustache.render(target.template, target.info)
+  it('generates file for a scheduled command', async () => {
+    type ScheduledCommandInfo = HasName
+    const info: ScheduledCommandInfo = {
+      name: 'new-scheduled-command',
+    }
 
-        await generate(target)
+    const target: Target<ScheduledCommandInfo> = {
+      name: info.name,
+      extension: '.ts',
+      placementDir: path.join('src', 'scheduled-commands'),
+      template: templates.scheduledCommand,
+      info: info,
+    }
+    const rendered = Mustache.render(target.template, { ...target.info, name: resourceNameToClassName(target.name) })
 
-        expect(fs.outputFile).to.have.been.calledWithMatch('src/common/new-type.ts',rendered)
-        expect(projectChecker.checkResourceExists).to.have.been.called
-    })
+    await generate(target)
+
+    expect(fs.outputFile).to.have.been.calledWithMatch('src/scheduled-commands/new-scheduled-command.ts', rendered)
+    expect(projectChecker.checkResourceExists).to.have.been.called
+  })
+
+  it('generates file for a type', async () => {
+    type TypeInfo = HasName & HasFields
+    const info: TypeInfo = {
+      name: 'new-type',
+      fields: [
+        { name: 'name', type: 'string' },
+        { name: 'description', type: 'string' },
+      ],
+    }
+
+    const target: Target<TypeInfo> = {
+      name: info.name,
+      extension: '.ts',
+      placementDir: path.join('src', 'common'),
+      template: templates.type,
+      info: info,
+    }
+    const rendered = Mustache.render(target.template, { ...target.info, name: resourceNameToClassName(target.name) })
+
+    await generate(target)
+
+    expect(fs.outputFile).to.have.been.calledWithMatch('src/common/new-type.ts', rendered)
+    expect(projectChecker.checkResourceExists).to.have.been.called
+  })
 })


### PR DESCRIPTION
## Description
PR to add a contribution from the community https://github.com/boostercloud/booster/pull/660

## Changes
- Add method resourceNameToClassName() to generate class name from passed resource name.
- Add few tests for resourceNameToClassName() and classNameToFileName() functions in filenames.ts
- Adjust generator test.
- Formatting in generator test was fixed.

## Checks
- [x ] Project Builds
- [x ] Project passes tests and checks
- [x ] Updated documentation accordingly
 
## Additional information
