### PR TITLE
Allow arrays of roles on jwt tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2741,12 +2741,12 @@
 			}
 		},
 		"node_modules/@boostercloud/framework-common-helpers": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.24.2.tgz",
-			"integrity": "sha512-cGwx+yQoeJuoKDcpb3pFG1QtaKxBB5f/3vYjddcQwfPB7wd9NTQlhA8LbwZgJkNBzClpQkILymTzb/4Sn4bFjQ==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.25.0.tgz",
+			"integrity": "sha512-9or9jDL8jX4M1Sz0zrqrT4A7PGbEU2zTblXJN+/cf8CKA0qOZbRYZ+fhhhllgR+xnznh8tD+C+ecNDyTpwUgIA==",
 			"dev": true,
 			"dependencies": {
-				"@boostercloud/framework-types": "^0.24.2",
+				"@boostercloud/framework-types": "^0.25.0",
 				"child-process-promise": "^2.2.1",
 				"tslib": "2.3.0"
 			}
@@ -2756,9 +2756,9 @@
 			"link": true
 		},
 		"node_modules/@boostercloud/framework-types": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.24.2.tgz",
-			"integrity": "sha512-kCV9ENbJlwJ7MbPgTAYfLema2VmPkq05df3zp9MwECpLjSm25QyKpSALlNa68d49BLV657WE43MVOojJAIzF8w==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.25.0.tgz",
+			"integrity": "sha512-IjEsekd8hFTbdlquAaU2XxdZCE7lmM0WTT0NWeVGkANNYRoU+rqQNxdHCQVWzM4JjzxxKZDf1PkaxhJ4SMVKSA==",
 			"dev": true,
 			"dependencies": {
 				"@types/graphql": "14.5.0",
@@ -21168,7 +21168,8 @@
 		"node_modules/lodash.truncate": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
+			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+			"dev": true
 		},
 		"node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -26213,6 +26214,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -29098,6 +29100,7 @@
 			"version": "6.8.0",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
 			"integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+			"dev": true,
 			"dependencies": {
 				"ajv": "^8.0.1",
 				"lodash.truncate": "^4.4.2",
@@ -29113,6 +29116,7 @@
 			"version": "8.9.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
 			"integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -29128,6 +29132,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -29142,6 +29147,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -29152,17 +29158,20 @@
 		"node_modules/table/node_modules/color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
 		},
 		"node_modules/table/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
 		},
 		"node_modules/table/node_modules/slice-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
 			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"astral-regex": "^2.0.0",
@@ -31296,12 +31305,13 @@
 			"integrity": "sha512-UzIwO92D0dSFwIRyyqAfRXICITLjF0IP8tRbEK/un7adirMssWZx8xF/1hZNE7t61knWZ+lhEuUvxlu2MO8qqA=="
 		},
 		"packages/framework-provider-local": {
-			"version": "0.24.2",
+			"name": "@boostercloud/framework-provider-local",
+			"version": "0.25.0",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@boostercloud/framework-common-helpers": "^0.24.2",
-				"@boostercloud/framework-types": "^0.24.2",
+				"@boostercloud/framework-common-helpers": "^0.25.0",
+				"@boostercloud/framework-types": "^0.25.0",
 				"@types/nedb": "^1.8.11",
 				"nedb": "^1.8.0",
 				"tslib": "2.3.0"
@@ -33025,12 +33035,12 @@
 			}
 		},
 		"@boostercloud/framework-common-helpers": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.24.2.tgz",
-			"integrity": "sha512-cGwx+yQoeJuoKDcpb3pFG1QtaKxBB5f/3vYjddcQwfPB7wd9NTQlhA8LbwZgJkNBzClpQkILymTzb/4Sn4bFjQ==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.25.0.tgz",
+			"integrity": "sha512-9or9jDL8jX4M1Sz0zrqrT4A7PGbEU2zTblXJN+/cf8CKA0qOZbRYZ+fhhhllgR+xnznh8tD+C+ecNDyTpwUgIA==",
 			"dev": true,
 			"requires": {
-				"@boostercloud/framework-types": "^0.24.2",
+				"@boostercloud/framework-types": "^0.25.0",
 				"child-process-promise": "^2.2.1",
 				"tslib": "2.3.0"
 			}
@@ -33038,8 +33048,8 @@
 		"@boostercloud/framework-provider-local": {
 			"version": "file:packages/framework-provider-local",
 			"requires": {
-				"@boostercloud/framework-common-helpers": "^0.24.2",
-				"@boostercloud/framework-types": "^0.24.2",
+				"@boostercloud/framework-common-helpers": "^0.25.0",
+				"@boostercloud/framework-types": "^0.25.0",
 				"@types/express": "4.17.12",
 				"@types/faker": "5.1.5",
 				"@types/nedb": "^1.8.11",
@@ -33054,9 +33064,9 @@
 			}
 		},
 		"@boostercloud/framework-types": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.24.2.tgz",
-			"integrity": "sha512-kCV9ENbJlwJ7MbPgTAYfLema2VmPkq05df3zp9MwECpLjSm25QyKpSALlNa68d49BLV657WE43MVOojJAIzF8w==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.25.0.tgz",
+			"integrity": "sha512-IjEsekd8hFTbdlquAaU2XxdZCE7lmM0WTT0NWeVGkANNYRoU+rqQNxdHCQVWzM4JjzxxKZDf1PkaxhJ4SMVKSA==",
 			"dev": true,
 			"requires": {
 				"@types/graphql": "14.5.0",
@@ -47814,7 +47824,8 @@
 		"lodash.truncate": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
+			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+			"dev": true
 		},
 		"lodash.union": {
 			"version": "4.6.0",
@@ -51736,7 +51747,8 @@
 		"require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "2.0.0",
@@ -54028,6 +54040,7 @@
 			"version": "6.8.0",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
 			"integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+			"dev": true,
 			"requires": {
 				"ajv": "^8.0.1",
 				"lodash.truncate": "^4.4.2",
@@ -54040,6 +54053,7 @@
 					"version": "8.9.0",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
 					"integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"json-schema-traverse": "^1.0.0",
@@ -54051,6 +54065,7 @@
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^2.0.1"
 					}
@@ -54059,6 +54074,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
 					"requires": {
 						"color-name": "~1.1.4"
 					}
@@ -54066,17 +54082,20 @@
 				"color-name": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
 				},
 				"json-schema-traverse": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
 				},
 				"slice-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
 					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.0.0",
 						"astral-regex": "^2.0.0",

--- a/packages/framework-core/src/booster-auth.ts
+++ b/packages/framework-core/src/booster-auth.ts
@@ -18,5 +18,5 @@ export class BoosterAuth {
 }
 
 function userHasSomeRole(user: UserEnvelope, authorizedRoles: Array<Class<RoleInterface>>): boolean {
-  return authorizedRoles.some((roleClass) => user.role === roleClass.name)
+  return authorizedRoles.some((roleClass) => user.roles?.includes(roleClass.name))
 }

--- a/packages/framework-core/src/services/graphql/graphql-query-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-query-generator.ts
@@ -169,7 +169,7 @@ export class GraphQLQueryGenerator {
               fields: {
                 id: { type: GraphQLString },
                 username: { type: new GraphQLNonNull(GraphQLString) },
-                roles: { type: new GraphQLNonNull(GraphQLString) },
+                roles: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
               },
             }),
           },

--- a/packages/framework-core/src/services/graphql/graphql-query-generator.ts
+++ b/packages/framework-core/src/services/graphql/graphql-query-generator.ts
@@ -169,7 +169,7 @@ export class GraphQLQueryGenerator {
               fields: {
                 id: { type: GraphQLString },
                 username: { type: new GraphQLNonNull(GraphQLString) },
-                role: { type: new GraphQLNonNull(GraphQLString) },
+                roles: { type: new GraphQLNonNull(GraphQLString) },
               },
             }),
           },

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -6,6 +6,7 @@ import { BoosterAuth } from '../src/booster-auth'
 describe('the "isUserAuthorized" method', () => {
   class Admin {}
   class Developer {}
+  class Reader {}
 
   it('returns true when the "authorizedRoles" is "all"', () => {
     const authorizedRoles: RoleAccess['authorize'] = 'all'
@@ -57,6 +58,28 @@ describe('the "isUserAuthorized" method', () => {
     const userEnvelope: UserEnvelope = {
       username: 'user@test.com',
       roles: ['Reader', 'Developer'],
+      claims: { 'custom:role': 'User' },
+    }
+
+    expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(true)
+  })
+
+  it('returns true when the user has more than one "authorizedRoles" on the roles', () => {
+    const authorizedRoles: RoleAccess['authorize'] = [Admin, Developer, Reader]
+    const userEnvelope: UserEnvelope = {
+      username: 'user@test.com',
+      roles: ['Admin', 'Reader'],
+      claims: { 'custom:role': 'User' },
+    }
+
+    expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(true)
+  })
+
+  it('returns true when the user has a validr role in the middle of the "authorizedRoles" list', () => {
+    const authorizedRoles: RoleAccess['authorize'] = [Admin, Developer, Reader]
+    const userEnvelope: UserEnvelope = {
+      username: 'user@test.com',
+      roles: ['Developer'],
       claims: { 'custom:role': 'User' },
     }
 

--- a/packages/framework-core/test/booster-auth.test.ts
+++ b/packages/framework-core/test/booster-auth.test.ts
@@ -1,0 +1,87 @@
+import { expect } from './expect'
+import { RoleAccess, UserEnvelope } from '@boostercloud/framework-types'
+
+import { BoosterAuth } from '../src/booster-auth'
+
+describe('the "isUserAuthorized" method', () => {
+  class Admin {}
+  class Developer {}
+
+  it('returns true when the "authorizedRoles" is "all"', () => {
+    const authorizedRoles: RoleAccess['authorize'] = 'all'
+
+    expect(BoosterAuth.isUserAuthorized(authorizedRoles)).to.eq(true)
+  })
+
+  it('returns false when the "authorizedRoles" is not "all" and no user was provided', () => {
+    const authorizedRoles: RoleAccess['authorize'] = [Admin, Developer]
+
+    expect(BoosterAuth.isUserAuthorized(authorizedRoles)).to.eq(false)
+  })
+
+  it('returns false when the user does not have any of the "authorizedRoles"', () => {
+    const authorizedRoles: RoleAccess['authorize'] = [Admin]
+    const userEnvelope: UserEnvelope = {
+      username: 'user@test.com',
+      roles: ['Developer'],
+      claims: { 'custom:role': 'User' },
+    }
+
+    expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(false)
+  })
+
+  it('returns true when the user has any of the "authorizedRoles"', () => {
+    const authorizedRoles: RoleAccess['authorize'] = [Admin, Developer]
+    const userEnvelope: UserEnvelope = {
+      username: 'user@test.com',
+      roles: ['Developer'],
+      claims: { 'custom:role': 'User' },
+    }
+
+    expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(true)
+  })
+
+  it('returns false when the user does not have any of the "authorizedRoles" and roles is a list', () => {
+    const authorizedRoles: RoleAccess['authorize'] = [Admin]
+    const userEnvelope: UserEnvelope = {
+      username: 'user@test.com',
+      roles: ['Developer', 'Reader'],
+      claims: { 'custom:role': 'User' },
+    }
+
+    expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(false)
+  })
+
+  it('returns true when the user has any of the "authorizedRoles" and roles is a list', () => {
+    const authorizedRoles: RoleAccess['authorize'] = [Admin, Developer]
+    const userEnvelope: UserEnvelope = {
+      username: 'user@test.com',
+      roles: ['Reader', 'Developer'],
+      claims: { 'custom:role': 'User' },
+    }
+
+    expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(true)
+  })
+
+  it('returns false when the user does not have any of the "authorizedRoles" and roles is an empty list', () => {
+    const authorizedRoles: RoleAccess['authorize'] = [Admin]
+    const userEnvelope: UserEnvelope = {
+      username: 'user@test.com',
+      roles: [],
+      claims: { 'custom:role': 'User' },
+    }
+
+    expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(false)
+  })
+
+  it('returns false when the user does not have any of the "authorizedRoles" and roles is a list with an empty string', () => {
+    const authorizedRoles: RoleAccess['authorize'] = [Admin]
+    const userEnvelope: UserEnvelope = {
+      username: 'user@test.com',
+      roles: [''],
+      claims: { 'custom:role': 'User' },
+    }
+
+    expect(BoosterAuth.isUserAuthorized(authorizedRoles, userEnvelope)).to.eq(false)
+  })
+})

--- a/packages/framework-core/test/booster-command-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-command-dispatcher.test.ts
@@ -5,8 +5,8 @@ import { fake, replace, restore } from 'sinon'
 import { expect } from './expect'
 import { BoosterCommandDispatcher } from '../src/booster-command-dispatcher'
 import { CommandBeforeFunction, Logger, Register } from '@boostercloud/framework-types'
-import { Command } from '../src/decorators'
-import { RegisterHandler } from '../src/booster-register-handler'
+import { Command } from '../src'
+import { RegisterHandler } from '../src'
 import { random } from 'faker'
 
 describe('the `BoosterCommandsDispatcher`', () => {
@@ -67,7 +67,7 @@ describe('the `BoosterCommandsDispatcher`', () => {
         typeName: 'UnauthorizedCommand',
         version: 'π', // JS doesn't care, and π is a number after all xD...
         currentUser: {
-          role: 'Loki',
+          roles: ['Loki'],
         },
       }
 
@@ -102,7 +102,7 @@ describe('the `BoosterCommandsDispatcher`', () => {
         typeName: 'ProperlyHandledCommand',
         version: 'π', // JS doesn't care, and π is a number after all xD...
         currentUser: {
-          role: 'Loki',
+          roles: ['Loki'],
         },
         value: commandValue,
         requestID: '42',
@@ -151,7 +151,7 @@ describe('the `BoosterCommandsDispatcher`', () => {
         typeName: 'ProperlyHandledCommand',
         version: 'π', // JS doesn't care, and π is a number after all xD...
         currentUser: {
-          role: 'Loki',
+          roles: ['Loki'],
         },
         value: commandValue,
         requestID: '42',

--- a/packages/framework-core/test/booster-events-reader.test.ts
+++ b/packages/framework-core/test/booster-events-reader.test.ts
@@ -130,7 +130,7 @@ describe('BoosterEventsReader', () => {
     it('user has no permissions', async () => {
       const request: EventSearchRequest = {
         currentUser: {
-          role: 'NonValidRole',
+          roles: ['NonValidRole'],
           username: internet.email(),
           claims: {},
         },
@@ -147,7 +147,7 @@ describe('BoosterEventsReader', () => {
     context('for a "byEntity" search', () => {
       const request: EventSearchRequest = {
         currentUser: {
-          role: CanReadEventsRole.name,
+          roles: [CanReadEventsRole.name],
           username: internet.email(),
           claims: {},
         },

--- a/packages/framework-core/test/booster-graphql-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-graphql-dispatcher.test.ts
@@ -257,7 +257,7 @@ describe('the `BoosterGraphQLDispatcher`', () => {
 
           const currentUser: UserEnvelope = {
             username: internet.email(),
-            role: random.word(),
+            roles: [random.word()],
             claims: {},
           }
 

--- a/packages/framework-core/test/booster-read-model-reader.test.ts
+++ b/packages/framework-core/test/booster-read-model-reader.test.ts
@@ -106,7 +106,7 @@ describe('BoosterReadModelReader', () => {
           validateByIdRequest({
             version: 1,
             class: TestReadModel,
-            currentUser: { id: '666', username: 'root', role: 'root' },
+            currentUser: { id: '666', username: 'root', roles: ['root'] },
             key: {
               id: 'π',
               sequenceKey: { name: 'salmon', value: 'sammy' },
@@ -121,7 +121,7 @@ describe('BoosterReadModelReader', () => {
           validateByIdRequest({
             version: 1,
             class: TestReadModel,
-            currentUser: { id: '666', username: 'root', role: 'root' },
+            currentUser: { id: '666', username: 'root', roles: ['root'] },
           })
         }).not.to.throw()
       })
@@ -132,7 +132,7 @@ describe('BoosterReadModelReader', () => {
           validateByIdRequest({
             version: 1,
             class: SequencedReadModel,
-            currentUser: { id: '666', username: 'root', role: 'root' },
+            currentUser: { id: '666', username: 'root', roles: ['root'] },
             key: {
               id: '§',
               sequenceKey: { name: 'salmon', value: 'sammy' },
@@ -235,7 +235,7 @@ describe('BoosterReadModelReader', () => {
         version: 1,
         currentUser: {
           username: internet.email(),
-          role: '',
+          roles: [''],
           claims: {},
         },
       }
@@ -260,7 +260,7 @@ describe('BoosterReadModelReader', () => {
 
     const currentUser = {
       username: internet.email(),
-      role: UserRole.name,
+      roles: [UserRole.name],
       claims: {},
     }
 

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -2,10 +2,9 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { expect } from './expect'
 import { Register, BoosterConfig, Level, UserEnvelope } from '@boostercloud/framework-types'
-import { replace, fake, restore } from 'sinon'
-import { RegisterHandler } from '../src/booster-register-handler'
+import { replace, fake, restore, spy } from 'sinon'
+import { RegisterHandler } from '../src'
 import { buildLogger } from '../src/booster-logger'
-import { spy } from 'sinon'
 
 class SomeEntity {}
 
@@ -123,7 +122,7 @@ describe('the `RegisterHandler` class', () => {
     }
     const user: UserEnvelope = {
       username: 'paco@example.com',
-      role: 'Paco',
+      roles: ['Paco'],
       claims: {},
     }
     const register = new Register('1234', user)

--- a/packages/framework-core/test/booster-token-verifier.test.ts
+++ b/packages/framework-core/test/booster-token-verifier.test.ts
@@ -66,6 +66,7 @@ describe('the "verifyToken" method', () => {
 
     expect(user.claims).to.deep.equals(expectedUser.claims)
     expect(user.header?.alg).equals(expectedUser.header?.alg)
+    expect(user.roles).to.have.all.members(expectedUser.roles)
   })
 
   it('decode and verify an auth token with the custom roles', async () => {
@@ -97,6 +98,7 @@ describe('the "verifyToken" method', () => {
 
     expect(user.claims).to.deep.equals(expectedUser.claims)
     expect(user.header?.alg).equals(expectedUser.header?.alg)
+    expect(user.roles).to.have.all.members(expectedUser.roles)
   })
 
   it('decode and verify an auth token with an empty custom role', async () => {
@@ -111,7 +113,7 @@ describe('the "verifyToken" method', () => {
     const expectedUser: UserEnvelope = {
       id: userId,
       username: email,
-      roles: ['User'],
+      roles: [''],
       claims: {
         sub: userId,
         iss: issuer,
@@ -128,6 +130,7 @@ describe('the "verifyToken" method', () => {
 
     expect(user.claims).to.deep.equals(expectedUser.claims)
     expect(user.header?.alg).equals(expectedUser.header?.alg)
+    expect(user.roles).to.have.all.members(expectedUser.roles)
   })
 
   it('decode and verify an auth token with a list of custom roles', async () => {
@@ -142,7 +145,7 @@ describe('the "verifyToken" method', () => {
     const expectedUser: UserEnvelope = {
       id: userId,
       username: email,
-      roles: ['User'],
+      roles: ['User', 'Other'],
       claims: {
         sub: userId,
         iss: issuer,
@@ -159,6 +162,7 @@ describe('the "verifyToken" method', () => {
 
     expect(user.claims).to.deep.equals(expectedUser.claims)
     expect(user.header?.alg).equals(expectedUser.header?.alg)
+    expect(user.roles).to.have.all.members(expectedUser.roles)
   })
 
   it('fails if role is a number', async () => {

--- a/packages/framework-core/test/booster-token-verifier.test.ts
+++ b/packages/framework-core/test/booster-token-verifier.test.ts
@@ -47,7 +47,7 @@ describe('the "verifyToken" method', () => {
     const expectedUser: UserEnvelope = {
       id: userId,
       username: email,
-      role: 'User',
+      roles: ['User'],
       claims: {
         sub: userId,
         iss: issuer,
@@ -80,7 +80,7 @@ describe('the "verifyToken" method', () => {
     const expectedUser: UserEnvelope = {
       id: userId,
       username: email,
-      role: 'User',
+      roles: ['User'],
       claims: {
         sub: userId,
         iss: issuer,
@@ -97,6 +97,100 @@ describe('the "verifyToken" method', () => {
 
     expect(user.claims).to.deep.equals(expectedUser.claims)
     expect(user.header?.alg).equals(expectedUser.header?.alg)
+  })
+
+  it('decode and verify an auth token with an empty custom role', async () => {
+    const token = jwks.token({
+      sub: userId,
+      iss: issuer,
+      'custom:role': '',
+      email,
+      phoneNumber,
+    })
+
+    const expectedUser: UserEnvelope = {
+      id: userId,
+      username: email,
+      roles: ['User'],
+      claims: {
+        sub: userId,
+        iss: issuer,
+        'custom:role': '',
+        email,
+        phoneNumber,
+      },
+      header: {
+        alg: 'RS256',
+      },
+    }
+
+    const user = await boosterTokenVerifier.verify(token)
+
+    expect(user.claims).to.deep.equals(expectedUser.claims)
+    expect(user.header?.alg).equals(expectedUser.header?.alg)
+  })
+
+  it('decode and verify an auth token with a list of custom roles', async () => {
+    const token = jwks.token({
+      sub: userId,
+      iss: issuer,
+      'custom:role': ['User', 'Other'],
+      email,
+      phoneNumber,
+    })
+
+    const expectedUser: UserEnvelope = {
+      id: userId,
+      username: email,
+      roles: ['User'],
+      claims: {
+        sub: userId,
+        iss: issuer,
+        'custom:role': ['User', 'Other'],
+        email,
+        phoneNumber,
+      },
+      header: {
+        alg: 'RS256',
+      },
+    }
+
+    const user = await boosterTokenVerifier.verify(token)
+
+    expect(user.claims).to.deep.equals(expectedUser.claims)
+    expect(user.header?.alg).equals(expectedUser.header?.alg)
+  })
+
+  it('fails if role is a number', async () => {
+    const token = jwks.token({
+      sub: userId,
+      iss: issuer,
+      'custom:role': 123,
+      email,
+      phoneNumber,
+    })
+
+    const verifyFunction = boosterTokenVerifier.verify(token)
+
+    await expect(verifyFunction).to.eventually.be.rejectedWith(
+      'Error: Invalid role format 123. Valid format are Array<string> or string'
+    )
+  })
+
+  it('fails if role is not a list of strings', async () => {
+    const token = jwks.token({
+      sub: userId,
+      iss: issuer,
+      'custom:role': ['a', 'b', 123],
+      email,
+      phoneNumber,
+    })
+
+    const user = boosterTokenVerifier.verify(token)
+
+    await expect(user).to.eventually.be.rejectedWith(
+      'Error: Invalid role format 123. Valid format are Array<string> or string'
+    )
   })
 
   it('fails if a different issuer emitted the token', async () => {

--- a/packages/framework-core/test/services/graphql/graphql-generator.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-generator.test.ts
@@ -132,7 +132,7 @@ describe('GraphQL generator', () => {
         requestID: mockRequestId,
         user: {
           username: mockEmail,
-          role: mockRole,
+          roles: [mockRole],
           claims: {},
         },
         operation: {
@@ -173,7 +173,7 @@ describe('GraphQL generator', () => {
         const expectedFetchPayload = {
           currentUser: {
             username: mockEmail,
-            role: mockRole,
+            roles: [mockRole],
             claims: {},
           },
           filters: {},
@@ -302,7 +302,7 @@ describe('GraphQL generator', () => {
           requestID: mockRequestId,
           currentUser: {
             username: mockEmail,
-            role: mockRole,
+            roles: [mockRole],
             claims: {},
           },
           typeName: mockType.name,
@@ -431,7 +431,7 @@ describe('GraphQL generator', () => {
         expect(asyncIteratorStub).to.be.calledOnceWithExactly({
           currentUser: {
             username: mockEmail,
-            role: mockRole,
+            roles: [mockRole],
             claims: {},
           },
           filters: {},
@@ -468,7 +468,7 @@ describe('GraphQL generator', () => {
         const expectedFetchEventsPayload: EventSearchRequest = {
           currentUser: {
             username: mockEmail,
-            role: mockRole,
+            roles: [mockRole],
             claims: {},
           },
           filters,

--- a/packages/framework-core/test/services/graphql/graphql-query-generator.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-query-generator.test.ts
@@ -673,7 +673,7 @@ describe('GraphQLQueryGenerator', () => {
             new Set(['type', 'entity', 'requestID', 'entityID', 'user', 'createdAt', 'value'])
           )
           const userType = returnElementType.getFields()['user'].type as GraphQLObjectType
-          expect(new Set(Object.keys(userType.getFields()))).to.be.deep.equal(new Set(['id', 'username', 'role']))
+          expect(new Set(Object.keys(userType.getFields()))).to.be.deep.equal(new Set(['id', 'username', 'roles']))
         }
       })
 

--- a/packages/framework-core/test/services/graphql/websocket-protocol/graphql-websocket-protocol.test.ts
+++ b/packages/framework-core/test/services/graphql/websocket-protocol/graphql-websocket-protocol.test.ts
@@ -180,7 +180,7 @@ describe('the `GraphQLWebsocketHandler`', () => {
           it('stores connection data including the user', async () => {
             const expectedUser: UserEnvelope = {
               username: internet.email(),
-              role: lorem.word(),
+              roles: [lorem.word()],
               claims: {},
             }
 
@@ -274,7 +274,7 @@ describe('the `GraphQLWebsocketHandler`', () => {
           const connectionData: ConnectionDataEnvelope = {
             user: {
               username: internet.email(),
-              role: lorem.word(),
+              roles: [lorem.word()],
               claims: {},
             },
             expirationTime: random.number(),

--- a/packages/framework-integration-tests/integration/provider-unaware/end-to-end/events.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/end-to-end/events.integration.ts
@@ -349,7 +349,7 @@ function queryByType(
             type
             user {
                 id
-                role
+                roles
                 username
             }
             value
@@ -378,7 +378,7 @@ function queryByEntity(
             type
             user {
                 id
-                role
+                roles
                 username
             }
             value

--- a/packages/framework-integration-tests/integration/provider-unaware/functionality/event-handlers.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/functionality/event-handlers.integration.ts
@@ -85,7 +85,7 @@ describe('Event handlers', () => {
             typ: 'JWT',
           },
           username: adminEmail,
-          role: ['Admin'],
+          roles: ['Admin'],
           id: adminEmail,
         },
       }
@@ -121,7 +121,7 @@ describe('Event handlers', () => {
             typ: 'JWT',
           },
           username: adminEmail,
-          role: ['Admin'],
+          roles: ['Admin'],
           id: adminEmail,
         },
       }

--- a/packages/framework-integration-tests/integration/provider-unaware/functionality/event-handlers.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/functionality/event-handlers.integration.ts
@@ -85,7 +85,7 @@ describe('Event handlers', () => {
             typ: 'JWT',
           },
           username: adminEmail,
-          role: 'Admin',
+          role: ['Admin'],
           id: adminEmail,
         },
       }
@@ -121,7 +121,7 @@ describe('Event handlers', () => {
             typ: 'JWT',
           },
           username: adminEmail,
-          role: 'Admin',
+          role: ['Admin'],
           id: adminEmail,
         },
       }

--- a/packages/framework-provider-aws/test/library/connections-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/connections-adapter.test.ts
@@ -20,7 +20,7 @@ describe('The "storeConnectionData" method', () => {
     const expectedData: ConnectionDataEnvelope = {
       expirationTime: random.number(),
       user: {
-        role: lorem.word(),
+        roles: [lorem.word()],
         username: internet.email(),
         claims: {},
       },
@@ -42,7 +42,7 @@ describe('The "fetchConnectionData" method', () => {
     const expectedData: ConnectionDataEnvelope = {
       expirationTime: random.number(),
       user: {
-        role: lorem.word(),
+        roles: [lorem.word()],
         username: internet.email(),
         claims: {},
       },

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -135,7 +135,7 @@ export interface ConnectionDataEnvelope {
 export interface UserEnvelope {
   id?: string
   username: string
-  role: string
+  roles: Array<string>
   claims: Record<string, unknown>
   header?: Record<string, unknown>
 }


### PR DESCRIPTION
## Description
Allow JWT tokens with an array of Roles 

## Changes
UserEnvelope now map the JWT roles to an Array of roles

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly

