### PR TITLE
fix: fix graphql type recognition for complex nested fields

### DIFF
--- a/packages/framework-core/src/services/graphql/graphql-type-informer.ts
+++ b/packages/framework-core/src/services/graphql/graphql-type-informer.ts
@@ -58,6 +58,11 @@ export class GraphQLTypeInformer {
           type: GraphQLList(new GraphQLNonNull(graphQLPropType)),
         }
       } else {
+        let graphQLPropType = this.getGraphQLTypeFor(prop.typeInfo.type);
+        if (!this.isGraphQLScalarType(graphQLPropType) && prop.typeInfo.type) {
+          const properties = getPropertiesMetadata(prop.typeInfo.type);
+          this.generateGraphQLTypeFromMetadata({ class: prop.typeInfo.type, properties });
+        }
         fields[prop.name] = { type: this.getGraphQLTypeFor(prop.typeInfo.type) }
       }
     }


### PR DESCRIPTION
This is a fix related https://github.com/boostercloud/booster/pull/890 but for non-array fields. It causes nested fields to have generated types rather than using the fallback JSONObject. Note that the type informer class could potentially be simplified in order to have a cleaner solution than this.