### PR TITLE
Publish `Booster.logger` for easy access along the core and apps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,10 @@
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "protocol": "inspector",
-      "runtimeArgs": ["--preserve-symlinks"]
+      "runtimeArgs": ["--preserve-symlinks"],
+      "env": {
+        "BOOSTER_ENV": "test"
+      }
     },
     {
       "type": "node",

--- a/packages/framework-core/src/booster-logger.ts
+++ b/packages/framework-core/src/booster-logger.ts
@@ -2,7 +2,7 @@ import { BoosterConfig, Level, Logger } from '@boostercloud/framework-types'
 
 const logPrefix = '[Booster] '
 
-export function buildLogger(level: Level, config: BoosterConfig): Logger {
+export function getLogger(config: BoosterConfig): Logger {
   const debug = config.logger?.debug ?? console.debug
   const info = config.logger?.info ?? console.info
   const error = config.logger?.error ?? console.error
@@ -14,8 +14,8 @@ export function buildLogger(level: Level, config: BoosterConfig): Logger {
   const prefixedErrFunction = error.bind(null, prefix)
 
   return {
-    debug: level <= Level.debug ? prefixedDebugFunction : noopLog,
-    info: level <= Level.info ? prefixedInfoFunction : noopLog,
+    debug: config.logLevel <= Level.debug ? prefixedDebugFunction : noopLog,
+    info: config.logLevel <= Level.info ? prefixedInfoFunction : noopLog,
     error: prefixedErrFunction,
   }
 }

--- a/packages/framework-core/src/booster.ts
+++ b/packages/framework-core/src/booster.ts
@@ -17,7 +17,7 @@ import {
 } from '@boostercloud/framework-types'
 import { BoosterEventDispatcher } from './booster-event-dispatcher'
 import { BoosterGraphQLDispatcher } from './booster-graphql-dispatcher'
-import { buildLogger } from './booster-logger'
+import { getLogger } from './booster-logger'
 import { BoosterScheduledCommandDispatcher } from './booster-scheduled-command-dispatcher'
 import { BoosterSubscribersNotifier } from './booster-subscribers-notifier'
 import { Importer } from './importer'
@@ -34,12 +34,15 @@ import { BoosterRocketDispatcher } from './booster-rocket-dispatcher'
  */
 export class Booster {
   public static readonly configuredEnvironments: Set<string> = new Set<string>()
-  private static logger: Logger
   public static readonly config = new BoosterConfig(checkAndGetCurrentEnv())
   /**
    * Avoid creating instances of this class
    */
   private constructor() {}
+
+  public static get logger(): Logger {
+    return getLogger(this.config)
+  }
 
   public static configureCurrentEnv(configurator: (config: BoosterConfig) => void): void {
     configurator(this.config)
@@ -65,7 +68,6 @@ export class Booster {
     const projectRootPath = codeRootPath.replace(new RegExp(this.config.codeRelativePath + '$'), '')
     this.config.userProjectRootPath = projectRootPath
     Importer.importUserProjectFiles(codeRootPath)
-    this.logger = buildLogger(this.config.logLevel, this.config)
     this.config.validate()
   }
 

--- a/packages/framework-core/test/booster-logger.test.ts
+++ b/packages/framework-core/test/booster-logger.test.ts
@@ -5,10 +5,10 @@
 
 import { expect } from './expect'
 import { fake, replace, restore } from 'sinon'
-import { buildLogger } from '../src/booster-logger'
+import { getLogger } from '../src/booster-logger'
 import { BoosterConfig, Level, Logger } from '@boostercloud/framework-types'
 
-describe('the `buildLogger method`', () => {
+describe('the `getLogger method`', () => {
   const config = new BoosterConfig('Test Logger')
 
   afterEach(() => {
@@ -23,7 +23,8 @@ describe('the `buildLogger method`', () => {
     replace(console, 'info', fakeConsoleInfo)
     replace(console, 'error', fakeConsoleError)
 
-    const logger = buildLogger(Level.debug, config)
+    config.logLevel = Level.debug
+    const logger = getLogger(config)
     logger.debug('a')
     logger.info('b')
     logger.error('c')
@@ -41,7 +42,8 @@ describe('the `buildLogger method`', () => {
     replace(console, 'info', fakeConsoleInfo)
     replace(console, 'error', fakeConsoleError)
 
-    const logger = buildLogger(Level.info, config)
+    config.logLevel = Level.info
+    const logger = getLogger(config)
     logger.debug('a')
     logger.info('b')
     logger.error('c')
@@ -59,7 +61,8 @@ describe('the `buildLogger method`', () => {
     replace(console, 'info', fakeConsoleInfo)
     replace(console, 'error', fakeConsoleError)
 
-    const logger = buildLogger(Level.error, config)
+    config.logLevel = Level.error
+    const logger = getLogger(config)
     logger.debug('a')
     logger.info('b')
     logger.error('c')
@@ -84,7 +87,8 @@ describe('the `buildLogger method`', () => {
     replace(customLogger, 'debug', fakeCustomDebug)
     configWithLogger.logger = customLogger
 
-    const logger = buildLogger(Level.debug, configWithLogger)
+    config.logLevel = Level.debug
+    const logger = getLogger(configWithLogger)
     logger.debug('a')
 
     expect(fakeConsoleDebug).to.not.have.been.called

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -4,7 +4,7 @@ import { expect } from './expect'
 import { Register, BoosterConfig, Level, UserEnvelope } from '@boostercloud/framework-types'
 import { replace, fake, restore, spy } from 'sinon'
 import { RegisterHandler } from '../src'
-import { buildLogger } from '../src/booster-logger'
+import { getLogger } from '../src/booster-logger'
 
 class SomeEntity {}
 
@@ -17,7 +17,8 @@ class SomeEvent {
 
 describe('the `RegisterHandler` class', () => {
   const testConfig = new BoosterConfig('Test')
-  const logger = buildLogger(Level.debug, testConfig)
+  testConfig.logLevel = Level.debug
+  const logger = getLogger(testConfig)
 
   afterEach(() => {
     restore()

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -12,14 +12,15 @@ import {
 import { replace, fake, stub, restore } from 'sinon'
 import { EventStore } from '../../src/services/event-store'
 import { expect } from '../expect'
-import { buildLogger } from '../../src/booster-logger'
+import { getLogger } from '../../src/booster-logger'
 
 describe('EventStore', () => {
   afterEach(() => {
     restore()
   })
   const testConfig = new BoosterConfig('Test')
-  const logger = buildLogger(Level.error, testConfig)
+  testConfig.logLevel = Level.error
+  const logger = getLogger(testConfig)
 
   class AnEvent {
     public constructor(readonly id: UUID, readonly entityId: string, readonly delta: number) {}

--- a/packages/framework-core/test/services/graphql/graphql-generator.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-generator.test.ts
@@ -19,7 +19,7 @@ import { GraphQLQueryGenerator } from '../../../src/services/graphql/graphql-que
 import { GraphQLMutationGenerator } from '../../../src/services/graphql/graphql-mutation-generator'
 import { GraphQLSubscriptionGenerator } from '../../../src/services/graphql/graphql-subcriptions-generator'
 import { random, internet, lorem } from 'faker'
-import { buildLogger } from '../../../src/booster-logger'
+import { getLogger } from '../../../src/booster-logger'
 import { BoosterEventsReader } from '../../../src/booster-events-reader'
 
 import { GraphQLResolverContext } from '../../../src/services/graphql/common'
@@ -33,7 +33,8 @@ describe('GraphQL generator', () => {
   beforeEach(() => {
     mockEnvironmentName = random.alphaNumeric(10)
     mockConfig = new BoosterConfig(mockEnvironmentName)
-    mockLogger = buildLogger(Level.error, mockConfig)
+    mockConfig.logLevel = Level.error
+    mockLogger = getLogger(mockConfig)
   })
 
   afterEach(() => {

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -2,7 +2,7 @@
 import { describe } from 'mocha'
 import { restore, fake, replace, spy } from 'sinon'
 import { ReadModelStore } from '../../src/services/read-model-store'
-import { buildLogger } from '../../src/booster-logger'
+import { getLogger } from '../../src/booster-logger'
 import {
   Level,
   Logger,
@@ -24,7 +24,8 @@ describe('ReadModelStore', () => {
   })
 
   const testConfig = new BoosterConfig('Test')
-  const logger = buildLogger(Level.error, testConfig)
+  testConfig.logLevel = Level.error
+  const logger = getLogger(testConfig)
 
   class AnImportantEntity {
     public constructor(readonly id: UUID, readonly someKey: UUID, readonly count: number) {}


### PR DESCRIPTION
## Description

Minor change to publish the configured `Booster.logger` object (with a fallback to console.log)

## Changes

- Replaced the private static property `logger` in the `Booster` singleton by a getter that proxies the logger defined in the current `Booster.config` object.
- It falls back to `console.log` when no logger is configured.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly
