### PR TITLE
Allow the local provider to use all the authorization features

### DIFF
--- a/packages/application-tester/src/index.ts
+++ b/packages/application-tester/src/index.ts
@@ -1,3 +1,4 @@
 export * from './application-tester'
 export * from './provider-test-helper'
 export * from './graphql-helper'
+export * from './token-helper'

--- a/packages/framework-integration-tests/integration/provider-unaware/load/entities-are-correctly-reduced.load.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/load/entities-are-correctly-reduced.load.ts
@@ -31,7 +31,7 @@ describe('Data consistency on entities', () => {
 
     it('adds stock to all of them with many events without corrupting data', async () => {
       const durationWarmup = 10
-      const arrivalRateWarmup = 800
+      const arrivalRateWarmup = 500
       const durationBurst = 10
       const arrivalRateBurst = 1500
       const expectedStock = durationWarmup * arrivalRateWarmup + durationBurst * arrivalRateBurst

--- a/packages/framework-integration-tests/package.json
+++ b/packages/framework-integration-tests/package.json
@@ -10,7 +10,7 @@
   },
   "bugs": "https://github.com/boostercloud/booster/issues",
   "dependencies": {
-    "@boostercloud/framework-common-helpers": "^0.16.3",
+    "@boostercloud/framework-common-helpers": "^0.20.0",
     "@boostercloud/framework-core": "^0.20.0",
     "@boostercloud/framework-provider-aws": "^0.20.0",
     "@boostercloud/framework-provider-kubernetes": "^0.20.0",

--- a/packages/framework-provider-local/src/library/graphql-adapter.ts
+++ b/packages/framework-provider-local/src/library/graphql-adapter.ts
@@ -14,11 +14,7 @@ export async function rawGraphQLRequestToEnvelope(
       requestID,
       eventType,
       connectionID,
-      currentUser: {
-        username: 'test@test.com',
-        role: '',
-        claims: {},
-      },
+      token: request.headers.authorization,
       value: request.body,
     }
   } catch (e) {

--- a/packages/framework-provider-local/test/library/graphql-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/graphql-adapter.test.ts
@@ -5,12 +5,14 @@ import { rawGraphQLRequestToEnvelope } from '../../src/library/graphql-adapter'
 import { expect } from '../expect'
 import { UUID } from '@boostercloud/framework-types'
 import { random } from 'faker'
+import { Request } from 'express'
 
 describe('Local provider graphql-adapter', () => {
   describe('rawGraphQLRequestToEnvelope', () => {
     let mockUuid: string
     let mockBody: any
-    let mockRequest: any
+    let mockRequest: Request
+    let mockUserToken: string
 
     let debugStub: SinonStub
     let generateStub: SinonStub
@@ -19,12 +21,16 @@ describe('Local provider graphql-adapter', () => {
 
     beforeEach(() => {
       mockUuid = random.uuid()
+      mockUserToken = random.uuid()
       mockBody = {
         query: '',
         variables: {},
       }
       mockRequest = mockReq()
       mockRequest.body = mockBody
+      mockRequest.headers = {
+        authorization: mockUserToken,
+      }
 
       debugStub = stub()
       generateStub = stub().returns(mockUuid)
@@ -58,11 +64,7 @@ describe('Local provider graphql-adapter', () => {
         requestID: mockUuid,
         eventType: 'MESSAGE',
         connectionID: undefined,
-        currentUser: {
-          username: 'test@test.com',
-          role: '',
-          claims: {},
-        },
+        token: mockUserToken,
         value: mockBody,
       })
     })


### PR DESCRIPTION
## Description
With this PR you can now use authorization in your local provider. You can use any auth rocket for that.

## Changes
The local provider was ignoring the token that was being sent in the request. After passing it through the core, all the authorization features are available.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly

