### PR TITLE
Refactor: Simpler GraphQL generators.

### DIFF
--- a/packages/framework-core/src/services/graphql/graphql-mutation-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-mutation-generator.ts
@@ -1,39 +1,63 @@
-import { ResolverBuilder, TargetTypesMap } from './common'
+import { GraphQLResolverContext } from './common'
 import { GraphQLTypeInformer } from './graphql-type-informer'
-import { GraphQLFieldConfigMap, GraphQLObjectType, GraphQLNonNull } from 'graphql'
+import { GraphQLFieldConfigMap, GraphQLNonNull, GraphQLFieldResolver } from 'graphql'
+import { AnyClass, BoosterConfig, CommandEnvelope, Logger } from '@boostercloud/framework-types'
+import { BoosterCommandDispatcher } from 'framework-core/src/booster-command-dispatcher'
 
-export class GraphQLMutationGenerator {
-  public constructor(
-    private readonly targetTypes: TargetTypesMap,
-    private readonly typeInformer: GraphQLTypeInformer,
-    private readonly mutationResolver: ResolverBuilder
-  ) {}
-
-  public generate(): GraphQLObjectType | undefined {
-    const mutations = this.generateMutations()
-    if (Object.keys(mutations).length === 0) {
-      return undefined
-    }
-    return new GraphQLObjectType({
-      name: 'Mutation',
-      fields: mutations,
+export class GraphQLCommandMutationGenerator {
+  public static generate(config: BoosterConfig, logger: Logger): GraphQLFieldConfigMap<any, any> {
+    const commandsDispatcher = new BoosterCommandDispatcher(config, logger)
+    const targetTypes = config.commandHandlers
+    const typeInformer = new GraphQLTypeInformer({
+      ...config.commandHandlers,
     })
-  }
 
-  private generateMutations(): GraphQLFieldConfigMap<any, any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mutations: GraphQLFieldConfigMap<any, any> = {}
-    for (const name in this.targetTypes) {
-      const type = this.targetTypes[name]
+    for (const name in targetTypes) {
+      const type = targetTypes[name]
       mutations[name] = {
-        type: this.typeInformer.getGraphQLTypeFor(type.returnClass ?? Boolean),
+        type: typeInformer.getGraphQLTypeFor(type.returnClass ?? Boolean),
         args: {
           input: {
-            type: new GraphQLNonNull(this.typeInformer.getGraphQLInputTypeFor(type.class)),
+            type: new GraphQLNonNull(typeInformer.getGraphQLInputTypeFor(type.class)),
           },
         },
-        resolve: this.mutationResolver(type.class),
+        resolve: commandResolverBuilder.bind(null, commandsDispatcher, type.class),
       }
     }
+
     return mutations
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toCommandEnvelope(commandName: string, value: any, context: GraphQLResolverContext): CommandEnvelope {
+  return {
+    requestID: context.requestID,
+    currentUser: context.user,
+    typeName: commandName,
+    value,
+    version: 1, // TODO: How to pass the version through GraphQL?
+  }
+}
+
+/**
+ * Builder method to generate a resolver function for a specific command class.
+ * @param commandsDispatcher
+ * @param commandClass
+ * @returns
+ */
+function commandResolverBuilder(
+  commandsDispatcher: BoosterCommandDispatcher,
+  commandClass: AnyClass
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): GraphQLFieldResolver<any, GraphQLResolverContext, { input: any }> {
+  return async (_parent, args, context, _info) => {
+    const commandEnvelope = toCommandEnvelope(commandClass.name, args.input, context)
+    const result = await commandsDispatcher.dispatchCommand(commandEnvelope)
+    // It could be that the command didn't return anything
+    // so in that case we return `true`, as GraphQL doesn't have a `null` type
+    return result ?? true
   }
 }


### PR DESCRIPTION
In this branch, I'm reworking the GraphQL generators with a simpler functional approach that's easier to understand and extend. In addition to that, this change is the first step to allow rockets to extend the GraphQL API freely.

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
 