### PR TITLE
Fix/real class instances

### DIFF
--- a/packages/framework-core/src/booster-command-dispatcher.ts
+++ b/packages/framework-core/src/booster-command-dispatcher.ts
@@ -9,6 +9,7 @@ import {
 } from '@boostercloud/framework-types'
 import { BoosterAuth } from './booster-auth'
 import { RegisterHandler } from './booster-register-handler'
+import {createInstance} from './services/parser-helpers'
 
 export class BoosterCommandDispatcher {
   public constructor(readonly config: BoosterConfig, readonly logger: Logger) {}
@@ -30,8 +31,7 @@ export class BoosterCommandDispatcher {
 
     const commandClass = commandMetadata.class
     this.logger.debug('Found the following command:', commandClass.name)
-    //const command = commandClass as CommandInterface
-    const commandInstance = new commandClass()
+    const commandInstance = createInstance(commandClass, commandEnvelope.value as any)
     Object.assign(commandInstance, commandEnvelope.value)
     // TODO: Here we could call "command.validate()" so that the user can prevalidate
     // the command inputted by the user.

--- a/packages/framework-core/src/booster-command-dispatcher.ts
+++ b/packages/framework-core/src/booster-command-dispatcher.ts
@@ -6,7 +6,6 @@ import {
   InvalidParameterError,
   NotAuthorizedError,
   NotFoundError,
-  CommandInterface,
 } from '@boostercloud/framework-types'
 import { BoosterAuth } from './booster-auth'
 import { RegisterHandler } from './booster-register-handler'
@@ -31,14 +30,14 @@ export class BoosterCommandDispatcher {
 
     const commandClass = commandMetadata.class
     this.logger.debug('Found the following command:', commandClass.name)
-    const command = commandClass as CommandInterface
-    const commandInstance = new command()
+    //const command = commandClass as CommandInterface
+    const commandInstance = new commandClass()
     Object.assign(commandInstance, commandEnvelope.value)
     // TODO: Here we could call "command.validate()" so that the user can prevalidate
     // the command inputted by the user.
     const register = new Register(commandEnvelope.requestID, commandEnvelope.currentUser)
-    this.logger.debug('Calling "handle" method on command: ', command)
-    await command.handle(commandInstance, register)
+    this.logger.debug('Calling "handle" method on command: ', commandClass)
+    await commandClass.handle(commandInstance, register)
     this.logger.debug('Command dispatched with register: ', register)
     await RegisterHandler.handle(this.config, this.logger, register)
   }

--- a/packages/framework-core/src/booster-command-dispatcher.ts
+++ b/packages/framework-core/src/booster-command-dispatcher.ts
@@ -9,7 +9,7 @@ import {
 } from '@boostercloud/framework-types'
 import { BoosterAuth } from './booster-auth'
 import { RegisterHandler } from './booster-register-handler'
-import {createInstance} from './services/parser-helpers'
+import { createInstance } from './services/parser-helpers'
 
 export class BoosterCommandDispatcher {
   public constructor(readonly config: BoosterConfig, readonly logger: Logger) {}
@@ -31,8 +31,7 @@ export class BoosterCommandDispatcher {
 
     const commandClass = commandMetadata.class
     this.logger.debug('Found the following command:', commandClass.name)
-    const commandInstance = createInstance(commandClass, commandEnvelope.value as any)
-    Object.assign(commandInstance, commandEnvelope.value)
+    const commandInstance = createInstance(commandClass, commandEnvelope.value)
     // TODO: Here we could call "command.validate()" so that the user can prevalidate
     // the command inputted by the user.
     const register = new Register(commandEnvelope.requestID, commandEnvelope.currentUser)

--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -4,8 +4,7 @@ import {
   Logger,
   Register,
   EventHandlerInterface,
-  UUID,
-  EventInterface,
+  UUID
 } from '@boostercloud/framework-types'
 import { EventStore } from './services/event-store'
 import { EventsStreamingCallback, RawEventsParser } from './services/raw-events-parser'
@@ -91,11 +90,15 @@ export class BoosterEventDispatcher {
         )
         continue
       }
+      const eventClass = config.events[eventEnvelope.typeName]
       await Promises.allSettledAndFulfilled(
         eventHandlers.map(async (eventHandler: EventHandlerInterface) => {
+
+          const eventInstance = new eventClass.class()
+          Object.assign(eventInstance, eventEnvelope.value)
           const register = new Register(eventEnvelope.requestID, eventEnvelope.currentUser)
           logger.debug('Calling "handle" method on event handler: ', eventHandler)
-          await eventHandler.handle(eventEnvelope.value as EventInterface, register)
+          await eventHandler.handle(eventInstance, register)
           return RegisterHandler.handle(config, logger, register)
         })
       )

--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -3,9 +3,9 @@ import {
   EventEnvelope,
   Logger,
   Register,
-  EventInterface,
   EventHandlerInterface,
   UUID,
+  EventInterface,
 } from '@boostercloud/framework-types'
 import { EventStore } from './services/event-store'
 import { EventsStreamingCallback, RawEventsParser } from './services/raw-events-parser'

--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -4,13 +4,14 @@ import {
   Logger,
   Register,
   EventHandlerInterface,
-  UUID
+  UUID,
 } from '@boostercloud/framework-types'
 import { EventStore } from './services/event-store'
 import { EventsStreamingCallback, RawEventsParser } from './services/raw-events-parser'
 import { ReadModelStore } from './services/read-model-store'
 import { RegisterHandler } from './booster-register-handler'
 import { Promises } from '@boostercloud/framework-common-helpers'
+import { createInstance } from './services/parser-helpers'
 
 export class BoosterEventDispatcher {
   /**
@@ -93,9 +94,7 @@ export class BoosterEventDispatcher {
       const eventClass = config.events[eventEnvelope.typeName]
       await Promises.allSettledAndFulfilled(
         eventHandlers.map(async (eventHandler: EventHandlerInterface) => {
-
-          const eventInstance = new eventClass.class()
-          Object.assign(eventInstance, eventEnvelope.value)
+          const eventInstance = createInstance(eventClass.class, eventEnvelope.value)
           const register = new Register(eventEnvelope.requestID, eventEnvelope.currentUser)
           logger.debug('Calling "handle" method on event handler: ', eventHandler)
           await eventHandler.handle(eventInstance, register)

--- a/packages/framework-core/src/decorators/entity.ts
+++ b/packages/framework-core/src/decorators/entity.ts
@@ -78,7 +78,7 @@ export function Reduces<TEvent extends EventInterface>(
   }
 }
 
-function registerReducer(eventName: string, reducerMethod: ReducerMetadata): void {
+function registerReducer(eventName: string, reducerMetadata: ReducerMetadata): void {
   Booster.configureCurrentEnv((config): void => {
     const reducerPath = config.reducers[eventName]
     if (reducerPath) {
@@ -88,7 +88,7 @@ function registerReducer(eventName: string, reducerMethod: ReducerMetadata): voi
       )
     }
 
-    config.reducers[eventName] = reducerMethod
+    config.reducers[eventName] = reducerMetadata
   })
 }
 

--- a/packages/framework-core/src/decorators/event.ts
+++ b/packages/framework-core/src/decorators/event.ts
@@ -1,8 +1,21 @@
+import {Class, EventInterface} from '@boostercloud/framework-types'
+import {Booster} from '../booster'
+
 /**
  * Annotation to tell Booster which classes are your Events
- * @param event
+ * @param eventClass
  * @constructor
  */
 // Disabling unused vars here, because it won't allow us to call the decorator without parens
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function Event(_: Function): void {}
+export function Event<TEvent extends EventInterface>(eventClass: Class<TEvent>): void {
+    Booster.configureCurrentEnv((config): void => {
+      if (config.events[eventClass.name]) {
+        throw new Error(`A event called ${eventClass.name} is already registered.
+        If you think that this is an error, try performing a clean build.`)
+      }
+      config.events[eventClass.name] = {
+        class: eventClass,
+      }
+    })
+}

--- a/packages/framework-core/src/services/parser-helpers.ts
+++ b/packages/framework-core/src/services/parser-helpers.ts
@@ -1,0 +1,7 @@
+import { Class } from '@boostercloud/framework-types'
+
+export function createInstance<T>(instanceClass: Class<T>, rawObject: Record<string, any>): T {
+  const instance = new instanceClass()
+  Object.assign(instance, rawObject)
+  return instance
+}

--- a/packages/framework-core/src/services/read-model-store.ts
+++ b/packages/framework-core/src/services/read-model-store.ts
@@ -107,13 +107,13 @@ export class ReadModelStore {
     )
   }
 
-  public async fetchReadModel(readModelName: string, readModelID: UUID): Promise<ReadModelInterface | null> {
+  public async fetchReadModel(readModelName: string, readModelID: UUID): Promise<ReadModelInterface | undefined> {
     this.logger.debug(
       `[ReadModelStore#fetchReadModel] Looking for existing version of read model ${readModelName} with ID ${readModelID}`
     )
-    const rawReadModel = this.provider.readModels.fetch(this.config, this.logger, readModelName, readModelID)
+    const rawReadModel = await this.provider.readModels.fetch(this.config, this.logger, readModelName, readModelID)
     const readModelMetadata = this.config.readModels[readModelName]
-    return rawReadModel ? createInstance(readModelMetadata.class, rawReadModel) : null
+    return rawReadModel ? createInstance(readModelMetadata.class, rawReadModel) : undefined
   }
 
   public projectionFunction(projectionMetadata: ProjectionMetadata): Function {

--- a/packages/framework-core/src/services/read-model-store.ts
+++ b/packages/framework-core/src/services/read-model-store.ts
@@ -39,7 +39,6 @@ export class ReadModelStore {
         const readModelName = projectionMetadata.class.name
         const entityInstance = new entityMetadata.class()
         Object.assign(entityInstance, entitySnapshotEnvelope.value)
-        // const entitySnapshot = entitySnapshotEnvelope.value as EntityInterface
         const readModelID = this.joinKeyForProjection(entityInstance, projectionMetadata)
         this.logger.debug(
           '[ReadModelStore#project] Projecting entity snapshot ',
@@ -112,7 +111,14 @@ export class ReadModelStore {
     this.logger.debug(
       `[ReadModelStore#fetchReadModel] Looking for existing version of read model ${readModelName} with ID ${readModelID}`
     )
-    return this.provider.readModels.fetch(this.config, this.logger, readModelName, readModelID)
+     const rawReadModel = this.provider.readModels.fetch(this.config, this.logger, readModelName, readModelID)
+      if (!rawReadModel) {
+       return rawReadModel
+      }
+    const readModelMetadata = this.config.readModels[readModelName]
+    const readModelInstance = new readModelMetadata.class()
+    void Object.assign(readModelInstance, rawReadModel)
+    return readModelInstance
   }
 
   public projectionFunction(projectionMetadata: ProjectionMetadata): Function {

--- a/packages/framework-core/test/booster-event-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-event-dispatcher.test.ts
@@ -25,7 +25,7 @@ class SomeEvent {
   public entityID(): UUID {
     return this.id
   }
-  public getPrefixedId(prefix: string): UUID {
+  public getPrefixedId(prefix: string): string {
     return `${prefix}-${this.id}`
   }
 }
@@ -80,11 +80,6 @@ describe('BoosterEventDispatcher', () => {
   const config = new BoosterConfig('test')
   config.provider = {} as ProviderLibrary
   config.events[SomeEvent.name] = { class: SomeEvent }
-  config.eventHandlers[SomeEvent.name] = [
-    {
-      handle: AnEventHandler.handle,
-    },
-  ]
 
   context('with a configured provider', () => {
     describe('the `dispatch` method', () => {
@@ -191,17 +186,17 @@ describe('BoosterEventDispatcher', () => {
 
     describe('the `dispatchEntityEventsToEventHandlers` method', () => {
       afterEach(() => {
-        config.eventHandlers['SomeEvent'] = []
+        config.eventHandlers[SomeEvent.name] = []
       })
 
       it('does nothing and does not throw if there are no event handlers', async () => {
         replace(RegisterHandler, 'handle', fake())
         const boosterEventDispatcher = BoosterEventDispatcher as any
         // We try first with null array of event handlers
-        config.eventHandlers['SomeEvent'] = null as any
+        config.eventHandlers[SomeEvent.name] = null as any
         await boosterEventDispatcher.dispatchEntityEventsToEventHandlers([someEvent], config, logger)
         // And now with an empty array
-        config.eventHandlers['SomeEvent'] = []
+        config.eventHandlers[SomeEvent.name] = []
         await boosterEventDispatcher.dispatchEntityEventsToEventHandlers([someEvent], config, logger)
         // It should not throw any errors
       })
@@ -209,7 +204,7 @@ describe('BoosterEventDispatcher', () => {
       it('calls all the handlers for the current event', async () => {
         const fakeHandler1 = fake()
         const fakeHandler2 = fake()
-        config.eventHandlers['SomeEvent'] = [{ handle: fakeHandler1 }, { handle: fakeHandler2 }]
+        config.eventHandlers[SomeEvent.name] = [{ handle: fakeHandler1 }, { handle: fakeHandler2 }]
 
         replace(RegisterHandler, 'handle', fake())
 
@@ -233,7 +228,7 @@ describe('BoosterEventDispatcher', () => {
         const fakeHandler2 = fake((event: EventInterface, register: Register) => {
           capturedRegister2 = register
         })
-        config.eventHandlers['SomeEvent'] = [{ handle: fakeHandler1 }, { handle: fakeHandler2 }]
+        config.eventHandlers[SomeEvent.name] = [{ handle: fakeHandler1 }, { handle: fakeHandler2 }]
 
         replace(RegisterHandler, 'handle', fake())
 
@@ -252,7 +247,7 @@ describe('BoosterEventDispatcher', () => {
           register.events(someEvent.value as EventInterface)
           capturedRegister = register
         })
-        config.eventHandlers['SomeEvent'] = [{ handle: fakeHandler }]
+        config.eventHandlers[SomeEvent.name] = [{ handle: fakeHandler }]
 
         replace(RegisterHandler, 'handle', fake())
 
@@ -265,6 +260,7 @@ describe('BoosterEventDispatcher', () => {
     })
 
     it('calls an instance method in the event and it is executed without failing', async () => {
+      config.eventHandlers[SomeEvent.name] = [{ handle: AnEventHandler.handle }]
       const boosterEventDispatcher = BoosterEventDispatcher as any
       const getPrefixedIdFake = fake()
       replace(SomeEvent.prototype, 'getPrefixedId', getPrefixedIdFake)

--- a/packages/framework-core/test/decorators/entity.test.ts
+++ b/packages/framework-core/test/decorators/entity.test.ts
@@ -50,43 +50,7 @@ describe('the `Entity` decorator', () => {
       methodName: 'react',
     })
   })
-  it('', () => {
-    @Event
-    class PersonCreated {
-      public constructor(
-        readonly personId: UUID,
-        readonly firstName: string,
-        readonly lastName: string,
-        readonly age: number
-      ) {}
-      public fullName(): string {
-        return this.firstName + ' ' + this.lastName
-      }
-      public entityID(): UUID {
-        return this.personId
-      }
-    }
-    @Entity
-    class Person {
-      public constructor(readonly id: UUID, readonly fullName: string, readonly age: number) {}
-      @Reduces(PersonCreated)
-      public static reducePersonCreated(event: PersonCreated, currentEntity: Person): Person {
-        const fullName = event.fullName()
-        return new Person(event.personId, fullName, event.age)
-      }
-    }
-    let exceptionThrown = false
-    try {
-      new PersonCreated(UUID.generate(), 'Pink', 'Floyd', 70)
-    } catch (e) {
-      exceptionThrown = true
-    }
-    expect(exceptionThrown).to.be.equal(false)
-    expect(Booster.config.entities['Person']).to.deep.equal({
-      class: Person,
-      authorizeReadEvents: [],
-    })
-  })
+
   it('adds the entity class as an entity with the right read events permissions', () => {
     @Entity({
       authorizeReadEvents: 'all',

--- a/packages/framework-core/test/decorators/entity.test.ts
+++ b/packages/framework-core/test/decorators/entity.test.ts
@@ -50,7 +50,43 @@ describe('the `Entity` decorator', () => {
       methodName: 'react',
     })
   })
-
+  it('', () => {
+    @Event
+    class PersonCreated {
+      public constructor(
+        readonly personId: UUID,
+        readonly firstName: string,
+        readonly lastName: string,
+        readonly age: number
+      ) {}
+      public fullName(): string {
+        return this.firstName + ' ' + this.lastName
+      }
+      public entityID(): UUID {
+        return this.personId
+      }
+    }
+    @Entity
+    class Person {
+      public constructor(readonly id: UUID, readonly fullName: string, readonly age: number) {}
+      @Reduces(PersonCreated)
+      public static reducePersonCreated(event: PersonCreated, currentEntity: Person): Person {
+        const fullName = event.fullName()
+        return new Person(event.personId, fullName, event.age)
+      }
+    }
+    let exceptionThrown = false
+    try {
+      new PersonCreated(UUID.generate(), 'Pink', 'Floyd', 70)
+    } catch (e) {
+      exceptionThrown = true
+    }
+    expect(exceptionThrown).to.be.equal(false)
+    expect(Booster.config.entities['Person']).to.deep.equal({
+      class: Person,
+      authorizeReadEvents: [],
+    })
+  })
   it('adds the entity class as an entity with the right read events permissions', () => {
     @Entity({
       authorizeReadEvents: 'all',

--- a/packages/framework-core/test/decorators/event.test.ts
+++ b/packages/framework-core/test/decorators/event.test.ts
@@ -3,22 +3,20 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { expect } from '../expect'
 import { Event } from '../../src/decorators'
-import {UUID} from '@boostercloud/framework-types'
-import {Booster} from '../../src'
+import { UUID } from '@boostercloud/framework-types'
+import { Booster } from '../../src'
 
 describe('the `Event` decorator', () => {
-  it('does nothing, but can be used', () => {
-      @Event
-      class AnEvent {
-          public constructor(readonly foo: string) {}
-          public entityID(): UUID {
-              return '123'
-          }
+  it('add the event class as an event', () => {
+    @Event
+    class AnEvent {
+      public constructor(readonly foo: string) {}
+      public entityID(): UUID {
+        return '123'
       }
-    // We add the 'foo' field and use it here so the TS compiler doesn't complain
-    // about it being unused.
-      expect(Booster.config.events['AnEvent']).to.deep.equal({
-          class: AnEvent,
-      })
+    }
+    expect(Booster.config.events['AnEvent']).to.deep.equal({
+      class: AnEvent,
+    })
   })
 })

--- a/packages/framework-core/test/decorators/event.test.ts
+++ b/packages/framework-core/test/decorators/event.test.ts
@@ -3,16 +3,22 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { expect } from '../expect'
 import { Event } from '../../src/decorators'
+import {UUID} from '@boostercloud/framework-types'
+import {Booster} from '../../src'
 
 describe('the `Event` decorator', () => {
   it('does nothing, but can be used', () => {
-    @Event
-    class CommentPosted {
-      public static foo = 'foo'
-    }
-
+      @Event
+      class AnEvent {
+          public constructor(readonly foo: string) {}
+          public entityID(): UUID {
+              return '123'
+          }
+      }
     // We add the 'foo' field and use it here so the TS compiler doesn't complain
     // about it being unused.
-    expect(CommentPosted.foo).to.equal('foo')
+      expect(Booster.config.events['AnEvent']).to.deep.equal({
+          class: AnEvent,
+      })
   })
 })

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -22,19 +22,19 @@ describe('EventStore', () => {
   const logger = buildLogger(Level.error)
 
   class AnEvent {
-    public constructor(readonly id: UUID, readonly entityId: string, readonly delta: number){}
-    public entityID(): UUID{
+    public constructor(readonly id: UUID, readonly entityId: string, readonly delta: number) {}
+    public entityID(): UUID {
       return this.entityId
     }
   }
 
   class AnotherEvent {
-    public constructor(readonly id: UUID){}
-    public entityID(): UUID{
+    public constructor(readonly id: UUID) {}
+    public entityID(): UUID {
       return this.id
     }
-    public getId(): UUID{
-      return this.id
+    public getPrefixedId(prefix: string): string {
+      return `${prefix}-${this.id}`
     }
   }
 
@@ -44,14 +44,14 @@ describe('EventStore', () => {
       return this.id
     }
     public static reducerThatCallsEntityMethod(event: AnEvent, currentEntity?: AnEntity): AnEntity {
-      if(currentEntity){
+      if (currentEntity) {
         currentEntity.getId()
       }
       return new AnEntity(event.entityId, event.delta)
     }
 
     public static reducerThatCallsEventMethod(event: AnotherEvent, currentEntity?: AnEntity): AnEntity {
-      event.getId()
+      event.getPrefixedId('prefix')
       return new AnEntity('1', 1)
     }
   }
@@ -73,8 +73,8 @@ describe('EventStore', () => {
     class: AnEntity,
     methodName: 'reducerThatCallsEventMethod',
   }
-  config.events[AnEvent.name] = {class: AnEvent}
-  config.events[AnotherEvent.name] = {class: AnotherEvent}
+  config.events[AnEvent.name] = { class: AnEvent }
+  config.events[AnotherEvent.name] = { class: AnotherEvent }
 
   const importantDateTimeStamp = new Date(2019, 11, 23, 6, 30).toISOString()
   const originOfTime = new Date(0).toISOString() // Unix epoch
@@ -97,15 +97,19 @@ describe('EventStore', () => {
     count: 0,
   }
 
-  function eventEnvelopeFor<TEvent extends EventInterface>(event: TEvent, typeName: string, timestamp?: string): EventEnvelope {
+  function eventEnvelopeFor<TEvent extends EventInterface>(
+    event: TEvent,
+    typeName: string,
+    timestamp?: string
+  ): EventEnvelope {
     return {
       version: 1,
       kind: 'event',
       entityID: '42',
-      entityTypeName: 'ImportantConcept',
+      entityTypeName: AnEntity.name,
       value: event,
       requestID: 'whatever',
-      typeName: 'ImportantEvent',
+      typeName: typeName,
       createdAt: timestamp || new Date().toISOString(),
     }
   }
@@ -115,10 +119,10 @@ describe('EventStore', () => {
       version: 1,
       kind: 'snapshot',
       entityID: '42',
-      entityTypeName: 'ImportantConcept',
+      entityTypeName: AnEntity.name,
       value: entity,
       requestID: 'whatever',
-      typeName: 'ImportantConcept',
+      typeName: AnEntity.name,
       createdAt: 'fakeTimeStamp',
       snapshottedEventCreatedAt: importantDateTimeStamp,
     }
@@ -138,7 +142,7 @@ describe('EventStore', () => {
           expect(this).to.be.equal(eventStore)
         })
 
-        const entityName = 'ImportantConcept'
+        const entityName = AnEntity.name
         const entityID = '42'
         await expect(eventStore.fetchEntitySnapshot(entityName, entityID)).to.be.eventually.fulfilled
       })
@@ -154,7 +158,7 @@ describe('EventStore', () => {
           replace(eventStore, 'entityReducer', fake())
           replace(eventStore, 'storeSnapshot', fake())
 
-          const entityName = 'ImportantConcept'
+          const entityName = AnEntity.name
           const entityID = '42'
           const entity = await eventStore.fetchEntitySnapshot(entityName, entityID)
 
@@ -200,7 +204,7 @@ describe('EventStore', () => {
           replace(eventStore, 'entityReducer', reducer)
           replace(eventStore, 'storeSnapshot', fake())
 
-          const entityName = 'ImportantConcept'
+          const entityName = AnEntity.name
           const entityID = '42'
           const entity = await eventStore.fetchEntitySnapshot(entityName, entityID)
 
@@ -274,7 +278,7 @@ describe('EventStore', () => {
           replace(eventStore, 'entityReducer', reducer)
           replace(eventStore, 'storeSnapshot', fake())
 
-          const entityName = 'ImportantConcept'
+          const entityName = AnEntity.name
           const entityID = '42'
           const entity = await eventStore.fetchEntitySnapshot(entityName, entityID)
 
@@ -340,7 +344,7 @@ describe('EventStore', () => {
           replace(eventStore, 'entityReducer', reducer)
           replace(eventStore, 'storeSnapshot', fake())
 
-          const entityName = 'ImportantConcept'
+          const entityName = AnEntity.name
           const entityID = '42'
           const entity = await eventStore.fetchEntitySnapshot(entityName, entityID)
 
@@ -376,7 +380,7 @@ describe('EventStore', () => {
           replace(eventStore, 'entityReducer', fake())
           replace(eventStore, 'storeSnapshot', fake())
 
-          const entityName = 'ImportantConcept'
+          const entityName = AnEntity.name
           const entityID = '42'
           const entity = await eventStore.fetchEntitySnapshot(entityName, entityID)
 
@@ -419,7 +423,7 @@ describe('EventStore', () => {
       it('looks for the latest snapshot stored in the event stream', async () => {
         replace(config.provider.events, 'latestEntitySnapshot', fake())
 
-        const entityTypeName = 'ImportantConcept'
+        const entityTypeName = AnEntity.name
         const entityID = '42'
         await eventStore.loadLatestSnapshot(entityTypeName, entityID)
 
@@ -436,7 +440,7 @@ describe('EventStore', () => {
       it('loads a event stream starting from a specific timestapm', async () => {
         replace(config.provider.events, 'forEntitySince', fake())
 
-        const entityTypeName = 'ImportantConcept'
+        const entityTypeName = AnEntity.name
         const entityID = '42'
         await eventStore.loadEventStreamSince(entityTypeName, entityID, originOfTime)
 
@@ -477,8 +481,8 @@ describe('EventStore', () => {
               kind: 'snapshot',
               requestID: eventEnvelope.requestID,
               entityID: '42',
-              entityTypeName: 'ImportantConcept',
-              typeName: 'ImportantConcept',
+              entityTypeName: AnEntity.name,
+              typeName: AnEntity.name,
               value: {
                 id: '42',
                 count: 1,
@@ -511,8 +515,8 @@ describe('EventStore', () => {
               kind: 'snapshot',
               requestID: eventEnvelope.requestID,
               entityID: '42',
-              entityTypeName: 'ImportantConcept',
-              typeName: 'ImportantConcept',
+              entityTypeName: AnEntity.name,
+              typeName: AnEntity.name,
               value: {
                 id: '42',
                 count: 1,
@@ -526,10 +530,11 @@ describe('EventStore', () => {
         it('is executed without failing', async () => {
           const eventEnvelope = eventEnvelopeFor(someEvent, AnotherEvent.name, 'fakeTimeStamp')
           const getIdFake = fake()
-          replace(AnotherEvent.prototype, 'getId', getIdFake)
+          replace(AnotherEvent.prototype, 'getPrefixedId', getIdFake)
           eventStore.entityReducer(null, eventEnvelope)
           expect(getIdFake).to.have.been.called
-        })})
+        })
+      })
       context('when an entity reducer calls an instance method in the entity', () => {
         it('is executed without failing', async () => {
           const snapshot = snapshotEnvelopeFor(someEntity)
@@ -538,16 +543,17 @@ describe('EventStore', () => {
           replace(AnEntity.prototype, 'getId', getIdFake)
           eventStore.entityReducer(snapshot, eventEnvelope)
           expect(getIdFake).to.have.been.called
-        })})
+        })
+      })
     })
 
     describe('reducerForEvent', () => {
       context('for an event with a registered reducer', () => {
         it('returns the proper reducer method for the event', () => {
-          const reducer = eventStore.reducerForEvent('ImportantEvent')
+          const reducer = eventStore.reducerForEvent(AnEvent.name)
 
           expect(reducer).to.be.instanceOf(Function)
-          expect(reducer).to.be.equal(eval('ImportantConcept')['someHandler'])
+          expect(reducer).to.be.equal(eval('AnEntity')['reducerThatCallsEntityMethod'])
         })
       })
 

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -6,8 +6,8 @@ import {
   EventInterface,
   EntityInterface,
   Level,
-  UUID,
   ProviderLibrary,
+  UUID,
 } from '@boostercloud/framework-types'
 import { replace, fake, stub, restore } from 'sinon'
 import { EventStore } from '../../src/services/event-store'
@@ -21,10 +21,38 @@ describe('EventStore', () => {
 
   const logger = buildLogger(Level.error)
 
-  class ImportantConcept {
-    public constructor(readonly id: UUID) {}
-    public static someHandler(): void {
-      console.log('I EXIST!!!')
+  class AnEvent {
+    public constructor(readonly id: UUID, readonly entityId: string, readonly delta: number){}
+    public entityID(): UUID{
+      return this.entityId
+    }
+  }
+
+  class AnotherEvent {
+    public constructor(readonly id: UUID){}
+    public entityID(): UUID{
+      return this.id
+    }
+    public getId(): UUID{
+      return this.id
+    }
+  }
+
+  class AnEntity {
+    public constructor(readonly id: UUID, readonly count: number) {}
+    public getId(): UUID {
+      return this.id
+    }
+    public static reducerThatCallsEntityMethod(event: AnEvent, currentEntity?: AnEntity): AnEntity {
+      if(currentEntity){
+        currentEntity.getId()
+      }
+      return new AnEntity(event.entityId, event.delta)
+    }
+
+    public static reducerThatCallsEventMethod(event: AnotherEvent, currentEntity?: AnEntity): AnEntity {
+      event.getId()
+      return new AnEntity('1', 1)
     }
   }
 
@@ -36,16 +64,23 @@ describe('EventStore', () => {
       forEntitySince: () => {},
     },
   } as any as ProviderLibrary
-  config.entities['ImportantConcept'] = { class: ImportantConcept, authorizeReadEvents: [] }
-  config.reducers['ImportantEvent'] = {
-    class: ImportantConcept,
-    methodName: 'someHandler',
+  config.entities[AnEntity.name] = { class: AnEntity, authorizeReadEvents: [] }
+  config.reducers[AnEvent.name] = {
+    class: AnEntity,
+    methodName: 'reducerThatCallsEntityMethod',
   }
+  config.reducers[AnotherEvent.name] = {
+    class: AnEntity,
+    methodName: 'reducerThatCallsEventMethod',
+  }
+  config.events[AnEvent.name] = {class: AnEvent}
+  config.events[AnotherEvent.name] = {class: AnotherEvent}
 
   const importantDateTimeStamp = new Date(2019, 11, 23, 6, 30).toISOString()
   const originOfTime = new Date(0).toISOString() // Unix epoch
 
   const someEvent = {
+    id: '1',
     entityID: () => '42',
     entityId: '42',
     delta: 1,
@@ -62,7 +97,7 @@ describe('EventStore', () => {
     count: 0,
   }
 
-  function eventEnvelopeFor<TEvent extends EventInterface>(event: TEvent, timestamp?: string): EventEnvelope {
+  function eventEnvelopeFor<TEvent extends EventInterface>(event: TEvent, typeName: string, timestamp?: string): EventEnvelope {
     return {
       version: 1,
       kind: 'event',
@@ -94,7 +129,7 @@ describe('EventStore', () => {
       it('properly binds `this` to the entityReducer', async () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const eventStore = new EventStore(config, logger) as any
-        const someEventEnvelope = eventEnvelopeFor(someEvent)
+        const someEventEnvelope = eventEnvelopeFor(someEvent, AnEvent.name)
 
         replace(eventStore, 'loadLatestSnapshot', fake.resolves(null))
         replace(eventStore, 'loadEventStreamSince', fake.resolves([someEventEnvelope]))
@@ -141,8 +176,8 @@ describe('EventStore', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const eventStore = new EventStore(config, logger) as any
           const someSnapshotEnvelope = snapshotEnvelopeFor(someEntity)
-          const someEventEnvelope = eventEnvelopeFor(someEvent)
-          const otherEventEnvelope = eventEnvelopeFor(otherEvent)
+          const someEventEnvelope = eventEnvelopeFor(someEvent, AnEvent.name)
+          const otherEventEnvelope = eventEnvelopeFor(otherEvent, AnEvent.name)
 
           replace(eventStore, 'loadLatestSnapshot', fake.resolves(someSnapshotEnvelope))
           replace(eventStore, 'loadEventStreamSince', fake.resolves([someEventEnvelope, otherEventEnvelope]))
@@ -202,8 +237,8 @@ describe('EventStore', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const eventStore = new EventStore(config, logger) as any
           const someSnapshotEnvelope = snapshotEnvelopeFor(someEntity)
-          const someEventEnvelope = eventEnvelopeFor(someEvent)
-          const otherEventEnvelope = eventEnvelopeFor(otherEvent)
+          const someEventEnvelope = eventEnvelopeFor(someEvent, AnEvent.name)
+          const otherEventEnvelope = eventEnvelopeFor(otherEvent, AnEvent.name)
           const pendingEvents = [
             someEventEnvelope,
             otherEventEnvelope,
@@ -270,8 +305,8 @@ describe('EventStore', () => {
         it('produces a new snapshot and returns it, but never stores it', async () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const eventStore = new EventStore(config, logger) as any
-          const someEventEnvelope = eventEnvelopeFor(someEvent)
-          const otherEventEnvelope = eventEnvelopeFor(otherEvent)
+          const someEventEnvelope = eventEnvelopeFor(someEvent, AnEvent.name)
+          const otherEventEnvelope = eventEnvelopeFor(otherEvent, AnEvent.name)
           const pendingEvents = [
             someEventEnvelope,
             otherEventEnvelope,
@@ -420,7 +455,7 @@ describe('EventStore', () => {
         context('given a snapshot and a new event', () => {
           it('calculates the new snapshot value using the proper reducer for the event and the entity types', () => {
             const snapshot = snapshotEnvelopeFor(someEntity)
-            const eventEnvelope = eventEnvelopeFor(someEvent, 'fakeTimeStamp')
+            const eventEnvelope = eventEnvelopeFor(someEvent, AnEvent.name, 'fakeTimeStamp')
             const fakeReducer = fake.returns({
               id: '42',
               count: 1,
@@ -430,8 +465,12 @@ describe('EventStore', () => {
             const newSnapshot = eventStore.entityReducer(snapshot, eventEnvelope)
             delete newSnapshot.createdAt
 
-            expect(eventStore.reducerForEvent).to.have.been.calledOnceWith('ImportantEvent')
-            expect(fakeReducer).to.have.been.calledOnceWith(eventEnvelope.value, snapshot.value)
+            const eventInstance = new AnEvent(someEvent.id, someEvent.entityId, someEvent.delta)
+            eventInstance.entityID = someEvent.entityID
+            const entityInstance = new AnEntity(someEntity.id, someEntity.count)
+
+            expect(eventStore.reducerForEvent).to.have.been.calledOnceWith(AnEvent.name)
+            expect(fakeReducer).to.have.been.calledOnceWith(eventInstance, entityInstance)
 
             expect(newSnapshot).to.be.deep.equal({
               version: 1,
@@ -451,7 +490,7 @@ describe('EventStore', () => {
 
         context('given no snapshot and an event', () => {
           it('generates a new snapshot value using the proper reducer for the event and the entity types', () => {
-            const eventEnvelope = eventEnvelopeFor(someEvent, 'fakeTimeStamp')
+            const eventEnvelope = eventEnvelopeFor(someEvent, AnEvent.name, 'fakeTimeStamp')
             const fakeReducer = fake.returns({
               id: '42',
               count: 1,
@@ -461,8 +500,11 @@ describe('EventStore', () => {
             const newSnapshot = eventStore.entityReducer(null, eventEnvelope)
             delete newSnapshot.createdAt
 
-            expect(eventStore.reducerForEvent).to.have.been.calledOnceWith('ImportantEvent')
-            expect(fakeReducer).to.have.been.calledOnceWith(eventEnvelope.value, null)
+            const eventInstance = new AnEvent(someEvent.id, someEvent.entityId, someEvent.delta)
+            eventInstance.entityID = someEvent.entityID
+
+            expect(eventStore.reducerForEvent).to.have.been.calledOnceWith(AnEvent.name)
+            expect(fakeReducer).to.have.been.calledOnceWith(eventInstance, null)
 
             expect(newSnapshot).to.be.deep.equal({
               version: 1,
@@ -480,6 +522,23 @@ describe('EventStore', () => {
           })
         })
       })
+      context('when an entity reducer calls an instance method in the event', () => {
+        it('is executed without failing', async () => {
+          const eventEnvelope = eventEnvelopeFor(someEvent, AnotherEvent.name, 'fakeTimeStamp')
+          const getIdFake = fake()
+          replace(AnotherEvent.prototype, 'getId', getIdFake)
+          eventStore.entityReducer(null, eventEnvelope)
+          expect(getIdFake).to.have.been.called
+        })})
+      context('when an entity reducer calls an instance method in the entity', () => {
+        it('is executed without failing', async () => {
+          const snapshot = snapshotEnvelopeFor(someEntity)
+          const eventEnvelope = eventEnvelopeFor(someEvent, AnEvent.name, 'fakeTimeStamp')
+          const getIdFake = fake()
+          replace(AnEntity.prototype, 'getId', getIdFake)
+          eventStore.entityReducer(snapshot, eventEnvelope)
+          expect(getIdFake).to.have.been.called
+        })})
     })
 
     describe('reducerForEvent', () => {

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -12,7 +12,7 @@ import {
   ProviderLibrary,
   ReadModelAction,
   OptimisticConcurrencyUnexpectedVersionError,
-  ProjectionResult
+  ProjectionResult,
 } from '@boostercloud/framework-types'
 import { expect } from '../expect'
 
@@ -46,8 +46,8 @@ describe('ReadModelStore', () => {
     }
 
     public static projectionThatCallsReadModelMethod(
-        entity: AnEntity,
-        currentReadModel: SomeReadModel
+      entity: AnEntity,
+      currentReadModel: SomeReadModel
     ): ProjectionResult<SomeReadModel> {
       currentReadModel.getId()
       return ReadModelAction.Nothing
@@ -198,6 +198,8 @@ describe('ReadModelStore', () => {
         replace(readModelStore, 'fetchReadModel', fake.returns(null))
         spy(SomeReadModel, 'someObserver')
         spy(AnotherReadModel, 'anotherObserver')
+        const entityValue: any = eventEnvelopeFor(AnImportantEntity.name).value
+        const anEntityInstance = new AnImportantEntity(entityValue.id, entityValue.someKey, entityValue.count)
 
         await readModelStore.project(eventEnvelopeFor(AnImportantEntity.name))
 
@@ -211,7 +213,7 @@ describe('ReadModelStore', () => {
           count: 123,
           boosterMetadata: { version: 1 },
         })
-        expect(AnotherReadModel.anotherObserver).to.have.been.calledOnceWith(anEntitySnapshot.value, null)
+        expect(AnotherReadModel.anotherObserver).to.have.been.calledOnceWith(anEntityInstance, null)
         expect(AnotherReadModel.anotherObserver).to.have.returned({
           id: 'joinColumnID',
           kind: 'another',
@@ -399,11 +401,11 @@ describe('ReadModelStore', () => {
         SomeReadModel.name,
         'joinColumnID'
       )
-      expect(result).to.be.null
+      expect(result).to.be.undefined
     })
 
     it('returns an instance of the current read model value when it exists', async () => {
-      replace(config.provider.readModels, 'fetch', fake.returns({ id: 'joinColumnID'}))
+      replace(config.provider.readModels, 'fetch', fake.returns({ id: 'joinColumnID' }))
       const readModelStore = new ReadModelStore(config, logger)
       const result = await readModelStore.fetchReadModel(SomeReadModel.name, 'joinColumnID')
 

--- a/packages/framework-integration-tests/src/entities/cart.ts
+++ b/packages/framework-integration-tests/src/entities/cart.ts
@@ -1,9 +1,9 @@
-import '../common/address'
+import { Address } from '../common/address'
 import { Entity, Reduces } from '@boostercloud/framework-core'
 import { UUID } from '@boostercloud/framework-types'
 import { CartItemChanged } from '../events/cart-item-changed'
 import { ShippingAddressUpdated as UpdatedCartShippingAddress } from '../events/shipping-address-updated'
-import { Address } from '../common/address'
+
 import { CartItem } from '../common/cart-item'
 import { CartChecked } from '../events/cart-checked'
 
@@ -20,12 +20,17 @@ export class Cart {
     public shippingAddress?: Address,
     public checks = 0
   ) {}
-
+  public getId() {
+    return this.id
+  }
   @Reduces(CartItemChanged)
   public static changeItem(event: CartItemChanged, currentCart: Cart): Cart {
     if (currentCart == null) {
       currentCart = new Cart(event.cartId, [])
     }
+    // This method calls are here to ensure they work. More info: https://github.com/boostercloud/booster/issues/797
+    currentCart.getId()
+    event.getProductId()
 
     const current = currentCart.cartItems.find((cartItem: CartItem): boolean => cartItem.productId === event.productId)
     if (current) {

--- a/packages/framework-integration-tests/src/event-handlers/handle-availability.ts
+++ b/packages/framework-integration-tests/src/event-handlers/handle-availability.ts
@@ -7,6 +7,8 @@ import { Product } from '../entities/product'
 @EventHandler(StockMoved)
 export class HandleAvailability {
   public static async handle(event: StockMoved, register: Register): Promise<void> {
+    // This method call is here to ensure it work. More info: https://github.com/boostercloud/booster/issues/797
+    event.getOrigin()
     const product = await Booster.entity(Product, event.productID)
     if (!product) {
       // This means that we have moved stock of a product we don't have in our store. Ignore it

--- a/packages/framework-integration-tests/src/events/cart-item-changed.ts
+++ b/packages/framework-integration-tests/src/events/cart-item-changed.ts
@@ -8,4 +8,8 @@ export class CartItemChanged {
   public entityID(): UUID {
     return this.cartId
   }
+
+  public getProductId(): UUID {
+    return this.productId
+  }
 }

--- a/packages/framework-integration-tests/src/events/stock-moved.ts
+++ b/packages/framework-integration-tests/src/events/stock-moved.ts
@@ -13,4 +13,8 @@ export class StockMoved {
   public entityID(): UUID {
     return this.productID
   }
+
+  public getOrigin(): string {
+    return this.origin
+  }
 }

--- a/packages/framework-integration-tests/src/read-models/cart-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/cart-read-model.ts
@@ -18,9 +18,18 @@ export class CartReadModel {
     public cartItemsIds?: Array<string>
   ) {}
 
+  public getChecks() {
+    return this.checks
+  }
   @Projects(Cart, 'id')
   public static updateWithCart(cart: Cart, oldCartReadModel?: CartReadModel): ProjectionResult<CartReadModel> {
     const cartProductIds = cart?.cartItems.map((item) => item.productId as string)
+    // This method calls are here to ensure they work. More info: https://github.com/boostercloud/booster/issues/797
+    cart.getId()
+    if (oldCartReadModel) {
+      oldCartReadModel.getChecks()
+    }
+
     return new CartReadModel(
       cart.id,
       cart.cartItems,

--- a/packages/framework-types/src/concepts/event-handler.ts
+++ b/packages/framework-types/src/concepts/event-handler.ts
@@ -1,16 +1,6 @@
 import { Register } from './register'
-import { Class } from '../typelevel'
+import { EventInterface } from './event'
 
-export interface EventHandlerInterface<TEventHandler = unknown> extends Class<TEventHandler> {
-  handle(event: TEventHandler, register: Register): Promise<void>
+export interface EventHandlerInterface {
+  handle(event: EventInterface, register: Register): Promise<void>
 }
-
-/*export interface EventHandlerMetadata<TEventHandler = unknown> {
-  // For the class, we care that it has the static methods specified by CommandInterface
-  // and it has at least the properties of a class (like name, constructor, etc...)
-  // We don't care about the properties of the instance, so we set the type parameter of
-  // Class to unknown.
-  readonly class: EventHandlerInterface<TEventHandler>
-  readonly properties: Array<PropertyMetadata>
-  readonly authorizedRoles: RoleAccess['authorize']
-}*/

--- a/packages/framework-types/src/concepts/event-handler.ts
+++ b/packages/framework-types/src/concepts/event-handler.ts
@@ -1,6 +1,16 @@
-import { EventInterface } from '../concepts/event'
 import { Register } from './register'
+import { Class } from '../typelevel'
 
-export interface EventHandlerInterface {
-  handle(event: EventInterface, register: Register): Promise<void>
+export interface EventHandlerInterface<TEventHandler = unknown> extends Class<TEventHandler> {
+  handle(event: TEventHandler, register: Register): Promise<void>
 }
+
+/*export interface EventHandlerMetadata<TEventHandler = unknown> {
+  // For the class, we care that it has the static methods specified by CommandInterface
+  // and it has at least the properties of a class (like name, constructor, etc...)
+  // We don't care about the properties of the instance, so we set the type parameter of
+  // Class to unknown.
+  readonly class: EventHandlerInterface<TEventHandler>
+  readonly properties: Array<PropertyMetadata>
+  readonly authorizedRoles: RoleAccess['authorize']
+}*/

--- a/packages/framework-types/src/concepts/event.ts
+++ b/packages/framework-types/src/concepts/event.ts
@@ -1,4 +1,5 @@
 import { UUID } from './uuid'
+import { Class } from '../typelevel'
 
 /**
  * An `Event` is a fact that has happened in your system.
@@ -7,4 +8,8 @@ import { UUID } from './uuid'
 
 export interface EventInterface {
   entityID(): UUID
+}
+
+export interface EventMetadata {
+  readonly class: Class<EventInterface>
 }

--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -37,6 +37,7 @@ export class BoosterConfig {
   )
   public readonly notifySubscribersHandler: string = path.join(this.codeRelativePath, 'index.boosterNotifySubscribers')
 
+  public readonly events: Record<EventName, EventMetadata> = {}
   public readonly entities: Record<EntityName, EntityMetadata> = {}
   public readonly reducers: Record<EventName, ReducerMetadata> = {}
   public readonly commandHandlers: Record<CommandName, CommandMetadata> = {}

--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -8,6 +8,7 @@ import {
   ReadModelMetadata,
   EventHandlerInterface,
   ScheduledCommandMetadata,
+  EventMetadata,
 } from './concepts'
 import { ProviderLibrary } from './provider'
 import { Level } from './logger'

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -15,7 +15,7 @@ export interface Envelope {
 export interface CommandEnvelope extends Envelope {
   typeName: string
   version: number
-  value: unknown
+  value: Record<string, any>
 }
 
 export interface ScheduledCommandEnvelope extends Envelope {

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -67,7 +67,7 @@ export interface ProviderReadModelsLibrary {
     config: BoosterConfig,
     logger: Logger,
     readModelName: string,
-    readModel: ReadModelInterface | null
+    readModel: ReadModelInterface | undefined
   ): Promise<any>
   subscribe(config: BoosterConfig, logger: Logger, subscriptionEnvelope: SubscriptionEnvelope): Promise<void>
   fetchSubscriptions(

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -63,7 +63,12 @@ export interface ProviderReadModelsLibrary {
     readModel: ReadModelInterface,
     expectedCurrentVersion?: number
   ): Promise<unknown>
-  delete(config: BoosterConfig, logger: Logger, readModelName: string, readModel: ReadModelInterface): Promise<any>
+  delete(
+    config: BoosterConfig,
+    logger: Logger,
+    readModelName: string,
+    readModel: ReadModelInterface | null
+  ): Promise<any>
   subscribe(config: BoosterConfig, logger: Logger, subscriptionEnvelope: SubscriptionEnvelope): Promise<void>
   fetchSubscriptions(
     config: BoosterConfig,


### PR DESCRIPTION
## Description
Currently, when you pass events, entities and read models to user's reducer and projections , you get a raw javascript object instead of an instance of their respective classes.
We have the same bug when calling event handlers: we are passing as a parameter the raw object stored in the event envelope, instead of the instance.
fixes: https://github.com/boostercloud/booster/issues/797
## Changes
Create proper instances for the event, entity, read model and event handlers.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly
 