### PR TITLE
fix: correct input types for non-nullable arrays

### DIFF
--- a/packages/framework-core/src/services/graphql/graphql-type-informer.ts
+++ b/packages/framework-core/src/services/graphql/graphql-type-informer.ts
@@ -114,7 +114,7 @@ export class GraphQLTypeInformer {
       return new GraphQLList(this.toInputType(graphQLType.ofType))
     }
     if (graphQLType instanceof GraphQLNonNull) {
-      return new GraphQLNonNull(graphQLType.ofType)
+      return new GraphQLNonNull(this.toInputType(graphQLType.ofType))
     }
     if (graphQLType instanceof GraphQLObjectType) {
       return new GraphQLInputObjectType({


### PR DESCRIPTION
The latest release improved the GraphQL schema generation by adding `GraphQLNonNull` to elements of arrays. 
However, this causes arrays in *input* types to result in `JSONObject` instead of the specific type. (https://github.com/boostercloud/booster/commit/e9906b4aad3dfdd97832fe2111343b3647cf467a)

Example:
![image](https://user-images.githubusercontent.com/66438062/126825381-3c395a0c-7021-4003-a87c-b3bcd824c645.png)

It also breaks PR https://github.com/boostercloud/booster/pull/890 which also fixes some `JSONObject` types, returning specific types instead.
```
[Booster]  Error: The type of UpsertDossierInput.parties must be Input Type but got: [DossierParty!].
```

This PR should improve the input types again:
![image](https://user-images.githubusercontent.com/66438062/126825496-12168a7c-e0c5-4bdb-825c-e0c9b6a979d0.png)
