### PR TITLE
Fix: Add Auth env vars

### DIFF
--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -127,7 +127,14 @@ export class BoosterConfig {
   }
 
   public get tokenVerifier(): TokenVerifier | undefined {
-    return this._tokenVerifier
+    if (this._tokenVerifier) return this._tokenVerifier
+    if (process.env[JWT_ENV_VARS.BOOSTER_JWT_ISSUER] && process.env[JWT_ENV_VARS.BOOSTER_JWKS_URI]) {
+      return {
+        issuer: process.env[JWT_ENV_VARS.BOOSTER_JWT_ISSUER] as string,
+        jwksUri: process.env[JWT_ENV_VARS.BOOSTER_JWKS_URI] as string,
+      }
+    }
+    return undefined
   }
 
   public set tokenVerifier(tokenVerifier: TokenVerifier | undefined) {
@@ -152,6 +159,11 @@ export class BoosterConfig {
       }
     }
   }
+}
+
+export const JWT_ENV_VARS = {
+  BOOSTER_JWT_ISSUER: 'BOOSTER_JWT_ISSUER',
+  BOOSTER_JWKS_URI: 'BOOSTER_JWKS_URI',
 }
 
 interface ResourceNames {


### PR DESCRIPTION
## Description

Quick fix to restore auth env vars, they're needed for rockets which modify internally the tokenVerifier object.