### PR TITLE
feat: create nested array fields in GraphQL schema based on metadata

### DIFF
--- a/packages/framework-core/src/services/graphql/graphql-type-informer.ts
+++ b/packages/framework-core/src/services/graphql/graphql-type-informer.ts
@@ -57,6 +57,11 @@ export class GraphQLTypeInformer {
         fields[prop.name] = {
           type: GraphQLList(graphQLPropType),
         }
+        // TODO: awaiting update of metadata-booster package to access .isArray boolean
+      } else if ((prop.typeInfo as any).isArray) {
+        fields[prop.name] = {
+          type: GraphQLList(this.getGraphQLTypeFor(prop.typeInfo.type)),
+        }
       } else {
         fields[prop.name] = { type: this.getGraphQLTypeFor(prop.typeInfo.type) }
       }

--- a/packages/framework-core/src/services/pub-sub/read-model-pub-sub.ts
+++ b/packages/framework-core/src/services/pub-sub/read-model-pub-sub.ts
@@ -44,8 +44,12 @@ function filterReadModel(readModel: Record<string, any>, filters?: Record<string
     return true
   }
   for (const filteredProp in filters) {
-    const readModelPropValue = readModel[filteredProp]
-    return filterByOperation(filters[filteredProp], readModelPropValue)
+    if (Array.isArray(readModel[filteredProp])) {
+      return readModel[filteredProp].some((readModelFilteredProp: any) =>
+        filterByOperation(filters[filteredProp], readModelFilteredProp)
+      )
+    }
+    return filterByOperation(filters[filteredProp], readModel[filteredProp])
   }
   return true
 }


### PR DESCRIPTION
## Description
Currently, nested array fields are transformed into `JSONObject` after generation of the GraphQL schema:
```GraphQL
type PartyReadModel {
  id: String
  type: String
  addresses: JSONObject
}
```

## Changes
This PR generates proper GraphQL types for nested array fields, similarly as with nested non-array fields:
```GraphQL
type PartyReadModel {
  id: String
  type: String
  addresses: [Address]
}

type Address {
  street: String
  postalCode: String
  city: String
  country: String
}
```

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly
 
## Additional information
* This PR relies on an update of `metadata-booster`: https://github.com/boostercloud/metadata-booster/pull/1.
* This PR is put in draft as these changes have impact on the filtering of read models. Although it doesn't break existing functionality, filtering on nested array fields is not working. A suggestion was done by updating `ReadModelPubSub`, but provider specific implementations still need an update in order to be able to filter properly from the GraphQL API.
* No new tests were written yet.