### PR TITLE
Switch interfaces to classes on new:type command

### DIFF
--- a/docs/chapters/04_features.md
+++ b/docs/chapters/04_features.md
@@ -178,8 +178,7 @@ The GraphQL API is fully **auto-generated** based on your _commands_ and _read m
 ```typescript
 // My type
 export class ItemWithFields {
-  sku: string
-  quantity: number
+  public constructor(sku: string, quantity: number) {}
 }
 ```
 

--- a/docs/chapters/04_features.md
+++ b/docs/chapters/04_features.md
@@ -174,6 +174,29 @@ Luckily, you can forget about that because Booster does all the work for you!
 
 The GraphQL API is fully **auto-generated** based on your _commands_ and _read models_.
 
+**Note:** The commands and read models attribute types should be classes instead of interfaces. This little change will allow you to perform complex graphQL filters. There's an example below:
+```typescript
+// My type
+export class ItemWithFields {
+  sku: string
+  quantity: number
+}
+```
+
+```typescript
+// My command (or read-model)
+import { ItemWithFields } from "./types";
+
+@Command({
+  authorize: 'all'// Specify authorized roles here. Use 'all' to authorize anyone
+})
+export class ChangeCart {
+  public constructor(readonly id: UUID, item: ItemWithFields) {
+  }
+
+  public static async handle(command: ChangeCart, register: Register): Promise<void> { ... }
+```
+
 ### Relationship between GraphQL operations and commands and read models
 
 GraphQL defines three kinds of operations that you can use: _mutations_, _queries_, and _subscriptions_.

--- a/docs/chapters/04_features.md
+++ b/docs/chapters/04_features.md
@@ -174,26 +174,25 @@ Luckily, you can forget about that because Booster does all the work for you!
 
 The GraphQL API is fully **auto-generated** based on your _commands_ and _read models_.
 
-**Note:** The commands and read models attribute types should be classes instead of interfaces. This little change will allow you to perform complex graphQL filters. There's an example below:
+**Note:** To get the full potential of the GraphQL API, it is recommended not to use `interface` types in any command or read model attributes. Use `class` types instead. This will allow you to perform complex graphQL filters, including over nested attributes. There's an example below:
 ```typescript
 // My type
-export class ItemWithFields {
+export class ItemWithQuantity { // Use "class", not "interface"
   public constructor(sku: string, quantity: number) {}
 }
 ```
 
 ```typescript
-// My command (or read-model)
-import { ItemWithFields } from "./types";
-
-@Command({
-  authorize: 'all'// Specify authorized roles here. Use 'all' to authorize anyone
+// The read-model file
+import { ItemWithQuantity } from "./types";
+@ReadModel({
+  authorize: 'all'
 })
-export class ChangeCart {
-  public constructor(readonly id: UUID, item: ItemWithFields) {
-  }
-
-  public static async handle(command: ChangeCart, register: Register): Promise<void> { ... }
+export class CartReadModel {
+  public constructor(
+          readonly id: UUID,
+          item: ItemWithQuantity // As ItemWithQuantity is a class, you will be able to query over nested attributes like item `quantity`
+  ) {}
 ```
 
 ### Relationship between GraphQL operations and commands and read models

--- a/packages/cli/src/templates/type.ts
+++ b/packages/cli/src/templates/type.ts
@@ -1,4 +1,4 @@
-export const template = `export interface {{{ name }}} {
+export const template = `export class {{{ name }}} {
   {{#fields}}
   {{{name}}}: {{{type}}}
   {{/fields}}

--- a/packages/cli/src/templates/type.ts
+++ b/packages/cli/src/templates/type.ts
@@ -1,6 +1,8 @@
 export const template = `export class {{{ name }}} {
-  {{#fields}}
-  {{{name}}}: {{{type}}}
-  {{/fields}}
+  public constructor(
+    {{#fields}}
+    public {{{name}}}: {{{type}}},
+    {{/fields}}
+  ) {}
 }
 `

--- a/packages/framework-integration-tests/integration/fixtures/common/item-with-fields.ts
+++ b/packages/framework-integration-tests/integration/fixtures/common/item-with-fields.ts
@@ -1,4 +1,6 @@
 export class ItemWithFields {
-  sku: string
-  quantity: number
+  public constructor(
+    public sku: string,
+    public quantity: number,
+  ) {}
 }

--- a/packages/framework-integration-tests/integration/fixtures/common/item-with-fields.ts
+++ b/packages/framework-integration-tests/integration/fixtures/common/item-with-fields.ts
@@ -1,4 +1,4 @@
-export interface ItemWithFields {
+export class ItemWithFields {
   sku: string
   quantity: number
 }

--- a/packages/framework-integration-tests/integration/fixtures/common/item.ts
+++ b/packages/framework-integration-tests/integration/fixtures/common/item.ts
@@ -1,2 +1,2 @@
-export interface Item {
+export class Item {
 }

--- a/packages/framework-integration-tests/integration/fixtures/common/item.ts
+++ b/packages/framework-integration-tests/integration/fixtures/common/item.ts
@@ -1,2 +1,4 @@
 export class Item {
+  public constructor(
+  ) {}
 }


### PR DESCRIPTION
## Description
Due to some limitations with the GraphQL API, the commands/read-models property types should be classes instead of interfaces.

## Changes
* Change `boost new:type` CLI command to generate a class instead of an interface
* Modified existing tests
* Added docs for this new limitation

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly
 