### PR TITLE
fix(core): Ensure Booster.entity returns an entity instead of envelope

### DIFF
--- a/packages/framework-core/src/booster.ts
+++ b/packages/framework-core/src/booster.ts
@@ -146,7 +146,7 @@ export class Booster {
   ): Promise<TEntity | undefined> {
     const eventStore = new EventStore(this.config, this.logger)
     const entitySnapshotEnvelope = await eventStore.fetchEntitySnapshot(entityClass.name, entityID)
-    return entitySnapshotEnvelope ? createInstance(entityClass, entitySnapshotEnvelope) : undefined
+    return entitySnapshotEnvelope ? createInstance(entityClass, entitySnapshotEnvelope.value) : undefined
   }
 
   /**

--- a/packages/framework-core/test/booster.test.ts
+++ b/packages/framework-core/test/booster.test.ts
@@ -210,7 +210,7 @@ describe('the `Booster` class', () => {
       config.provider = {} as ProviderLibrary
 
       it('the `entity` function calls to the `fetchEntitySnapshot` method in the EventStore', async () => {
-        replace(EventStore.prototype, 'fetchEntitySnapshot', fake.returns({ id: '42' }))
+        replace(EventStore.prototype, 'fetchEntitySnapshot', fake.returns({ value: { id: '42' } }))
 
         class SomeEntity {
           public constructor(readonly id: UUID) {}


### PR DESCRIPTION
## Description
Closes #896 
Closes #918 
Currently, Booster.entity returns a `EventEnvelope` when it should actually return the `Entity`.

## Changes
Changes src/booster.ts:149 from `createInstance(entityClass, entitySnapshotEnvelope)` to `createInstance(entityClass, entitySnapshotEnvelope.value)`

Changes tests/booster.test.ts:213 from `replace(EventStore.prototype, 'fetchEntitySnapshot', fake.returns({  id: '42'  }))` to `replace(EventStore.prototype, 'fetchEntitySnapshot', fake.returns({ value: { id: '42' } }))` to fix core tests

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
 
## Additional information
