### PR TITLE
Temporary disable k8s integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -118,26 +118,28 @@ jobs:
       - run: npx lerna run compile
       - run: npx lerna run integration/local --stream
 
-  kubernetes-integration-tests:
-    name: Kubernetes integration tests
-    runs-on: ubuntu-latest
-    env:
-      KUBECONFIG: '/home/runner/.kube/config'
-    steps:
-      - uses: actions/checkout@v2
-      - uses: manusa/actions-setup-minikube@v2.3.1
-        with:
-          minikube version: 'v1.18.1'
-          kubernetes version: 'v1.19.7'
-          driver: 'docker'
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-      - run: sudo snap install helm --classic
-      - run: kubectl create ns booster-my-store-kubernetes
-      - run: kubectl config set-context --current --namespace=booster-my-store-kubernetes
-      - run: minikube start --namespace=booster-my-store-kubernetes
-      - run: npx lerna bootstrap
-      - run: npx lerna run compile
-      - run: npx lerna run integration/k8s-deploy --stream
-      - run: npx lerna run integration/k8s-nuke --stream
+  # Kubernetes tests started failing on June 2021. We should fix them if adding more kubernetes features.
+  # issue: https://github.com/boostercloud/booster/issues/885
+  #kubernetes-integration-tests:
+  #  name: Kubernetes integration tests
+  #  runs-on: ubuntu-latest
+  #  env:
+  #    KUBECONFIG: '/home/runner/.kube/config'
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - uses: manusa/actions-setup-minikube@v2.3.1
+  #      with:
+  #        minikube version: 'v1.18.1'
+  #        kubernetes version: 'v1.19.7'
+  #        driver: 'docker'
+  #    - uses: actions/setup-node@v1
+  #      with:
+  #        node-version: 14.x
+  #    - run: sudo snap install helm --classic
+  #    - run: kubectl create ns booster-my-store-kubernetes
+  #    - run: kubectl config set-context --current --namespace=booster-my-store-kubernetes
+  #    - run: minikube start --namespace=booster-my-store-kubernetes
+  #    - run: npx lerna bootstrap
+  #    - run: npx lerna run compile
+  #    - run: npx lerna run integration/k8s-deploy --stream
+  #    - run: npx lerna run integration/k8s-nuke --stream


### PR DESCRIPTION
We're finally disabling k8s tests temporary, there's already an issue created to solve this when we get a chance