### PR TITLE
feat: Added custom logger configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2741,12 +2741,12 @@
 			}
 		},
 		"node_modules/@boostercloud/framework-common-helpers": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.25.0.tgz",
-			"integrity": "sha512-9or9jDL8jX4M1Sz0zrqrT4A7PGbEU2zTblXJN+/cf8CKA0qOZbRYZ+fhhhllgR+xnznh8tD+C+ecNDyTpwUgIA==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.26.0.tgz",
+			"integrity": "sha512-42YoOiZbK+sPl2DtvMx1CTjQCQW1hE5hof/un0cWdkBxGiex/N9c0vW5u+/KXOo/pNfurCQpvpKnRDjRRdwqTg==",
 			"dev": true,
 			"dependencies": {
-				"@boostercloud/framework-types": "^0.25.0",
+				"@boostercloud/framework-types": "^0.26.0",
 				"child-process-promise": "^2.2.1",
 				"tslib": "2.3.0"
 			}
@@ -2756,9 +2756,9 @@
 			"link": true
 		},
 		"node_modules/@boostercloud/framework-types": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.25.0.tgz",
-			"integrity": "sha512-IjEsekd8hFTbdlquAaU2XxdZCE7lmM0WTT0NWeVGkANNYRoU+rqQNxdHCQVWzM4JjzxxKZDf1PkaxhJ4SMVKSA==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.26.0.tgz",
+			"integrity": "sha512-8wEsjXlOCdAlu2fpY/NYa3kN+d00lTKYOidQzhslVtu+LfuLXEVmnwwEkNsI0ld7dl3CNOp9t+WA7USjnVFGwA==",
 			"dev": true,
 			"dependencies": {
 				"@types/graphql": "14.5.0",
@@ -31306,12 +31306,12 @@
 		},
 		"packages/framework-provider-local": {
 			"name": "@boostercloud/framework-provider-local",
-			"version": "0.25.0",
+			"version": "0.26.0",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@boostercloud/framework-common-helpers": "^0.25.0",
-				"@boostercloud/framework-types": "^0.25.0",
+				"@boostercloud/framework-common-helpers": "^0.26.0",
+				"@boostercloud/framework-types": "^0.26.0",
 				"@types/nedb": "^1.8.11",
 				"nedb": "^1.8.0",
 				"tslib": "2.3.0"
@@ -33035,12 +33035,12 @@
 			}
 		},
 		"@boostercloud/framework-common-helpers": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.25.0.tgz",
-			"integrity": "sha512-9or9jDL8jX4M1Sz0zrqrT4A7PGbEU2zTblXJN+/cf8CKA0qOZbRYZ+fhhhllgR+xnznh8tD+C+ecNDyTpwUgIA==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.26.0.tgz",
+			"integrity": "sha512-42YoOiZbK+sPl2DtvMx1CTjQCQW1hE5hof/un0cWdkBxGiex/N9c0vW5u+/KXOo/pNfurCQpvpKnRDjRRdwqTg==",
 			"dev": true,
 			"requires": {
-				"@boostercloud/framework-types": "^0.25.0",
+				"@boostercloud/framework-types": "^0.26.0",
 				"child-process-promise": "^2.2.1",
 				"tslib": "2.3.0"
 			}
@@ -33048,8 +33048,8 @@
 		"@boostercloud/framework-provider-local": {
 			"version": "file:packages/framework-provider-local",
 			"requires": {
-				"@boostercloud/framework-common-helpers": "^0.25.0",
-				"@boostercloud/framework-types": "^0.25.0",
+				"@boostercloud/framework-common-helpers": "^0.26.0",
+				"@boostercloud/framework-types": "^0.26.0",
 				"@types/express": "4.17.12",
 				"@types/faker": "5.1.5",
 				"@types/nedb": "^1.8.11",
@@ -33064,9 +33064,9 @@
 			}
 		},
 		"@boostercloud/framework-types": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.25.0.tgz",
-			"integrity": "sha512-IjEsekd8hFTbdlquAaU2XxdZCE7lmM0WTT0NWeVGkANNYRoU+rqQNxdHCQVWzM4JjzxxKZDf1PkaxhJ4SMVKSA==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.26.0.tgz",
+			"integrity": "sha512-8wEsjXlOCdAlu2fpY/NYa3kN+d00lTKYOidQzhslVtu+LfuLXEVmnwwEkNsI0ld7dl3CNOp9t+WA7USjnVFGwA==",
 			"dev": true,
 			"requires": {
 				"@types/graphql": "14.5.0",

--- a/packages/framework-core/src/booster-logger.ts
+++ b/packages/framework-core/src/booster-logger.ts
@@ -1,11 +1,17 @@
-import { Level, Logger } from '@boostercloud/framework-types'
+import { BoosterConfig, Level, Logger } from '@boostercloud/framework-types'
 
 const logPrefix = '[Booster] '
 
-export function buildLogger(level: Level): Logger {
-  const prefixedDebugFunction = console.debug.bind(null, logPrefix)
-  const prefixedInfoFunction = console.info.bind(null, logPrefix)
-  const prefixedErrFunction = console.error.bind(null, logPrefix)
+export function buildLogger(level: Level, config: BoosterConfig): Logger {
+  const debug = config.logger?.debug ?? console.debug
+  const info = config.logger?.info ?? console.info
+  const error = config.logger?.error ?? console.error
+
+  const prefix = config?.logPrefix ?? logPrefix
+
+  const prefixedDebugFunction = debug.bind(null, prefix)
+  const prefixedInfoFunction = info.bind(null, prefix)
+  const prefixedErrFunction = error.bind(null, prefix)
 
   return {
     debug: level <= Level.debug ? prefixedDebugFunction : noopLog,

--- a/packages/framework-core/src/booster.ts
+++ b/packages/framework-core/src/booster.ts
@@ -65,7 +65,7 @@ export class Booster {
     const projectRootPath = codeRootPath.replace(new RegExp(this.config.codeRelativePath + '$'), '')
     this.config.userProjectRootPath = projectRootPath
     Importer.importUserProjectFiles(codeRootPath)
-    this.logger = buildLogger(this.config.logLevel)
+    this.logger = buildLogger(this.config.logLevel, this.config)
     this.config.validate()
   }
 

--- a/packages/framework-core/test/booster-logger.test.ts
+++ b/packages/framework-core/test/booster-logger.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
@@ -5,9 +6,11 @@
 import { expect } from './expect'
 import { fake, replace, restore } from 'sinon'
 import { buildLogger } from '../src/booster-logger'
-import { Level } from '@boostercloud/framework-types'
+import { BoosterConfig, Level, Logger } from '@boostercloud/framework-types'
 
 describe('the `buildLogger method`', () => {
+  const config = new BoosterConfig('Test Logger')
+
   afterEach(() => {
     restore()
   })
@@ -20,7 +23,7 @@ describe('the `buildLogger method`', () => {
     replace(console, 'info', fakeConsoleInfo)
     replace(console, 'error', fakeConsoleError)
 
-    const logger = buildLogger(Level.debug)
+    const logger = buildLogger(Level.debug, config)
     logger.debug('a')
     logger.info('b')
     logger.error('c')
@@ -38,7 +41,7 @@ describe('the `buildLogger method`', () => {
     replace(console, 'info', fakeConsoleInfo)
     replace(console, 'error', fakeConsoleError)
 
-    const logger = buildLogger(Level.info)
+    const logger = buildLogger(Level.info, config)
     logger.debug('a')
     logger.info('b')
     logger.error('c')
@@ -56,7 +59,7 @@ describe('the `buildLogger method`', () => {
     replace(console, 'info', fakeConsoleInfo)
     replace(console, 'error', fakeConsoleError)
 
-    const logger = buildLogger(Level.error)
+    const logger = buildLogger(Level.error, config)
     logger.debug('a')
     logger.info('b')
     logger.error('c')
@@ -64,5 +67,27 @@ describe('the `buildLogger method`', () => {
     expect(fakeConsoleDebug).to.not.have.been.called
     expect(fakeConsoleInfo).to.not.have.been.calledOnce
     expect(fakeConsoleError).to.have.been.calledOnce
+  })
+
+  it('use custom logger when is defined at config level', () => {
+    const fakeConsoleDebug = fake()
+    const fakeCustomDebug = fake()
+    replace(console, 'debug', fakeConsoleDebug)
+    const configWithLogger = new BoosterConfig('TestLogger')
+
+    const customLogger: Logger = {
+      debug: (message?: any, ...optionalParams: any[]) => {},
+      info: (message?: any, ...optionalParams: any[]) => {},
+      error: (message?: any, ...optionalParams: any[]) => {},
+    }
+
+    replace(customLogger, 'debug', fakeCustomDebug)
+    configWithLogger.logger = customLogger
+
+    const logger = buildLogger(Level.debug, configWithLogger)
+    logger.debug('a')
+
+    expect(fakeConsoleDebug).to.not.have.been.called
+    expect(fakeCustomDebug).to.have.been.calledOnce
   })
 })

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -16,7 +16,8 @@ class SomeEvent {
 }
 
 describe('the `RegisterHandler` class', () => {
-  const logger = buildLogger(Level.debug)
+  const testConfig = new BoosterConfig('Test')
+  const logger = buildLogger(Level.debug, testConfig)
 
   afterEach(() => {
     restore()

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -18,8 +18,8 @@ describe('EventStore', () => {
   afterEach(() => {
     restore()
   })
-
-  const logger = buildLogger(Level.error)
+  const testConfig = new BoosterConfig('Test')
+  const logger = buildLogger(Level.error, testConfig)
 
   class AnEvent {
     public constructor(readonly id: UUID, readonly entityId: string, readonly delta: number) {}

--- a/packages/framework-core/test/services/graphql/graphql-generator.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-generator.test.ts
@@ -12,6 +12,7 @@ import {
   EventSearchResponse,
   ReadModelRequestArgs,
   ReadModelRequestProperties,
+  Logger,
 } from '@boostercloud/framework-types'
 import { expect } from '../../expect'
 import { GraphQLQueryGenerator } from '../../../src/services/graphql/graphql-query-generator'
@@ -27,11 +28,12 @@ import { GraphQLFieldResolver } from 'graphql'
 describe('GraphQL generator', () => {
   let mockEnvironmentName: string
   let mockConfig: BoosterConfig
-  const mockLogger = buildLogger(Level.error)
+  let mockLogger: Logger
 
   beforeEach(() => {
     mockEnvironmentName = random.alphaNumeric(10)
     mockConfig = new BoosterConfig(mockEnvironmentName)
+    mockLogger = buildLogger(Level.error, mockConfig)
   })
 
   afterEach(() => {

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -23,7 +23,8 @@ describe('ReadModelStore', () => {
     restore()
   })
 
-  const logger = buildLogger(Level.error)
+  const testConfig = new BoosterConfig('Test')
+  const logger = buildLogger(Level.error, testConfig)
 
   class AnImportantEntity {
     public constructor(readonly id: UUID, readonly someKey: UUID, readonly count: number) {}

--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -16,6 +16,7 @@ import { ProviderLibrary } from './provider'
 import { Level } from './logger'
 import * as path from 'path'
 import { RocketDescriptor, RocketFunction } from './rocket-descriptor'
+import { Logger } from '.'
 
 /**
  * Class used by external packages that needs to get a representation of
@@ -23,6 +24,8 @@ import { RocketDescriptor, RocketFunction } from './rocket-descriptor'
  */
 export class BoosterConfig {
   public logLevel: Level = Level.debug
+  public logPrefix?: string
+  public logger?: Logger
   private _provider?: ProviderLibrary
   public providerPackage?: string
   public rockets?: Array<RocketDescriptor>


### PR DESCRIPTION
## Description

This PR will allow Booster users to change the default logger and specify a custom one. The custom logger implements the `Logger` interface:

```typescript
interface Logger {
    debug(message?: any, ...optionalParams: any[]): void;
    info(message?: any, ...optionalParams: any[]): void;
    error(message?: any, ...optionalParams: any[]): void;
}
```

Configuration example:

```typescript
Booster.configure('prod', (config: BoosterConfig): void => {
  config.appName = 'awesome-app'
  config.providerPackage = '@boostercloud/framework-provider-aws'
  config.logPrefix = '<My awesome app > '
  config.logLevel = Level.debug
  config.logger = {
    debug: (message: string, ...optionalParameters: any[]) => {
       // ... Call to your log thing....
    },
    info: (message: string, ...optionalParameters: any[]) => {
     
    },
    error: (message: string, ...optionalParameters: any[]) => {
    
    },
  }
})

``` 
Additionally, a `logPrefix`could be also be specified.


## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly
