### PR TITLE
fix: Improve missing *-infrastructure error message

### DIFF
--- a/packages/framework-provider-aws/src/setup.ts
+++ b/packages/framework-provider-aws/src/setup.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ProviderInfrastructure, ProviderLibrary, RocketDescriptor } from '@boostercloud/framework-types'
+import { HasInfrastructure, ProviderLibrary, RocketDescriptor } from '@boostercloud/framework-types'
 import { DynamoDB } from 'aws-sdk'
 import { requestFailed, requestSucceeded } from './library/api-gateway-io'
 import {
@@ -37,10 +37,6 @@ const dynamoDB: DynamoDB.DocumentClient = new DynamoDB.DocumentClient({
     timeout: 2000,
   },
 })
-
-interface HasInfrastructure {
-  Infrastructure: (rockets?: RocketDescriptor[]) => ProviderInfrastructure
-}
 
 /* We load the infrastructure package dynamically here to avoid including it in the
  * dependencies that are deployed in the lambda functions. The infrastructure

--- a/packages/framework-provider-azure/src/index.ts
+++ b/packages/framework-provider-azure/src/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ProviderInfrastructure, ProviderLibrary, RocketDescriptor } from '@boostercloud/framework-types'
+import { HasInfrastructure, ProviderLibrary } from '@boostercloud/framework-types'
 import { requestFailed, requestSucceeded } from './library/api-adapter'
 import { rawGraphQLRequestToEnvelope } from './library/graphql-adapter'
 import {
@@ -18,10 +18,6 @@ if (typeof process.env[environmentVarNames.cosmosDbConnectionString] === 'undefi
   cosmosClient = {} as any
 } else {
   cosmosClient = new CosmosClient(process.env[environmentVarNames.cosmosDbConnectionString] as string)
-}
-
-interface HasInfrastructure {
-  Infrastructure: (rockets?: RocketDescriptor[]) => ProviderInfrastructure
 }
 
 /* We load the infrastructure package dynamically here to avoid including it in the

--- a/packages/framework-provider-kubernetes/src/index.ts
+++ b/packages/framework-provider-kubernetes/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ProviderInfrastructure, ProviderLibrary, UserApp, RocketDescriptor } from '@boostercloud/framework-types'
+import { HasInfrastructure, ProviderLibrary, UserApp } from '@boostercloud/framework-types'
 import { EventRegistry } from './services/event-registry'
 import { ReadModelRegistry } from './services/read-model-registry'
 import * as EventsAdapter from './library/events-adapter'
@@ -18,10 +18,6 @@ const eventRegistry = new EventRegistry(storageUrl)
 const readModelRegistry = new ReadModelRegistry(storageUrl)
 const userApp: UserApp = require(path.join(process.cwd(), 'dist', 'index.js'))
 const redisDB = RedisAdapter.build()
-
-interface HasInfrastructure {
-  Infrastructure: (rockets?: RocketDescriptor[]) => ProviderInfrastructure
-}
 
 /* We load the infrastructure package dynamically here to avoid including it in the
  * dependencies that are deployed in the lambda functions. The infrastructure

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -1,4 +1,4 @@
-import { ProviderLibrary, ProviderInfrastructure, UserApp, RocketDescriptor } from '@boostercloud/framework-types'
+import { HasInfrastructure, ProviderLibrary, UserApp } from '@boostercloud/framework-types'
 import {
   rawEventsToEnvelopes,
   readEntityEventsSince,
@@ -24,10 +24,6 @@ export * from './services'
 const eventRegistry = new EventRegistry()
 const readModelRegistry = new ReadModelRegistry()
 const userApp: UserApp = require(path.join(process.cwd(), 'dist', 'index.js'))
-
-interface HasInfrastructure {
-  Infrastructure: (rockets?: RocketDescriptor[]) => ProviderInfrastructure
-}
 
 /* We load the infrastructure package dynamically here to avoid including it in the
  * dependencies that are deployed in the lambda functions. The infrastructure

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -15,6 +15,7 @@ import {
 import { Logger } from './logger'
 import { FilterFor } from './searcher'
 import { ReadOnlyNonEmptyArray } from './typelevel'
+import { RocketDescriptor } from './rocket-descriptor'
 
 export interface ProviderLibrary {
   events: ProviderEventsLibrary
@@ -119,4 +120,8 @@ export interface ProviderInfrastructure {
 
 export interface ScheduledCommandsLibrary {
   rawToEnvelope(rawMessage: unknown, logger: Logger): Promise<ScheduledCommandEnvelope>
+}
+
+export interface HasInfrastructure {
+  Infrastructure: (rockets?: RocketDescriptor[]) => ProviderInfrastructure
 }


### PR DESCRIPTION
## Description
This PR will make error message about missing `*-infrastructure` package consistent for each provider

Fixes #871

## Changes
- Added same error message to each provider
- Fixed typo
- Added new `HasInfrastructure` interface

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~- [ ] Updated documentation accordingly~