### PR TITLE
feat(azure): Add Azure Scheduled Commands support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
 				"eslint-config-prettier": "8.3.0",
 				"eslint-plugin-import": "2.22.1",
 				"eslint-plugin-prettier": "3.4.0",
+				"has-tostringtag": "^1.0.0",
 				"husky": "6.0.0",
 				"lerna": "4.0.0",
 				"lint-staged": "11.0.0",
@@ -2124,34 +2125,14 @@
 			}
 		},
 		"node_modules/@boostercloud/framework-common-helpers": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.21.3.tgz",
-			"integrity": "sha512-YkH6kUXeguSI4Og2xsT90DMsec1ja5rG+AtbtYR/j7kKsLxFIH2TRJZZXWg7Z0Q7NoC/KRygqKfsjO6RQL5JMA==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.21.4.tgz",
+			"integrity": "sha512-8Tu+S9cjn9tThJIIsO0a9/6Z1C3IThxuGGgqtmYE7UkW+yoN0sxD23nNXUs0q3QaMD0EEn7s+ixY/MINw2S8pA==",
 			"dev": true,
 			"dependencies": {
-				"@boostercloud/framework-types": "^0.21.3",
+				"@boostercloud/framework-types": "^0.21.4",
+				"child-process-promise": "^2.2.1",
 				"tslib": "2.3.0"
-			}
-		},
-		"node_modules/@boostercloud/framework-core": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-core/-/framework-core-0.21.3.tgz",
-			"integrity": "sha512-iGAVXB/Z8TthQusYpc3hc7NiF6+hm21iKwfnfskGTDEIwBlG2hI6FZ3/2d6pIeH2tfCTuM5cCZ8xb5cj8jVjjw==",
-			"dev": true,
-			"dependencies": {
-				"@boostercloud/framework-common-helpers": "^0.21.3",
-				"@boostercloud/framework-types": "^0.21.3",
-				"fp-ts": "2.10.5",
-				"graphql": "^15.5.1",
-				"graphql-subscriptions": "1.2.1",
-				"graphql-type-json": "0.3.2",
-				"inflected": "2.1.0",
-				"iterall": "1.3.0",
-				"jsonwebtoken": "8.5.1",
-				"jwks-rsa": "2.0.3",
-				"reflect-metadata": "0.1.13",
-				"tslib": "2.3.0",
-				"validator": "13.6.0"
 			}
 		},
 		"node_modules/@boostercloud/framework-provider-local": {
@@ -2159,9 +2140,9 @@
 			"link": true
 		},
 		"node_modules/@boostercloud/framework-types": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.21.3.tgz",
-			"integrity": "sha512-x+QCru9xMWYbaJgiekEqbUe99yuEfQogV1kPvkXbh+Cwx/mMR2DwNYM/qA7/ks1ZLWd8I0VgUkJroSvhzJwYEw==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.21.4.tgz",
+			"integrity": "sha512-k6eZ6LC5P73Rdd6Hy9RzapKcBUytbbMmTjM4fAQqltTNiaPsZH7KQNCzY6Vcnx6JH4sABnI8Q0uVVqbUorYPZw==",
 			"dev": true,
 			"dependencies": {
 				"@types/graphql": "14.5.0",
@@ -14894,9 +14875,9 @@
 			}
 		},
 		"node_modules/has-symbols": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
@@ -14914,6 +14895,22 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-unicode": {
@@ -26042,13 +26039,12 @@
 		},
 		"packages/framework-provider-local": {
 			"name": "@boostercloud/framework-provider-local",
-			"version": "0.21.3",
+			"version": "0.21.4",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@boostercloud/framework-common-helpers": "^0.21.3",
-				"@boostercloud/framework-core": "^0.21.3",
-				"@boostercloud/framework-types": "^0.21.3",
+				"@boostercloud/framework-common-helpers": "^0.21.4",
+				"@boostercloud/framework-types": "^0.21.4",
 				"@types/nedb": "^1.8.11",
 				"nedb": "^1.8.0",
 				"tslib": "2.3.0"
@@ -27301,42 +27297,21 @@
 			}
 		},
 		"@boostercloud/framework-common-helpers": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.21.3.tgz",
-			"integrity": "sha512-YkH6kUXeguSI4Og2xsT90DMsec1ja5rG+AtbtYR/j7kKsLxFIH2TRJZZXWg7Z0Q7NoC/KRygqKfsjO6RQL5JMA==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.21.4.tgz",
+			"integrity": "sha512-8Tu+S9cjn9tThJIIsO0a9/6Z1C3IThxuGGgqtmYE7UkW+yoN0sxD23nNXUs0q3QaMD0EEn7s+ixY/MINw2S8pA==",
 			"dev": true,
 			"requires": {
-				"@boostercloud/framework-types": "^0.21.3",
+				"@boostercloud/framework-types": "^0.21.4",
+				"child-process-promise": "^2.2.1",
 				"tslib": "2.3.0"
-			}
-		},
-		"@boostercloud/framework-core": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-core/-/framework-core-0.21.3.tgz",
-			"integrity": "sha512-iGAVXB/Z8TthQusYpc3hc7NiF6+hm21iKwfnfskGTDEIwBlG2hI6FZ3/2d6pIeH2tfCTuM5cCZ8xb5cj8jVjjw==",
-			"dev": true,
-			"requires": {
-				"@boostercloud/framework-common-helpers": "^0.21.3",
-				"@boostercloud/framework-types": "^0.21.3",
-				"fp-ts": "2.10.5",
-				"graphql": "^15.5.1",
-				"graphql-subscriptions": "1.2.1",
-				"graphql-type-json": "0.3.2",
-				"inflected": "2.1.0",
-				"iterall": "1.3.0",
-				"jsonwebtoken": "8.5.1",
-				"jwks-rsa": "2.0.3",
-				"reflect-metadata": "0.1.13",
-				"tslib": "2.3.0",
-				"validator": "13.6.0"
 			}
 		},
 		"@boostercloud/framework-provider-local": {
 			"version": "file:packages/framework-provider-local",
 			"requires": {
-				"@boostercloud/framework-common-helpers": "^0.21.3",
-				"@boostercloud/framework-core": "^0.21.3",
-				"@boostercloud/framework-types": "^0.21.3",
+				"@boostercloud/framework-common-helpers": "^0.21.4",
+				"@boostercloud/framework-types": "^0.21.4",
 				"@types/express": "4.17.12",
 				"@types/faker": "5.1.5",
 				"@types/nedb": "^1.8.11",
@@ -27351,10 +27326,9 @@
 			}
 		},
 		"@boostercloud/framework-types": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.21.3.tgz",
-			"integrity": "sha512-x+QCru9xMWYbaJgiekEqbUe99yuEfQogV1kPvkXbh+Cwx/mMR2DwNYM/qA7/ks1ZLWd8I0VgUkJroSvhzJwYEw==",
-			"dev": true,
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.21.4.tgz",
+			"integrity": "sha512-k6eZ6LC5P73Rdd6Hy9RzapKcBUytbbMmTjM4fAQqltTNiaPsZH7KQNCzY6Vcnx6JH4sABnI8Q0uVVqbUorYPZw=="
 			"requires": {
 				"@types/graphql": "14.5.0",
 				"tslib": "2.3.0",
@@ -37960,10 +37934,9 @@
 			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
 		},
 		"has-symbols": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
 		},
 		"has-to-string-tag-x": {
 			"version": "1.4.1",
@@ -37971,6 +37944,14 @@
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
 			"requires": {
 				"has-symbol-support-x": "^1.4.1"
+			}
+		},
+		"has-tostringtag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"requires": {
+				"has-symbols": "^1.0.2"
 			}
 		},
 		"has-unicode": {

--- a/packages/framework-provider-azure-infrastructure/package.json
+++ b/packages/framework-provider-azure-infrastructure/package.json
@@ -33,7 +33,11 @@
     "ms-rest-azure": "^3.0.0",
     "mustache": "4.1.0",
     "needle": "^2.5.0",
-    "uuid": "8.3.2"
+    "uuid": "8.3.2",
+    "chai": "4.2.0",
+    "chai-as-promised": "7.1.1",
+    "mocha": "8.4.0",
+    "sinon-chai": "3.5.0"
   },
   "scripts": {
     "format": "prettier --write --ext '.js,.ts' **/*.ts **/*/*.ts",

--- a/packages/framework-provider-azure-infrastructure/src/index.ts
+++ b/packages/framework-provider-azure-infrastructure/src/index.ts
@@ -1,6 +1,5 @@
 import { deploy, nuke } from './infrastructure'
 import { BoosterConfig, Logger, ProviderInfrastructure, RocketDescriptor } from '@boostercloud/framework-types'
-export * from './test-helper/azure-test-helper'
 
 export const Infrastructure = (rocketDescriptors?: RocketDescriptor[]): ProviderInfrastructure => {
   return {

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/application-stack.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/application-stack.ts
@@ -7,6 +7,9 @@ import { EventsStack } from './events-stack'
 import { ReadModelsStack } from './read-models-stack'
 import { DeploymentExtended } from 'azure-arm-resource/lib/resource/models'
 import { armTemplates } from '../arm-templates'
+import { GraphqlFunction } from './graphql-function'
+import { EventHandlerFunction } from './event-handler-function'
+import { SchedulesFunctions } from './schedules-functions'
 
 export class ApplicationStackBuilder {
   public constructor(readonly config: BoosterConfig) {}
@@ -92,48 +95,14 @@ export class ApplicationStackBuilder {
     )
 
     logger.info('Packaging Booster project for deployment...')
-    const zipPath = await packageAzureFunction([
-      {
-        name: 'graphql',
-        config: {
-          bindings: [
-            {
-              authLevel: 'anonymous',
-              type: 'httpTrigger',
-              direction: 'in',
-              name: 'rawRequest',
-              methods: ['post'],
-            },
-            {
-              type: 'http',
-              direction: 'out',
-              name: '$return',
-            },
-          ],
-          scriptFile: '../dist/index.js',
-          entryPoint: this.config.serveGraphQLHandler.split('.')[1],
-        },
-      },
-      {
-        name: 'eventHandler',
-        config: {
-          bindings: [
-            {
-              type: 'cosmosDBTrigger',
-              name: 'rawEvent',
-              direction: 'in',
-              leaseCollectionName: 'leases',
-              connectionStringSetting: 'COSMOSDB_CONNECTION_STRING',
-              databaseName: this.config.resourceNames.applicationStack,
-              collectionName: this.config.resourceNames.eventsStore,
-              createLeaseCollectionIfNotExists: 'true',
-            },
-          ],
-          scriptFile: '../dist/index.js',
-          entryPoint: this.config.eventDispatcherHandler.split('.')[1],
-        },
-      },
-    ])
+    const graphqlFunctionDefinition = new GraphqlFunction(this.config).getFunctionDefinition()
+    const eventHandlerFunctionDefinition = new EventHandlerFunction(this.config).getFunctionDefinition()
+    let featuresDefinitions = [graphqlFunctionDefinition, eventHandlerFunctionDefinition]
+    const schedulesFunctionsDefinition = new SchedulesFunctions(this.config).getFunctionDefinitions()
+    if (schedulesFunctionsDefinition) {
+      featuresDefinitions = featuresDefinitions.concat(schedulesFunctionsDefinition)
+    }
+    const zipPath = await packageAzureFunction(featuresDefinitions)
 
     logger.info('Deploying Zip...')
     await deployFunctionPackage(

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/event-handler-function.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/event-handler-function.ts
@@ -1,0 +1,28 @@
+import { BoosterConfig } from '@boostercloud/framework-types'
+import { FunctionDefinition } from '../types/functionDefinition'
+
+export class EventHandlerFunction {
+  public constructor(readonly config: BoosterConfig) {}
+
+  public getFunctionDefinition(): FunctionDefinition {
+    return {
+      name: 'eventHandler',
+      config: {
+        bindings: [
+          {
+            type: 'cosmosDBTrigger',
+            name: 'rawEvent',
+            direction: 'in',
+            leaseCollectionName: 'leases',
+            connectionStringSetting: 'COSMOSDB_CONNECTION_STRING',
+            databaseName: this.config.resourceNames.applicationStack,
+            collectionName: this.config.resourceNames.eventsStore,
+            createLeaseCollectionIfNotExists: 'true',
+          },
+        ],
+        scriptFile: '../dist/index.js',
+        entryPoint: this.config.eventDispatcherHandler.split('.')[1],
+      },
+    }
+  }
+}

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/event-handler-function.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/event-handler-function.ts
@@ -1,10 +1,10 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
-import { FunctionDefinition } from '../types/functionDefinition'
+import { EventHandlerFunctionDefinition } from '../types/functionDefinition'
 
 export class EventHandlerFunction {
   public constructor(readonly config: BoosterConfig) {}
 
-  public getFunctionDefinition(): FunctionDefinition {
+  public getFunctionDefinition(): EventHandlerFunctionDefinition {
     return {
       name: 'eventHandler',
       config: {

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/graphql-function.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/graphql-function.ts
@@ -1,0 +1,30 @@
+import { BoosterConfig } from '@boostercloud/framework-types'
+import { FunctionDefinition } from '../types/functionDefinition'
+
+export class GraphqlFunction {
+  public constructor(readonly config: BoosterConfig) {}
+
+  public getFunctionDefinition(): FunctionDefinition {
+    return {
+      name: 'graphql',
+      config: {
+        bindings: [
+          {
+            authLevel: 'anonymous',
+            type: 'httpTrigger',
+            direction: 'in',
+            name: 'rawRequest',
+            methods: ['post'],
+          },
+          {
+            type: 'http',
+            direction: 'out',
+            name: '$return',
+          },
+        ],
+        scriptFile: '../dist/index.js',
+        entryPoint: this.config.serveGraphQLHandler.split('.')[1],
+      },
+    }
+  }
+}

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/graphql-function.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/graphql-function.ts
@@ -1,10 +1,10 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
-import { FunctionDefinition } from '../types/functionDefinition'
+import { GraphQLFunctionDefinition } from '../types/functionDefinition'
 
 export class GraphqlFunction {
   public constructor(readonly config: BoosterConfig) {}
 
-  public getFunctionDefinition(): FunctionDefinition {
+  public getFunctionDefinition(): GraphQLFunctionDefinition {
     return {
       name: 'graphql',
       config: {

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/schedules-functions.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/schedules-functions.ts
@@ -10,15 +10,13 @@ export class SchedulesFunctions {
   public constructor(readonly config: BoosterConfig) {}
 
   public getFunctionDefinitions(): Array<FunctionDefinition> | undefined {
-    if (Object.keys(this.config.scheduledCommandHandlers).length) {
-      return Object.keys(this.config.scheduledCommandHandlers)
-        .map((scheduledCommandName) => this.buildScheduledCommandInfo(scheduledCommandName))
-        .filter((scheduledCommandInfo) => !SchedulesFunctions.isEmpty(scheduledCommandInfo.metadata.scheduledOn))
-        .map((scheduledCommandInfo) =>
-          this.scheduledCommandInfoToTimeTriggerFunction(scheduledCommandInfo)
-        ) as Array<FunctionDefinition>
-    }
-    return undefined
+    if (SchedulesFunctions.isEmpty(this.config.scheduledCommandHandlers)) return
+    return Object.keys(this.config.scheduledCommandHandlers)
+      .map((scheduledCommandName) => this.buildScheduledCommandInfo(scheduledCommandName))
+      .filter((scheduledCommandInfo) => !SchedulesFunctions.isEmpty(scheduledCommandInfo.metadata.scheduledOn))
+      .map((scheduledCommandInfo) =>
+        this.scheduledCommandInfoToTimeTriggerFunction(scheduledCommandInfo)
+      ) as Array<FunctionDefinition>
   }
 
   private scheduledCommandInfoToTimeTriggerFunction(
@@ -42,7 +40,7 @@ export class SchedulesFunctions {
     }
   }
 
-  private static isEmpty(value: ScheduleInterface): boolean {
+  private static isEmpty(value: Record<string, unknown> | ScheduleInterface): boolean {
     return !Object.keys(value).length
   }
 

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/schedules-functions.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/schedules-functions.ts
@@ -1,0 +1,61 @@
+import { BoosterConfig, ScheduleInterface } from '@boostercloud/framework-types'
+import { FunctionDefinition } from '../types/functionDefinition'
+
+interface TimeTriggerFunction {
+  name: string
+  config: {
+    bindings: [
+      {
+        type: string
+        name: string
+        direction: string
+        schedule: string
+      }
+    ]
+    scriptFile: string
+    entryPoint: string
+  }
+}
+
+export class SchedulesFunctions {
+  public constructor(readonly config: BoosterConfig) {}
+
+  public getFunctionDefinitions(): Array<FunctionDefinition> | undefined {
+    if (Object.keys(this.config.scheduledCommandHandlers).length) {
+      return Object.keys(this.config.scheduledCommandHandlers).map((scheduledCommandName) => {
+        const scheduledCommandMetadata = this.config.scheduledCommandHandlers[scheduledCommandName]
+        const cronExpression = SchedulesFunctions.createCronExpression(scheduledCommandMetadata.scheduledOn)
+        return {
+          name: `scheduleFunction-${scheduledCommandName}`,
+          config: {
+            bindings: [
+              {
+                type: 'timerTrigger',
+                name: `${scheduledCommandName}`,
+                direction: 'in',
+                schedule: `${cronExpression}`,
+              },
+            ],
+            scriptFile: '../dist/index.js',
+            entryPoint: this.config.scheduledTaskHandler.split('.')[1],
+          },
+        } as TimeTriggerFunction
+      }) as Array<FunctionDefinition>
+    }
+    return undefined
+  }
+
+  /**
+   * Azure Functions uses the NCronTab library to interpret NCRONTAB expressions.
+   * An NCRONTAB expression is similar to a CRON expression except that it includes an additional sixth field at the beginning to use for time precision in seconds:
+   * {second} {minute} {hour} {day} {month} {day-of-week}
+   * @param scheduledCommandMetadata
+   * @private
+   */
+  private static createCronExpression(scheduledCommandMetadata: ScheduleInterface): string {
+    const { minute = '*', hour = '*', day = '*', month = '*', weekDay = '*' } = scheduledCommandMetadata
+    const expression = `0 ${minute} ${hour} ${day} ${month} ${weekDay}`
+    const neverRunByDefault = '0 0 5 31 2 ? *'
+    return `${expression !== '* * * ? * *' ? expression : neverRunByDefault}`
+  }
+}

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/schedules-functions.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/stacks/schedules-functions.ts
@@ -54,8 +54,6 @@ export class SchedulesFunctions {
    */
   private static createCronExpression(scheduledCommandMetadata: ScheduleInterface): string {
     const { minute = '*', hour = '*', day = '*', month = '*', weekDay = '*' } = scheduledCommandMetadata
-    const expression = `0 ${minute} ${hour} ${day} ${month} ${weekDay}`
-    const neverRunByDefault = '0 0 5 31 2 ? *'
-    return `${expression !== '* * * ? * *' ? expression : neverRunByDefault}`
+    return `0 ${minute} ${hour} ${day} ${month} ${weekDay}`
   }
 }

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/types/functionDefinition.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/types/functionDefinition.ts
@@ -1,0 +1,4 @@
+export interface FunctionDefinition {
+  name: string
+  config: object
+}

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/types/functionDefinition.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/types/functionDefinition.ts
@@ -1,4 +1,37 @@
-export interface FunctionDefinition {
+export interface IBinding {
+  type: string
   name: string
-  config: object
+  direction: string
 }
+
+export interface IScheduleBinding extends IBinding {
+  schedule: string
+}
+
+export interface IGraphQLBinding extends IBinding {
+  authLevel?: string
+  methods?: Array<string>
+}
+
+export interface IEventHandlerBinding extends IBinding {
+  leaseCollectionName: string
+  connectionStringSetting: string
+  databaseName: string
+  collectionName: string
+  createLeaseCollectionIfNotExists: string
+}
+
+export interface FunctionDefinition<T extends IBinding = IBinding> {
+  name: string
+  config: {
+    bindings: Array<T>
+    scriptFile: string
+    entryPoint: string
+  }
+}
+
+export type ScheduleFunctionDefinition = FunctionDefinition<IScheduleBinding>
+
+export type GraphQLFunctionDefinition = FunctionDefinition<IGraphQLBinding>
+
+export type EventHandlerFunctionDefinition = FunctionDefinition<IEventHandlerBinding>

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/types/functionDefinition.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/types/functionDefinition.ts
@@ -1,19 +1,19 @@
-export interface IBinding {
+export interface Binding {
   type: string
   name: string
   direction: string
 }
 
-export interface IScheduleBinding extends IBinding {
+export type ScheduleBinding = Binding & {
   schedule: string
 }
 
-export interface IGraphQLBinding extends IBinding {
+export type GraphQLBinding = Binding & {
   authLevel?: string
   methods?: Array<string>
 }
 
-export interface IEventHandlerBinding extends IBinding {
+export type EventHandlerBinding = Binding & {
   leaseCollectionName: string
   connectionStringSetting: string
   databaseName: string
@@ -21,7 +21,7 @@ export interface IEventHandlerBinding extends IBinding {
   createLeaseCollectionIfNotExists: string
 }
 
-export interface FunctionDefinition<T extends IBinding = IBinding> {
+export interface FunctionDefinition<T extends Binding = Binding> {
   name: string
   config: {
     bindings: Array<T>
@@ -30,8 +30,8 @@ export interface FunctionDefinition<T extends IBinding = IBinding> {
   }
 }
 
-export type ScheduleFunctionDefinition = FunctionDefinition<IScheduleBinding>
+export type ScheduleFunctionDefinition = FunctionDefinition<ScheduleBinding>
 
-export type GraphQLFunctionDefinition = FunctionDefinition<IGraphQLBinding>
+export type GraphQLFunctionDefinition = FunctionDefinition<GraphQLBinding>
 
-export type EventHandlerFunctionDefinition = FunctionDefinition<IEventHandlerBinding>
+export type EventHandlerFunctionDefinition = FunctionDefinition<EventHandlerBinding>

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/utils.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/utils.ts
@@ -7,11 +7,7 @@ import * as uuid from 'uuid'
 import * as path from 'path'
 import * as archiver from 'archiver'
 import * as needle from 'needle'
-
-interface FunctionDefinition {
-  name: string
-  config: object
-}
+import { FunctionDefinition } from './types/functionDefinition'
 
 /**
  * Deploys an Azure resource to a resource group.

--- a/packages/framework-provider-azure-infrastructure/test/expect.ts
+++ b/packages/framework-provider-azure-infrastructure/test/expect.ts
@@ -1,0 +1,6 @@
+import * as chai from 'chai'
+
+chai.use(require('sinon-chai'))
+chai.use(require('chai-as-promised'))
+
+export const expect = chai.expect

--- a/packages/framework-provider-azure-infrastructure/test/infrastructure/stacks/event-handler-functions.test.ts
+++ b/packages/framework-provider-azure-infrastructure/test/infrastructure/stacks/event-handler-functions.test.ts
@@ -1,0 +1,26 @@
+import { expect } from '../../expect'
+import { BoosterConfig } from '@boostercloud/framework-types'
+import { describe } from 'mocha'
+import { EventHandlerFunction } from '../../../src/infrastructure/stacks/event-handler-function'
+
+describe('Creating event-handler-functions', () => {
+  const config = new BoosterConfig('test')
+  config.resourceNames.applicationStack = 'applicationStack'
+  config.resourceNames.eventsStore = 'eventsStore'
+
+  it('create the expected EventHandlerFunctionDefiniton', () => {
+    const definition = new EventHandlerFunction(config).getFunctionDefinition()
+    expect(definition).not.to.be.null
+    expect(definition.name).to.be.equal('eventHandler')
+    expect(definition.config.bindings[0].type).to.be.equal('cosmosDBTrigger')
+    expect(definition.config.bindings[0].name).to.be.equal('rawEvent')
+    expect(definition.config.bindings[0].direction).to.be.equal('in')
+    expect(definition.config.bindings[0].leaseCollectionName).to.be.equal('leases')
+    expect(definition.config.bindings[0].connectionStringSetting).to.be.equal('COSMOSDB_CONNECTION_STRING')
+    expect(definition.config.bindings[0].databaseName).to.be.equal('new-booster-app-app')
+    expect(definition.config.bindings[0].collectionName).to.be.equal('new-booster-app-app-events-store')
+    expect(definition.config.bindings[0].createLeaseCollectionIfNotExists).to.be.equal('true')
+    expect(definition.config.scriptFile).to.be.equal('../dist/index.js')
+    expect(definition.config.entryPoint).to.be.equal('boosterEventDispatcher')
+  })
+})

--- a/packages/framework-provider-azure-infrastructure/test/infrastructure/stacks/graphql-functions.test.ts
+++ b/packages/framework-provider-azure-infrastructure/test/infrastructure/stacks/graphql-functions.test.ts
@@ -1,0 +1,27 @@
+import { expect } from '../../expect'
+import { BoosterConfig } from '@boostercloud/framework-types'
+import { describe } from 'mocha'
+import { GraphqlFunction } from '../../../src/infrastructure/stacks/graphql-function'
+
+describe('Creating graphql-functions', () => {
+  const config = new BoosterConfig('test')
+  config.resourceNames.applicationStack = 'applicationStack'
+  config.resourceNames.eventsStore = 'eventsStore'
+
+  it('create the expected GraphQLFunctionDefiniton', () => {
+    const definition = new GraphqlFunction(config).getFunctionDefinition()
+    expect(definition).not.to.be.null
+    expect(definition.name).to.be.equal('graphql')
+    expect(definition.config.bindings[0].type).to.be.equal('httpTrigger')
+    expect(definition.config.bindings[0].name).to.be.equal('rawRequest')
+    expect(definition.config.bindings[0].direction).to.be.equal('in')
+    expect(definition.config.bindings[0].authLevel).to.be.equal('anonymous')
+    expect(definition.config.bindings[0]?.methods?.length).to.be.equal(1)
+    expect(definition.config.bindings[0].methods?.pop()).to.be.equal('post')
+    expect(definition.config.bindings[1].type).to.be.equal('http')
+    expect(definition.config.bindings[1].name).to.be.equal('$return')
+    expect(definition.config.bindings[1].direction).to.be.equal('out')
+    expect(definition.config.scriptFile).to.be.equal('../dist/index.js')
+    expect(definition.config.entryPoint).to.be.equal('boosterServeGraphQL')
+  })
+})

--- a/packages/framework-provider-azure-infrastructure/test/infrastructure/stacks/schedules-functions.test.ts
+++ b/packages/framework-provider-azure-infrastructure/test/infrastructure/stacks/schedules-functions.test.ts
@@ -4,7 +4,7 @@ import { BoosterConfig, ScheduledCommandInterface, ScheduleInterface } from '@bo
 import { describe } from 'mocha'
 import { ScheduleFunctionDefinition } from '../../../src/infrastructure/types/functionDefinition'
 
-describe('Creating schedules-functions', () => {
+describe('Creating scheduled-functions', () => {
   describe('without scheduledCommandHandlers', () => {
     const config = new BoosterConfig('test')
 

--- a/packages/framework-provider-azure-infrastructure/test/infrastructure/stacks/schedules-functions.test.ts
+++ b/packages/framework-provider-azure-infrastructure/test/infrastructure/stacks/schedules-functions.test.ts
@@ -1,0 +1,117 @@
+import { expect } from '../../expect'
+import { SchedulesFunctions } from '../../../src/infrastructure/stacks/schedules-functions'
+import { BoosterConfig, ScheduledCommandInterface, ScheduleInterface } from '@boostercloud/framework-types'
+import { describe } from 'mocha'
+import { ScheduleFunctionDefinition } from '../../../src/infrastructure/types/functionDefinition'
+
+describe('Creating schedules-functions', () => {
+  describe('without scheduledCommandHandlers', () => {
+    const config = new BoosterConfig('test')
+
+    it('is an undefined object', async () => {
+      const definitions = new SchedulesFunctions(config).getFunctionDefinitions()
+      expect(definitions).to.be.undefined
+    })
+  })
+
+  describe('with one scheduledCommandHandlers', () => {
+    const config = new BoosterConfig('test')
+    const scheduleCommandInterface = {} as ScheduledCommandInterface
+    const scheduleInterface = { day: '1' } as ScheduleInterface
+
+    const scheduleCommandName = 'test'
+    config.scheduledCommandHandlers[scheduleCommandName] = {
+      class: scheduleCommandInterface,
+      scheduledOn: scheduleInterface,
+    }
+
+    it('is one definition with the proper fields', () => {
+      const definitions = new SchedulesFunctions(config).getFunctionDefinitions() as Array<ScheduleFunctionDefinition>
+      expect(definitions).not.to.be.null
+      expect(definitions.length).to.be.equal(1)
+      expectDefinition(definitions[0], scheduleCommandName, '0 * * 1 * *')
+    })
+  })
+
+  describe('with two scheduledCommandHandlers', () => {
+    const config = new BoosterConfig('test')
+    const scheduleCommandInterface = {} as ScheduledCommandInterface
+    const scheduleInterface = { day: '1' } as ScheduleInterface
+
+    const scheduleCommandName1 = 'test-1'
+    config.scheduledCommandHandlers[scheduleCommandName1] = {
+      class: scheduleCommandInterface,
+      scheduledOn: scheduleInterface,
+    }
+
+    const scheduleCommandName2 = 'test-2'
+    config.scheduledCommandHandlers[scheduleCommandName2] = {
+      class: scheduleCommandInterface,
+      scheduledOn: scheduleInterface,
+    }
+
+    it('is two definitions with the proper fields', () => {
+      const definitions = new SchedulesFunctions(config).getFunctionDefinitions() as Array<ScheduleFunctionDefinition>
+      expect(definitions).not.to.be.null
+      expect(definitions.length).to.be.equal(2)
+      expectDefinition(definitions[0], scheduleCommandName1, '0 * * 1 * *')
+      expectDefinition(definitions[1], scheduleCommandName2, '0 * * 1 * *')
+    })
+  })
+
+  describe('with all scheduled fields', () => {
+    const config = new BoosterConfig('test')
+    const scheduleCommandInterface = {} as ScheduledCommandInterface
+    const scheduleInterface = {
+      day: 'day',
+      hour: 'hour',
+      weekDay: 'weekDay',
+      minute: 'minute',
+      month: 'month',
+      year: 'year',
+    } as ScheduleInterface
+
+    const scheduleCommandName = 'test'
+    config.scheduledCommandHandlers[scheduleCommandName] = {
+      class: scheduleCommandInterface,
+      scheduledOn: scheduleInterface,
+    }
+
+    it('create the expected nCronTab', () => {
+      const definitions = new SchedulesFunctions(config).getFunctionDefinitions() as Array<ScheduleFunctionDefinition>
+      expectDefinition(definitions[0], scheduleCommandName, '0 minute hour day month weekDay')
+    })
+  })
+
+  describe('without scheduled fields', () => {
+    const config = new BoosterConfig('test')
+    const scheduleCommandInterface = {} as ScheduledCommandInterface
+    const scheduleInterface = {} as ScheduleInterface
+
+    const scheduleCommandName = 'test'
+    config.scheduledCommandHandlers[scheduleCommandName] = {
+      class: scheduleCommandInterface,
+      scheduledOn: scheduleInterface,
+    }
+
+    it('skip the function', () => {
+      const definitions = new SchedulesFunctions(config).getFunctionDefinitions() as Array<ScheduleFunctionDefinition>
+      expect(definitions.length).to.be.equal(0)
+    })
+  })
+
+  function expectDefinition(
+    definition: ScheduleFunctionDefinition,
+    scheduleCommandName: string,
+    nCronTabExpression = '0 * * * * *'
+  ) {
+    expect(definition.name).to.be.equal(`scheduleFunction-${scheduleCommandName}`)
+    expect(definition.config.bindings.length).to.be.equal(1)
+    expect(definition.config.bindings[0].type).to.be.equal('timerTrigger')
+    expect(definition.config.bindings[0].name).to.be.equal(scheduleCommandName)
+    expect(definition.config.bindings[0].direction).to.be.equal('in')
+    expect(definition.config.bindings[0].schedule).to.be.equal(nCronTabExpression)
+    expect(definition.config.scriptFile).to.be.equal('../dist/index.js')
+    expect(definition.config.entryPoint).to.be.equal('boosterTriggerScheduledCommand')
+  }
+})

--- a/packages/framework-provider-azure/src/index.ts
+++ b/packages/framework-provider-azure/src/index.ts
@@ -12,6 +12,7 @@ import { CosmosClient } from '@azure/cosmos'
 import { environmentVarNames } from './constants'
 import { fetchReadModel, storeReadModel } from './library/read-model-adapter'
 import { searchReadModel } from './library/searcher-adapter'
+import { rawScheduledInputToEnvelope } from './library/scheduled-adapter'
 
 let cosmosClient: CosmosClient
 if (typeof process.env[environmentVarNames.cosmosDbConnectionString] === 'undefined') {
@@ -67,7 +68,7 @@ export const Provider = (): ProviderLibrary => ({
   },
   // ScheduledCommandsLibrary
   scheduled: {
-    rawToEnvelope: undefined as any,
+    rawToEnvelope: rawScheduledInputToEnvelope,
   },
   // ProviderInfrastructureGetter
   infrastructure: () => {

--- a/packages/framework-provider-azure/src/library/scheduled-adapter.ts
+++ b/packages/framework-provider-azure/src/library/scheduled-adapter.ts
@@ -2,7 +2,7 @@ import { Logger, ScheduledCommandEnvelope, UUID } from '@boostercloud/framework-
 
 interface AzureScheduledCommandEnvelope {
   bindings: {
-    [name: string]: object
+    [name: string]: unknown
   }
 }
 

--- a/packages/framework-provider-azure/src/library/scheduled-adapter.ts
+++ b/packages/framework-provider-azure/src/library/scheduled-adapter.ts
@@ -1,0 +1,26 @@
+import { Logger, ScheduledCommandEnvelope, UUID } from '@boostercloud/framework-types'
+
+interface AzureScheduledCommandEnvelope {
+  bindings: {
+    [name: string]: object
+  }
+}
+
+export async function rawScheduledInputToEnvelope(
+  input: Partial<AzureScheduledCommandEnvelope>,
+  logger: Logger
+): Promise<ScheduledCommandEnvelope> {
+  logger.debug('Received AzureScheduledCommand request: ', input)
+
+  if (!input.bindings || !Object.keys(input.bindings).length)
+    throw new Error(
+      `bindings is not defined or empty, scheduled command envelope should have the structure {bindings: [name: string]: string }, but you gave ${JSON.stringify(
+        input
+      )}`
+    )
+
+  return {
+    requestID: UUID.generate(),
+    typeName: Object.keys(input.bindings)[0],
+  }
+}

--- a/packages/framework-provider-local-infrastructure/src/index.ts
+++ b/packages/framework-provider-local-infrastructure/src/index.ts
@@ -51,6 +51,6 @@ export const Infrastructure = (): ProviderInfrastructure => {
       expressServer.use(router)
       expressServer.use(defaultErrorHandler)
       expressServer.listen(port)
-  },
+    },
   }
 }


### PR DESCRIPTION
## Description
There’s a Scheduled Commands feature in AWS that takes a typical cron string and triggers a command on a schedule instead of making it wait for a request. This feature is now supported in Azure


## Changes

* Add PackageAzureFunction classes for: GraphQL, EventHandler and ScheduleCommands function
* Refactor Azure/ApplicationStackBuilder class
* Refactor Azure/FunctionDefinition
* Add Azure rawScheduledInputToEnvelope
* Update Azure Provider to include Azure/rawScheduledInputToEnvelope call


## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly

