### PR TITLE
fix: add CLI flag

### DIFF
--- a/packages/cli/src/services/dependencies.ts
+++ b/packages/cli/src/services/dependencies.ts
@@ -3,7 +3,7 @@ import { wrapExecError } from '../common/errors'
 
 export async function installProductionDependencies(projectPath: string): Promise<void> {
   try {
-    await exec('npm install --production --no-bin-links', { cwd: projectPath })
+    await exec('npm install --production --no-bin-links --no-optional', { cwd: projectPath })
   } catch (e) {
     throw wrapExecError(e, 'Could not install production dependencies')
   }

--- a/packages/cli/test/services/dependencies.test.ts
+++ b/packages/cli/test/services/dependencies.test.ts
@@ -15,7 +15,7 @@ describe('dependencies service', () => {
 
       await expect(installProductionDependencies(path)).to.eventually.be.fulfilled
 
-      expect(childProcessPromise.exec).to.have.been.calledWithMatch('npm install --production --no-bin-links', {
+      expect(childProcessPromise.exec).to.have.been.calledWithMatch('npm install --production --no-bin-links --no-optional', {
         cwd: path,
       })
     })

--- a/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/cli/cli.project.integration.ts
@@ -307,7 +307,7 @@ describe('Project', () => {
           // Rewrite dependencies to use local versions
           await overrideWithBoosterLocalDependencies(fullProjectPath)
           // Install those dependencies
-          await exec('npm install --production --no-bin-links', { cwd: fullProjectPath })
+          await exec('npm install --production --no-bin-links --no-optional', { cwd: fullProjectPath })
 
           await expect(exec('npm run compile', { cwd: fullProjectPath })).to.be.eventually.fulfilled
         })


### PR DESCRIPTION
## Description
The CLI flag `--no-optional` was missing in this [PR](https://github.com/boostercloud/booster/pull/816) 

## Changes
Adding the `--no-optional` flag to the `npm install --production` command.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly
 
## Additional information
