### PR TITLE
Fail if env variable is not set on Azure integration tests

### DIFF
--- a/packages/framework-integration-tests/integration/helper/app-helper.ts
+++ b/packages/framework-integration-tests/integration/helper/app-helper.ts
@@ -12,7 +12,7 @@ export function applicationName(): string {
 
 export async function getProviderTestHelper(): Promise<ProviderTestHelper> {
   const provider = process.env.TESTED_PROVIDER
-  const environmentName = process.env.BOOSTER_ENV ?? 'azure'
+  const environmentName = checkAndGetCurrentEnv()
   const providerHelpers: Record<string, () => Promise<ProviderTestHelper>> = {
     AWS: () => AWSTestHelper.build(applicationName()),
     AZURE: () => AzureTestHelper.build(applicationName(), environmentName),
@@ -37,4 +37,14 @@ export async function setEnv(): Promise<void> {
     process.env['BOOSTER_APP_SUFFIX'] = stdout.trim().substring(0, 6)
     console.log('setting BOOSTER_APP_SUFFIX=' + process.env.BOOSTER_APP_SUFFIX)
   }
+}
+
+export function checkAndGetCurrentEnv(): string {
+  const env = process.env.BOOSTER_ENV
+  if (!env || env.trim().length == 0) {
+    throw new Error(
+      'Booster environment is missing. You need to provide an environment to configure your Booster project'
+    )
+  }
+  return env
 }

--- a/packages/framework-integration-tests/integration/provider-specific/azure/deployment/deployment.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-specific/azure/deployment/deployment.integration.ts
@@ -1,6 +1,6 @@
 import { AzureTestHelper } from '@boostercloud/framework-provider-azure-infrastructure'
 import { expect } from '../../../helper/expect'
-import { applicationName } from '../../../helper/app-helper'
+import { applicationName, checkAndGetCurrentEnv } from '../../../helper/app-helper'
 
 describe('After deployment', () => {
   describe('the ARM template', () => {
@@ -8,7 +8,7 @@ describe('After deployment', () => {
       // The project must have been deployed by the cliHelper hook in setup.ts
       // that scripts uses the cli to do the deployment, so we just check here
       // that the resource group exists
-      const environmentName = process.env.BOOSTER_ENV ?? 'azure'
+      const environmentName = checkAndGetCurrentEnv()
       await expect(AzureTestHelper.checkResourceGroup(applicationName(), environmentName)).to.be.eventually.fulfilled
     })
   })

--- a/packages/framework-integration-tests/integration/provider-specific/azure/nuke/nuke.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-specific/azure/nuke/nuke.integration.ts
@@ -1,11 +1,11 @@
 import { AzureTestHelper } from '@boostercloud/framework-provider-azure-infrastructure'
-import { applicationName } from '../../../helper/app-helper'
+import { applicationName, checkAndGetCurrentEnv } from '../../../helper/app-helper'
 import { expect } from '../../../helper/expect'
 
 describe('After nuke', () => {
   describe('the resource group', () => {
     it('is deleted successfully', async () => {
-      const environmentName = process.env.BOOSTER_ENV ?? 'azure'
+      const environmentName = checkAndGetCurrentEnv()
       await expect(
         AzureTestHelper.checkResourceGroup(applicationName(), environmentName)
       ).to.be.eventually.rejectedWith('ResourceGroupNotFound')


### PR DESCRIPTION
## Description
Improve Azure integration test

## Changes
Refactor BOOSTER_ENV check to fail if it's not set

## Checks
- [X] Project Builds
- [X] Project passes tests and checks

