### PR TITLE
include custom object types like enums

### DIFF
--- a/packages/framework-core/src/services/graphql/graphql-query-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-query-generator.ts
@@ -192,7 +192,7 @@ export class GraphQLQueryGenerator {
   private generateFilterFor(prop: PropertyMetadata): GraphQLInputObjectType | GraphQLScalarType {
     const filterName = `${prop.typeInfo.name}PropertyFilter`
 
-    if (!prop.typeInfo.type) return GraphQLJSONObject
+    if (!prop.typeInfo.type || typeof prop.typeInfo.type === 'object') return GraphQLJSONObject
 
     if (!this.generatedFiltersByTypeName[filterName]) {
       const primitiveType = this.typeInformer.getOriginalAncestor(prop.typeInfo.type)


### PR DESCRIPTION
## Description

Fix to avoid excluding enums as `GraphQLJSONObject` types

## Changes

Now checks when the type at compilation time is just an `object` type, setting then the `GraphQLJSONObject` by default

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly

