### PR TITLE
GitHub actions nuke AWS stack when was deployed

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -76,6 +76,8 @@ jobs:
 
   aws-nuke-integration-tests:
     name: AWS Nuke Integration Tests
+    if: always() && needs.aws-deploy-integration-tests.result == 'success'
+    continue-on-error: true
     needs:
       - aws-load-tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Github actions integration tests are defined by consequent jobs with steps. There is a problem where when an integration test fails after deploying the stack to AWS, the rest of the steps get skipped, including the `nuke` one. This is causing that many stacks are created in AWS without being deleted after running the tests, so AWS limits are being hit.

This PR includes a solution that makes the `nuke` job run if the `deployment` step has succeeded, even if any integration test in the middle fails.

## Changes

A conditional expression was added to the GitHub actions `YAML` file to make the nuke job always run when the deployment has succeeded. Also, the property `continue-on-error` is set to true, so it doesn't get skipped if any other job has failed.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~- [ ] Updated documentation accordingly~ Not necessary 
 
## Additional information

This change has been tested with the integration tests passing and failing, and it always removes the stack.

Closes #758 