### PR TITLE
Show rocket errors on the CLI

### DIFF
--- a/packages/framework-provider-aws-infrastructure/src/index.ts
+++ b/packages/framework-provider-aws-infrastructure/src/index.ts
@@ -9,19 +9,7 @@ export * from './test-helper/aws-test-helper'
 export const Infrastructure = (rocketDescriptors?: RocketDescriptor[]): ProviderInfrastructure => {
   const rockets = rocketDescriptors?.map(loadRocket)
   return {
-    deploy: async (config: BoosterConfig, logger: Logger) => {
-      try {
-        await deploy(config, logger, rockets)
-      } catch (error) {
-        logger.error(error)
-      }
-    },
-    nuke: async (config: BoosterConfig, logger: Logger) => {
-      try {
-        await nuke(config, logger, rockets)
-      } catch (error) {
-        logger.error(error)
-      }
-    },
+    deploy: async (config: BoosterConfig, logger: Logger) => await deploy(config, logger, rockets),
+    nuke: async (config: BoosterConfig, logger: Logger) => await nuke(config, logger, rockets),
   }
 }

--- a/packages/framework-provider-aws-infrastructure/test/index.test.ts
+++ b/packages/framework-provider-aws-infrastructure/test/index.test.ts
@@ -40,50 +40,32 @@ describe('the `framework-provider-aws-infrastructure` package', () => {
           expect(infra.deploy).to.have.been.calledWith(fakeConfig, logger)
         })
 
-        it('logs an error through the passed logger when an error is thrown', async () => {
+        it('throws an error if the deploy process failed', async () => {
           const errorMessage = new Error('Ooops')
           replace(infra, 'deploy', fake.throws(errorMessage))
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const fakeConfig = { fake: 'config' } as any
 
-          const logger: Logger = {
-            info: fake(),
-            error: fake(),
-            debug: fake(),
-          }
-
           expect(providerInfrastructure.deploy).to.be.a('function')
           if (providerInfrastructure.deploy)
-            await expect(providerInfrastructure.deploy(fakeConfig, logger)).not.to.eventually.be.rejected
-
-          // It receives the thrown Error object, not just the message
-          expect(logger.error).to.have.been.calledWithMatch(errorMessage)
+            await expect(providerInfrastructure.deploy(fakeConfig, logger)).to.be.rejectedWith(errorMessage)
         })
       })
 
       describe('nuke', () => {
         xit('initializes nuke with no rockets')
 
-        it('logs an error through the passed logger when an error is thrown', async () => {
+        it('throws error if the nuke process fails', async () => {
           const errorMessage = new Error('Ooops')
           replace(infra, 'nuke', fake.throws(errorMessage))
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const fakeConfig = { fake: 'config' } as any
 
-          const logger: Logger = {
-            info: fake(),
-            error: fake(),
-            debug: fake(),
-          }
-
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const providerInfrastructureAlias = providerInfrastructure as any
-          await expect(providerInfrastructureAlias.nuke(fakeConfig, logger)).not.to.eventually.be.rejected
-
-          // It receives the thrown Error object, not just the message
-          expect(logger.error).to.have.been.calledWithMatch(errorMessage)
+          await expect(providerInfrastructureAlias.nuke(fakeConfig, logger)).to.be.rejectedWith(errorMessage)
         })
       })
     })


### PR DESCRIPTION
## Description
Related issue: https://github.com/boostercloud/booster/issues/597

Currently, when deploying a booster application, and if a rocket throws an error, the CLI just keeps printing the next steps, when the deployment failed (it just shows an "X"):
```bash
boost deploy -e development
ℹ boost deploy [development] 🚀
ℹ Bootstraping the following environment: {"name":"Default environment","account":"<id>","region":"eu-west-1"}
 ⏳  Bootstrapping environment aws://<id>/eu-west-1...
my-app-dev-toolkit: creating CloudFormation changeset...
[██████████████████████████████████████████████████████████] (3/3)



 ✅  Environment aws://<id>/eu-west-1 bootstrapped.
ℹ Deploying my-app-dev on environment development
✖ <------ IT ONLY SHOWS THIS "X"
✔ Deploying
✔ Cleaning up deployment files
ℹ Deployment complete!
```
This is better explained in the issue above, but it's happening because the `Script.step` function is treating the `logger.error` that it's thrown in the `aws-infrastructure` package as a "success" call in the `tryCatch` statement: https://github.com/boostercloud/booster/blob/main/packages/cli/src/common/script.ts#L56

**The solutions I thought about were:**
1. Just letting the `deploy` and `nuke` methods throw, so the program is interrupted
2. Modify the logger implementation so `logger.error` always throws.

I decided to go for the **1st option** because `logger.error` is used in different places and I preferred to go with the safe approach.

## Changes
- Remove try-catch wrapper on the `aws-infrastructure` package
- Modified test check that these methods throw exceptions

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [] Updated documentation accordingly --- Not needed
