### PR TITLE
Modify read events API docs

### DIFF
--- a/docs/chapters/04_features.md
+++ b/docs/chapters/04_features.md
@@ -745,6 +745,7 @@ query {
 
 - Subscriptions don't work for the events API yet
 - You can only query events, but not write them through this API. Use a command for that.
+- Currently, only available on the AWS provider.
 
 ### Filter & Pagination
 #### Filtering a read model


### PR DESCRIPTION
I'm just waiting for confirmation from discord but I think the read events API only works with the AWS provider. I'm just adding this limitation to the docs.