### PR TITLE
fix(cli): print failed command

### DIFF
--- a/packages/cli/src/common/errors.ts
+++ b/packages/cli/src/common/errors.ts
@@ -1,3 +1,5 @@
+import Brand from './brand'
+
 /**
  * Builds an error extracting its message from the "stdout" and "stderr" properties if present
  * @param e
@@ -6,5 +8,5 @@
 export function wrapExecError(e: Error, prefix: string): Error {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { stdout, stderr } = e as any
-  return new Error(prefix + '\n' + stdout + stderr)
+  return new Error(Brand.dangerize(prefix) + '\n' + stdout + stderr)
 }

--- a/packages/cli/src/common/script.ts
+++ b/packages/cli/src/common/script.ts
@@ -55,7 +55,10 @@ export class Script<TContext> {
                 await action(ctx)
                 Script.logger.succeed(message)
               },
-              (err) => err as Error
+              (err) => {
+                Script.logger.fail(message)
+                return err as Error
+              }
             )
           )
         )

--- a/packages/cli/src/services/project-initializer.ts
+++ b/packages/cli/src/services/project-initializer.ts
@@ -14,6 +14,7 @@ import * as prettierRc from '../templates/project/prettierrc-yaml'
 import * as mochaRc from '../templates/project/mocharc-yml'
 import { wrapExecError } from '../common/errors'
 import { installAllDependencies } from './dependencies'
+import Brand from '../common/brand'
 
 export async function generateConfigFiles(config: ProjectInitializerConfig): Promise<void> {
   await Promise.all(filesToGenerate.map(renderToFile(config)))
@@ -42,7 +43,7 @@ export async function initializeGit(config: ProjectInitializerConfig): Promise<v
   try {
     await exec('git init && git add -A && git commit -m "Initial commit"', { cwd: projectDir(config) })
   } catch (e) {
-    throw wrapExecError(e, 'Could not initialize git repository')
+    throw wrapExecError(e, Brand.dangerize('Could not initialize git repository'))
   }
 }
 

--- a/packages/cli/src/services/project-initializer.ts
+++ b/packages/cli/src/services/project-initializer.ts
@@ -14,7 +14,6 @@ import * as prettierRc from '../templates/project/prettierrc-yaml'
 import * as mochaRc from '../templates/project/mocharc-yml'
 import { wrapExecError } from '../common/errors'
 import { installAllDependencies } from './dependencies'
-import Brand from '../common/brand'
 
 export async function generateConfigFiles(config: ProjectInitializerConfig): Promise<void> {
   await Promise.all(filesToGenerate.map(renderToFile(config)))
@@ -43,7 +42,7 @@ export async function initializeGit(config: ProjectInitializerConfig): Promise<v
   try {
     await exec('git init && git add -A && git commit -m "Initial commit"', { cwd: projectDir(config) })
   } catch (e) {
-    throw wrapExecError(e, Brand.dangerize('Could not initialize git repository'))
+    throw wrapExecError(e, 'Could not initialize git repository')
   }
 }
 


### PR DESCRIPTION
## Description
This PR should fix #637 issue and possibly other issues that might appear when CLI command is stuck

## Changes
- log `.fail` message if it fails (it will exit process and mark step as failed)
- colorize git initialization command error message

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~Updated documentation accordingly~

## Additional information
Fixes #637

<img width="548" alt="Screenshot 2021-11-03 at 15 41 22" src="https://user-images.githubusercontent.com/36774784/140070845-f15b4a53-450a-4899-907f-eb6c3824db72.png">

