### PR TITLE
Fixed related with the K8s provider

### DIFF
--- a/packages/framework-integration-tests/integration/providers/kubernetes/constants.ts
+++ b/packages/framework-integration-tests/integration/providers/kubernetes/constants.ts
@@ -1,3 +1,15 @@
 export const sandboxProjectName = 'kubernetes-project'
 export const kubernetesNamespace = 'booster-my-store-kubernetes'
-export const boosterKubernetesServices = ['booster', 'fileuploader']
+export const boosterKubernetesServices = [
+  'booster',
+  'booster-dapr',
+  'dapr-api',
+  'dapr-dashboard',
+  'dapr-placement',
+  'dapr-sentry',
+  'dapr-sidecar-injector',
+  'fileuploader',
+  'redis-headless',
+  'redis-master',
+  'redis-replicas',
+]

--- a/packages/framework-integration-tests/integration/providers/kubernetes/constants.ts
+++ b/packages/framework-integration-tests/integration/providers/kubernetes/constants.ts
@@ -1,15 +1,3 @@
 export const sandboxProjectName = 'kubernetes-project'
 export const kubernetesNamespace = 'booster-my-store-kubernetes'
-export const boosterKubernetesServices = [
-  'booster',
-  'booster-dapr',
-  'dapr-api',
-  'dapr-dashboard',
-  'dapr-placement',
-  'dapr-sentry',
-  'dapr-sidecar-injector',
-  'fileuploader',
-  'redis-headless',
-  'redis-master',
-  'redis-replicas',
-]
+export const boosterKubernetesServices = ['booster', 'fileuploader']

--- a/packages/framework-integration-tests/integration/providers/kubernetes/deployment/deployment.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/kubernetes/deployment/deployment.integration.ts
@@ -26,6 +26,6 @@ describe('Kubernetes provider', () => {
       return item?.metadata?.name
     })
 
-    expect(serviceNames).to.deep.contains(boosterKubernetesServices)
+    expect(serviceNames).to.include.members(boosterKubernetesServices)
   })
 })

--- a/packages/framework-integration-tests/integration/providers/kubernetes/deployment/deployment.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/kubernetes/deployment/deployment.integration.ts
@@ -26,6 +26,6 @@ describe('Kubernetes provider', () => {
       return item?.metadata?.name
     })
 
-    expect(serviceNames).to.contains(boosterKubernetesServices)
+    expect(serviceNames).to.deep.contains(boosterKubernetesServices)
   })
 })

--- a/packages/framework-integration-tests/integration/providers/kubernetes/deployment/deployment.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/kubernetes/deployment/deployment.integration.ts
@@ -26,6 +26,6 @@ describe('Kubernetes provider', () => {
       return item?.metadata?.name
     })
 
-    expect(boosterKubernetesServices).to.contains(serviceNames)
+    expect(serviceNames).to.contains(boosterKubernetesServices)
   })
 })

--- a/packages/framework-integration-tests/integration/providers/kubernetes/deployment/deployment.integration.ts
+++ b/packages/framework-integration-tests/integration/providers/kubernetes/deployment/deployment.integration.ts
@@ -13,7 +13,6 @@ describe('Kubernetes provider', () => {
     expect(services.body).not.to.be.undefined
 
     const serviceNames = services.body.items.map((item: Kubernetes.V1Service) => {
-
       expect(item.metadata?.namespace).to.equal(kubernetesNamespace)
 
       if (item?.metadata?.name === 'booster' || item?.metadata?.name === 'fileuploader') {
@@ -27,6 +26,6 @@ describe('Kubernetes provider', () => {
       return item?.metadata?.name
     })
 
-    expect(serviceNames).to.deep.equal(boosterKubernetesServices)
+    expect(boosterKubernetesServices).to.contains(serviceNames)
   })
 })

--- a/packages/framework-integration-tests/integration/providers/kubernetes/deployment/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/kubernetes/deployment/setup.ts
@@ -14,9 +14,6 @@ before(async () => {
   console.log('overriding Booster dependencies...')
   await overrideWithBoosterLocalDependencies(sandboxPath)
 
-  // This command is also ran during the deployment, but this provider takes dependencies from the root sandboxed directory.
-  // This is a bug that only happens on integration-tests, and this is a quick workaround to avoid editing the provider or the cli package.
-  await exec('npm install --production --no-bin-links', { cwd: sandboxPath })
   console.log(`starting kubernetes server in ${sandboxPath}...`)
   // start kubernetes
   await deploy(sandboxPath)

--- a/packages/framework-integration-tests/integration/providers/kubernetes/deployment/setup.ts
+++ b/packages/framework-integration-tests/integration/providers/kubernetes/deployment/setup.ts
@@ -4,7 +4,6 @@ import { sandboxProjectName } from '../constants'
 import { overrideWithBoosterLocalDependencies } from '../../../helper/deps-helper'
 import { sleep } from '../../../helper/sleep'
 import { deploy } from '../deploy'
-import { exec } from 'child-process-promise'
 
 before(async () => {
   console.log('preparing sandboxed project...')

--- a/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/deploy-manager.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/deploy-manager.ts
@@ -1,6 +1,6 @@
 import { K8sManagement } from './k8s-sdk/k8s-management'
 import { BoosterConfig, Logger } from '@boostercloud/framework-types'
-import { getProjectNamespaceName, createProjectZipFile, uploadFile } from './utils'
+import { getProjectNamespaceName, createProjectZipFile, uploadFile, waitForIt } from './utils'
 import { uploadService } from './templates/upload-service-template'
 import { boosterVolumeClaim } from './templates/volume-claim-template'
 import { boosterService } from './templates/booster-service-template'
@@ -10,7 +10,7 @@ import { boosterAppPod } from './templates/booster-app-template'
 import { HelmManager } from './helm-manager'
 import { DaprManager } from './dapr-manager'
 import { scopeLogger } from '../helpers/logger'
-
+import fetch from 'node-fetch'
 export class DeployManager {
   private clusterManager: K8sManagement
   private namespace: string
@@ -124,6 +124,7 @@ export class DeployManager {
       this.templateValues.serviceType = 'NodePort'
     }
   }
+
   /**
    * verify that the upload service is running and in a negative case it tries to create it
    */
@@ -167,15 +168,14 @@ export class DeployManager {
    */
   public async uploadUserCode(): Promise<void> {
     const l = scopeLogger('uploadUserCode', this.logger)
-    l.debug('Waiting for service to be ready')
+    l.debug('Waiting for Upload service to be ready')
     const fileUploadService = await this.clusterManager.waitForServiceToBeReady(this.namespace, uploadService.name)
     l.debug('Creating zip file')
     const codeZipFile = await createProjectZipFile(l)
+    l.debug('Waiting for Upload service to be accesible')
+    await this.waitForServiceToBeAvailable(fileUploadService?.ip)
     l.debug('Uploading file')
-    const fileUploadServiceAddress = fileUploadService?.port
-      ? `${fileUploadService?.ip}:${fileUploadService?.port}`
-      : fileUploadService?.ip
-    const fileUploadResponse = await uploadFile(l, fileUploadServiceAddress, codeZipFile)
+    const fileUploadResponse = await uploadFile(l, fileUploadService?.ip, codeZipFile)
     if (fileUploadResponse.statusCode !== 200) {
       l.debug('Cannot upload code, throwing')
       throw new Error('Unable to upload your code, please check the fileuploader pod for more information')
@@ -224,6 +224,30 @@ export class DeployManager {
    */
   public async deleteAllResources(): Promise<void> {
     await this.clusterManager.deleteNamespace(this.namespace)
+  }
+
+  private async waitForServiceToBeAvailable(url: string | undefined, timeout = 180000): Promise<void> {
+    const l = scopeLogger('waitForServiceToBeAvailable', this.logger)
+    if (!url) {
+      throw new Error('Service Url not valid')
+    }
+    await waitForIt(
+      () => {
+        l.debug('Getting service from namespace')
+        return fetch(`http://${url}`)
+          .then((response) => {
+            return response.status
+          })
+          .catch(() => {
+            return 0
+          })
+      },
+      (requestStatus) => {
+        return requestStatus === 200
+      },
+      'Unable to get the services in available status',
+      timeout
+    )
   }
 
   private async ensureServiceIsReady(template: Template): Promise<void> {

--- a/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/deploy-manager.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/deploy-manager.ts
@@ -172,10 +172,13 @@ export class DeployManager {
     const fileUploadService = await this.clusterManager.waitForServiceToBeReady(this.namespace, uploadService.name)
     l.debug('Creating zip file')
     const codeZipFile = await createProjectZipFile(l)
+    const fileUploadServiceAddress = fileUploadService?.port
+      ? `${fileUploadService?.ip}:${fileUploadService?.port}`
+      : fileUploadService?.ip
     l.debug('Waiting for Upload service to be accesible')
-    await this.waitForServiceToBeAvailable(fileUploadService?.ip)
+    await this.waitForServiceToBeAvailable(fileUploadServiceAddress)
     l.debug('Uploading file')
-    const fileUploadResponse = await uploadFile(l, fileUploadService?.ip, codeZipFile)
+    const fileUploadResponse = await uploadFile(l, fileUploadServiceAddress, codeZipFile)
     if (fileUploadResponse.statusCode !== 200) {
       l.debug('Cannot upload code, throwing')
       throw new Error('Unable to upload your code, please check the fileuploader pod for more information')

--- a/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/utils.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/src/infrastructure/utils.ts
@@ -59,7 +59,7 @@ export async function createProjectZipFile(logger: Logger): Promise<string> {
   const archive = archiver('zip', { zlib: { level: 9 } })
   l.debug('Putting contents into zip file')
   archive.pipe(output)
-  archive.glob('**/*')
+  archive.directory('.deploy', false)
   await archive.finalize()
   return new Promise((resolve, reject) => {
     output.on('close', () => {

--- a/packages/framework-provider-kubernetes-infrastructure/test/infrastructure/dapr-manager.test.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/test/infrastructure/dapr-manager.test.ts
@@ -6,6 +6,7 @@ import { stub, restore, replace, fake } from 'sinon'
 import { BoosterConfig, Logger } from '@boostercloud/framework-types'
 import { stateStore } from '../../src/infrastructure/templates/statestore'
 import { internet } from 'faker'
+import { CoreV1Api, KubeConfig, KubernetesObjectApi } from '@kubernetes/client-node'
 const fs = require('fs')
 
 describe('Users Dapr interaction inside the cluster', () => {
@@ -14,6 +15,9 @@ describe('Users Dapr interaction inside the cluster', () => {
     error: fake(),
     debug: fake(),
   }
+
+  replace(KubeConfig.prototype, 'makeApiClient', fake.returns(new CoreV1Api()))
+  replace(KubernetesObjectApi, 'makeApiClient', fake.returns(new KubernetesObjectApi()))
   const k8sManager = new K8sManagement(fakeLogger)
   const configuration = new BoosterConfig('test')
   const helmManager = new HelmManager(fakeLogger)

--- a/packages/framework-provider-kubernetes-infrastructure/test/infrastructure/deploy-manager.test.ts
+++ b/packages/framework-provider-kubernetes-infrastructure/test/infrastructure/deploy-manager.test.ts
@@ -150,7 +150,8 @@ describe('User interaction during the deploy:', async () => {
   })
 
   it('allows verifying that the upload code works', async () => {
-    stub(k8sManager, 'waitForServiceToBeReady').resolves()
+    stub(k8sManager, 'waitForServiceToBeReady').resolves({ ip: 'http://ip_mock.com' })
+    replace(utils, 'waitForIt', fake.resolves(200))
     replace(utils, 'uploadFile', fake.resolves({ statusCode: 200 }))
     replace(utils, 'createProjectZipFile', fake.resolves('path'))
     await expect(deployManager.uploadUserCode()).to.eventually.be.fulfilled

--- a/packages/framework-provider-kubernetes/src/services/event-registry.ts
+++ b/packages/framework-provider-kubernetes/src/services/event-registry.ts
@@ -58,7 +58,7 @@ export class EventRegistry {
     if (result.length <= 0) {
       return null
     }
-    return result[0]
+    return result[result.length - 1]
   }
 
   private eventKey(event: EventEnvelope): string {


### PR DESCRIPTION
## Description
Added a verification before trying to upload any code into the cluster because in AWS the services are DNS based and the domain takes some time to propagate (around 1 min) and the deployment was failing some times because of this. 

Also added a small fix because we were obtaining the first snapshot instead of the last snapshot when we were using the read models. 

## Changes
Changes in K8s provider

## Checks
- [x] Project Builds
- [x] Project passes tests and checks

