### PR TITLE
removed error if join key is not valid and avoid to pass empty instance to readmodels

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -131,7 +131,7 @@ jobs:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
 
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -162,7 +162,7 @@ jobs:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
 
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -193,7 +193,7 @@ jobs:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
 
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -226,7 +226,7 @@ jobs:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
 
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap
@@ -259,7 +259,7 @@ jobs:
   #        minikube version: 'v1.18.1'
   #        kubernetes version: 'v1.19.7'
   #        driver: 'docker'
-  #    - uses: actions/setup-node@v1
+  #    - uses: actions/setup-node@v3
   #      with:
   #        node-version: 16.x
   #    - run: sudo snap install helm --classic

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: Bootstrapping project

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           USER_NAME: ${{ secrets.DEPLOYING_USER_NAME }}
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN_ACTION }} # Token for pushing
 
-      - uses: actions/setup-node@main
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - run: npx lerna bootstrap

--- a/packages/framework-core/src/services/read-model-store.ts
+++ b/packages/framework-core/src/services/read-model-store.ts
@@ -41,7 +41,7 @@ export class ReadModelStore {
         const readModelID = this.joinKeyForProjection(entityInstance, projectionMetadata)
         const sequenceKey = this.sequenceKeyForProjection(entityInstance, projectionMetadata)
         if (!readModelID) {
-          this.logger.debug(
+          this.logger.warn(
             `Couldn't find the joinKey named ${projectionMetadata.joinKey} in entity snapshot of ${entityMetadata.class.name}. Skipping...`
           )
           return

--- a/packages/framework-core/src/services/read-model-store.ts
+++ b/packages/framework-core/src/services/read-model-store.ts
@@ -8,7 +8,6 @@ import {
   ProjectionMetadata,
   UUID,
   EntityInterface,
-  InvalidParameterError,
   ReadModelAction,
   OptimisticConcurrencyUnexpectedVersionError,
   SequenceKey,
@@ -41,6 +40,12 @@ export class ReadModelStore {
         const entityInstance = createInstance(entityMetadata.class, entitySnapshotEnvelope.value)
         const readModelID = this.joinKeyForProjection(entityInstance, projectionMetadata)
         const sequenceKey = this.sequenceKeyForProjection(entityInstance, projectionMetadata)
+        if (!readModelID) {
+          this.logger.debug(
+            `Couldn't find the joinKey named ${projectionMetadata.joinKey} in entity snapshot of ${entityMetadata.class.name}. Skipping...`
+          )
+          return
+        }
         this.logger.debug(
           '[ReadModelStore#project] Projecting entity snapshot ',
           entitySnapshotEnvelope,
@@ -65,13 +70,7 @@ export class ReadModelStore {
   }
 
   private joinKeyForProjection(entity: EntityInterface, projectionMetadata: ProjectionMetadata): UUID {
-    const joinKey = (entity as any)[projectionMetadata.joinKey]
-    if (!joinKey) {
-      throw new InvalidParameterError(
-        `Couldn't find the joinKey named ${projectionMetadata.joinKey} in entity snapshot: ${entity}`
-      )
-    }
-    return joinKey
+    return (entity as any)[projectionMetadata.joinKey]
   }
 
   private sequenceKeyForProjection(
@@ -152,7 +151,7 @@ export class ReadModelStore {
     if (rawReadModels?.length) {
       if (rawReadModels.length > 1) {
         throw 'Got multiple objects for a request by Id. If this is a sequenced read model you should also specify the sequenceKey field.'
-      } else if (rawReadModels.length === 1) {
+      } else if (rawReadModels.length === 1 && rawReadModels[0]) {
         const readModelMetadata = this.config.readModels[readModelName]
         return createInstance(readModelMetadata.class, rawReadModels[0])
       }

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -443,6 +443,22 @@ describe('ReadModelStore', () => {
         expect(result).to.be.undefined
       })
 
+      it("returns `undefined` when the read model doesn't exist and provider returns [undefined]", async () => {
+        replace(config.provider.readModels, 'fetch', fake.returns([undefined]))
+        const readModelStore = new ReadModelStore(config, logger)
+
+        const result = await readModelStore.fetchReadModel(SomeReadModel.name, 'joinColumnID')
+
+        expect(config.provider.readModels.fetch).to.have.been.calledOnceWithExactly(
+          config,
+          logger,
+          SomeReadModel.name,
+          'joinColumnID',
+          undefined
+        )
+        expect(result).to.be.undefined
+      })
+
       it('returns an instance of the current read model value when it exists', async () => {
         replace(config.provider.readModels, 'fetch', fake.returns([{ id: 'joinColumnID' }]))
         const readModelStore = new ReadModelStore(config, logger)

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -13,7 +13,6 @@ import {
   ReadModelAction,
   OptimisticConcurrencyUnexpectedVersionError,
   ProjectionResult,
-  InvalidParameterError,
 } from '@boostercloud/framework-types'
 import { expect } from '../expect'
 import { createInstance } from '@boostercloud/framework-common-helpers'
@@ -496,14 +495,11 @@ describe('ReadModelStore', () => {
     })
 
     context('when the joinkey does not exist', () => {
-      it('throws an `InvalidParameterError', () => {
+      it('should not throw and error an skip', () => {
         const anEntitySnapshot = eventEnvelopeFor(AnImportantEntity.name)
         const anEntityInstance = createInstance(AnImportantEntity, anEntitySnapshot.value) as any
         const readModelStore = new ReadModelStore(config, logger) as any
-
-        expect(() => {
-          readModelStore.joinKeyForProjection(anEntityInstance, { joinKey: 'whatever' })
-        }).to.throw(InvalidParameterError)
+        expect(readModelStore.joinKeyForProjection(anEntityInstance, { joinKey: 'whatever' })).to.be.undefined
       })
     })
   })


### PR DESCRIPTION
Fixes two bugs:

Removed error and just log a warning if a joining key doesn't exists in read models
Avoid passing an empty object instance if the entity doesn't exists into the read models

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly

