### PR TITLE
Local provider GraphQL filters compatibility

### DIFF
--- a/packages/framework-provider-local/src/library/read-model-adapter.ts
+++ b/packages/framework-provider-local/src/library/read-model-adapter.ts
@@ -1,6 +1,6 @@
 import {
   BoosterConfig,
-  FilterOld,
+  FilterFor,
   Logger,
   ReadModelEnvelope,
   ReadModelInterface,
@@ -53,7 +53,7 @@ export async function searchReadModel(
   _config: BoosterConfig,
   logger: Logger,
   readModelName: string,
-  filters: Record<string, FilterOld<QueryValue>>
+  filters: Record<string, FilterFor<QueryValue>>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<Array<any>> {
   logger.info('Converting filter to query')

--- a/packages/framework-provider-local/src/library/read-model-adapter.ts
+++ b/packages/framework-provider-local/src/library/read-model-adapter.ts
@@ -7,7 +7,7 @@ import {
   UUID,
 } from '@boostercloud/framework-types'
 import { ReadModelRegistry } from '../services/read-model-registry'
-import { queryRecordFor, QueryValue } from './searcher-adapter'
+import { queryRecordFor } from './searcher-adapter'
 
 export async function rawReadModelEventsToEnvelopes(
   config: BoosterConfig,
@@ -53,7 +53,7 @@ export async function searchReadModel(
   _config: BoosterConfig,
   logger: Logger,
   readModelName: string,
-  filters: Record<string, FilterFor<QueryValue>>
+  filters: FilterFor<any>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<Array<any>> {
   logger.info('Converting filter to query')

--- a/packages/framework-provider-local/src/library/searcher-adapter.ts
+++ b/packages/framework-provider-local/src/library/searcher-adapter.ts
@@ -1,4 +1,4 @@
-import { FilterOld } from '@boostercloud/framework-types'
+import { FilterFor } from '@boostercloud/framework-types'
 
 /**
  * Creates a query record out of the read mode name and
@@ -7,7 +7,7 @@ import { FilterOld } from '@boostercloud/framework-types'
  */
 export function queryRecordFor(
   readModelName: string,
-  filters: Record<string, FilterOld<QueryValue>>
+  filters: Record<string, FilterFor<QueryValue>>
 ): Record<string, QueryOperation<QueryValue>> {
   const queryFromFilters: Record<string, object> = {}
   if (Object.keys(filters).length != 0) {
@@ -21,9 +21,13 @@ export function queryRecordFor(
 /**
  * Transforms a GraphQL Booster filter into an neDB query
  */
-function filterToQuery(filter: FilterOld<QueryValue>): QueryOperation<QueryValue> {
-  const query = queryOperatorTable[filter.operation]
-  return query(filter.values)
+function filterToQuery(filter: FilterFor<QueryValue>): QueryOperation<QueryValue> {
+  const [query] = Object.entries(filter).map(([propName, filter]) => {
+    const query = queryOperatorTable[propName]
+    const queryFilter = Array.isArray(filter) ? filter : [filter]
+    return query(queryFilter)
+  })
+  return query
 }
 
 export type QueryValue = number | string | boolean
@@ -51,17 +55,16 @@ type QueryOperation<TValue> =
  * of `=`, in which the operator is the value itself.
  */
 const queryOperatorTable: Record<string, (values: Array<QueryValue>) => QueryOperation<QueryValue>> = {
-  '=': (values) => values[0],
-  '!=': (values) => ({ $ne: values[0] }),
-  '<': (values) => ({ $lt: values[0] }),
-  '>': (values) => ({ $gt: values[0] }),
-  '<=': (values) => ({ $lte: values[0] }),
-  '>=': (values) => ({ $gte: values[0] }),
+  eq: (values) => values[0],
+  ne: (values) => ({ $ne: values[0] }),
+  lt: (values) => ({ $lt: values[0] }),
+  gt: (values) => ({ $gt: values[0] }),
+  lte: (values) => ({ $lte: values[0] }),
+  gte: (values) => ({ $gte: values[0] }),
   in: (values) => ({ $in: values }),
-  between: (values) => ({ $gt: values[0], $lte: values[1] }),
   contains: buildRegexQuery.bind(null, 'contains'),
-  'not-contains': buildRegexQuery.bind(null, 'not-contains'),
-  'begins-with': buildRegexQuery.bind(null, 'begins-with'),
+  beginsWith: buildRegexQuery.bind(null, 'begins-with'),
+  includes: buildRegexQuery.bind(null, 'contains'),
 }
 
 /**
@@ -71,12 +74,6 @@ function buildRegexQuery(operation: string, values: Array<QueryValue>): QueryOpe
   const matcher = values[0]
   if (typeof matcher != 'string') {
     throw new Error(`Attempted to perform a ${operation} operation on a non-string`)
-  }
-  if (operation === 'not-contains') {
-    // Matching on a string not containing something by using
-    // negative lookahead, which JS' regexes support.
-    // Check: https://stackoverflow.com/a/406408/3847023
-    return { $regex: new RegExp(`^((?!${matcher}).)*$`, 'gm') }
   }
   if (operation === 'begins-with') {
     return { $regex: new RegExp(`^${matcher}`) }

--- a/packages/framework-provider-local/test/library/read-model-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/read-model-adapter.test.ts
@@ -1,8 +1,8 @@
 import { createStubInstance, fake, SinonStub, SinonStubbedInstance, replace, stub } from 'sinon'
 import { ReadModelRegistry } from '../../src/services'
-import { BoosterConfig, Logger } from '@boostercloud/framework-types'
+import { BoosterConfig, Logger, ReadModelEnvelope, UUID } from '@boostercloud/framework-types'
 import { expect } from '../expect'
-import { ReadModelEnvelope, UUID } from '@boostercloud/framework-types'
+
 import { random } from 'faker'
 import { createMockReadModelEnvelope } from '../helpers/read-model-helper'
 import { fetchReadModel, searchReadModel, storeReadModel } from '../../src/library/read-model-adapter'
@@ -85,7 +85,7 @@ describe('read-models-adapter', () => {
     it('should call read model registry store with the appropriate operation converted', async () => {
       const mockReadModel = createMockReadModelEnvelope()
       await searchReadModel(mockReadModelRegistry, mockConfig, mockLogger, mockReadModel.typeName, {
-        foo: { operation: '>', values: [1] },
+        foo: { gt: 1 },
       })
       expect(queryStub).to.have.been.calledWithExactly({ typeName: mockReadModel.typeName, 'value.foo': { $gt: 1 } })
     })

--- a/packages/framework-provider-local/test/library/searcher-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/searcher-adapter.test.ts
@@ -4,59 +4,54 @@ import { queryRecordFor } from '../../src/library/searcher-adapter'
 describe('searcher-adapter', () => {
   const typeName = 'SomeReadModel'
   describe('converts simple operators', () => {
-    it('converts the "=" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: '=', values: ['one'] } })
+    it('converts the "eq" operator', () => {
+      const result = queryRecordFor(typeName, { field: { eq: 'one' } })
       expect(result).to.deep.equal({ 'value.field': 'one', typeName })
     })
 
-    it('converts the "!=" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: '!=', values: ['one'] } })
+    it('converts the "ne" operator', () => {
+      const result = queryRecordFor(typeName, { field: { ne: 'one' } })
       expect(result).to.deep.equal({ 'value.field': { $ne: 'one' }, typeName })
     })
 
-    it('converts the "<" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: '<', values: ['one'] } })
-      expect(result).to.deep.equal({ 'value.field': { $lt: 'one' }, typeName })
+    it('converts the "lt" operator', () => {
+      const result = queryRecordFor(typeName, { field: { lt: 1 } })
+      expect(result).to.deep.equal({ 'value.field': { $lt: 1 }, typeName })
     })
 
-    it('converts the ">" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: '>', values: ['one'] } })
-      expect(result).to.deep.equal({ 'value.field': { $gt: 'one' }, typeName })
+    it('converts the "gt" operator', () => {
+      const result = queryRecordFor(typeName, { field: { gt: 1 } })
+      expect(result).to.deep.equal({ 'value.field': { $gt: 1 }, typeName })
     })
 
-    it('converts the "<=" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: '<=', values: ['one'] } })
-      expect(result).to.deep.equal({ 'value.field': { $lte: 'one' }, typeName })
+    it('converts the "lte" operator', () => {
+      const result = queryRecordFor(typeName, { field: { lte: 1 } })
+      expect(result).to.deep.equal({ 'value.field': { $lte: 1 }, typeName })
     })
 
-    it('converts the ">=" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: '>=', values: ['one'] } })
-      expect(result).to.deep.equal({ 'value.field': { $gte: 'one' }, typeName })
+    it('converts the "gte" operator', () => {
+      const result = queryRecordFor(typeName, { field: { gte: 1 } })
+      expect(result).to.deep.equal({ 'value.field': { $gte: 1 }, typeName })
     })
 
     it('converts the "in" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: 'in', values: ['one'] } })
-      expect(result).to.deep.equal({ 'value.field': { $in: ['one'] }, typeName })
-    })
-
-    it('converts the "between" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: 'between', values: ['one', 'two'] } })
-      expect(result).to.deep.equal({ 'value.field': { $gt: 'one', $lte: 'two' }, typeName })
+      const result = queryRecordFor(typeName, { field: { in: ['one', 'two'] } })
+      expect(result).to.deep.equal({ 'value.field': { $in: ['one', 'two'] }, typeName })
     })
   })
   describe('converts operators that rely on regexes', () => {
     it('converts the "contains" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: 'contains', values: ['one'] } })
+      const result = queryRecordFor(typeName, { field: { contains: 'one' } })
       expect(result).to.deep.equal({ 'value.field': { $regex: new RegExp('one') }, typeName })
     })
 
-    it('converts the "not-contains" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: 'not-contains', values: ['one'] } })
-      expect(result).to.deep.equal({ 'value.field': { $regex: new RegExp('^((?!one).)*$', 'gm') }, typeName })
+    it('converts the "includes" operator', () => {
+      const result = queryRecordFor(typeName, { field: { includes: 'one' } })
+      expect(result).to.deep.equal({ 'value.field': { $regex: new RegExp('one') }, typeName })
     })
 
-    it('converts the "begins-with" operator', () => {
-      const result = queryRecordFor(typeName, { field: { operation: 'begins-with', values: ['one'] } })
+    it('converts the "beginsWith" operator', () => {
+      const result = queryRecordFor(typeName, { field: { beginsWith: 'one' } })
       expect(result).to.deep.equal({ 'value.field': { $regex: new RegExp('^one') }, typeName })
     })
   })


### PR DESCRIPTION
## Description
Modify Local provider searcher-adapter.ts to be able to use the new GraphQL filters like the rest of the providers.

## Changes
Modified the provider's `searcher-adapter.ts` to make it compatible with the new format.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~- [ ] Updated documentation accordingly~ Not necessary 
 
## Additional information
Now the local provider GraphQL API is at the same state as the Azure and the K8s ones.

Closes: #601 