### PR TITLE
Issue 1053: Add Array joinKey support in read model projections

### DIFF
--- a/docs/chapters/03_booster-architecture.md
+++ b/docs/chapters/03_booster-architecture.md
@@ -675,14 +675,24 @@ export class UserReadModel {
   public constructor(readonly username: string, /* ...(other interesting fields from users)... */) {}
 
   @Projects(User, 'id')
-  public static projectUser(entity: User, current?: ProjectionResult<UserReadModel>) { // Here we update the user fields}
+  public static projectUser(entity: User, current?: ProjectionResult<UserReadModel>, readModelID?: UUID) { // Here we update the user fields}
 
   @Projects(Post, 'ownerId')
-  public static projectUserPost(entity: Post, current?: ProjectionResult<UserReadModel>) { //Here we can adapt the read model to show specific user information related with the Post entity}
+  public static projectUserPost(entity: Post, current?: ProjectionResult<UserReadModel>, readModelID?: UUID) { //Here we can adapt the read model to show specific user information related with the Post entity}
 }
 ```
 
 In the previous example we are projecting the `User` entity using the user `id` and also we are projecting the `User` entity based on the `ownerId` of the `Post` entity. Notice that both join keys are references to the `User` identifier, but it's not required that the join key is an identifier.
+
+You can even select arrays of UUIDs as `joinKey`, Booster will execute the projection for all the read models corresponding to those ids contained in the array (projections are completely isolated from each other). So, for example, if we would have a `Group` with an array of users in that group (`users: Array<UUID>`), we can have the following to update each `UserReadModel` accordingly:
+
+```typescript
+  @Projects(Group, 'users')
+  public static projectUserGroup(entity: Group, current?: ProjectionResult<UserReadModel>, readModelID?: UUID) { 
+    //Here we can update the read models with group information
+    //This logic will be executed for each read model id in the array 
+  }
+```
 
 As you may have notice from the `ProjectionResult` type, projections can also return `ReadModelAction`, which includes:
 

--- a/docs/chapters/03_booster-architecture.md
+++ b/docs/chapters/03_booster-architecture.md
@@ -675,10 +675,14 @@ export class UserReadModel {
   public constructor(readonly username: string, /* ...(other interesting fields from users)... */) {}
 
   @Projects(User, 'id')
-  public static projectUser(entity: User, current?: ProjectionResult<UserReadModel>, readModelID?: UUID) { // Here we update the user fields}
+  public static projectUser(entity: User, current?: UserReadModel, readModelID?: UUID): ProjectionResult<UserReadModel> { 
+    // Here we update the user fields
+  }
 
   @Projects(Post, 'ownerId')
-  public static projectUserPost(entity: Post, current?: ProjectionResult<UserReadModel>, readModelID?: UUID) { //Here we can adapt the read model to show specific user information related with the Post entity}
+  public static projectUserPost(entity: Post, current?: UserReadModel, readModelID?: UUID): ProjectionResult<UserReadModel> { 
+    //Here we can adapt the read model to show specific user information related with the Post entity
+  }
 }
 ```
 
@@ -688,7 +692,7 @@ You can even select arrays of UUIDs as `joinKey`, Booster will execute the proje
 
 ```typescript
   @Projects(Group, 'users')
-  public static projectUserGroup(entity: Group, current?: ProjectionResult<UserReadModel>, readModelID?: UUID) { 
+  public static projectUserGroup(entity: Group, current?: UserReadModel, readModelID?: UUID): ProjectionResult<UserReadModel> { 
     //Here we can update the read models with group information
     //This logic will be executed for each read model id in the array 
   }

--- a/docs/chapters/03_booster-architecture.md
+++ b/docs/chapters/03_booster-architecture.md
@@ -675,12 +675,12 @@ export class UserReadModel {
   public constructor(readonly username: string, /* ...(other interesting fields from users)... */) {}
 
   @Projects(User, 'id')
-  public static projectUser(entity: User, current?: UserReadModel, readModelID?: UUID): ProjectionResult<UserReadModel> { 
+  public static projectUser(entity: User, current?: UserReadModel): ProjectionResult<UserReadModel> { 
     // Here we update the user fields
   }
 
   @Projects(Post, 'ownerId')
-  public static projectUserPost(entity: Post, current?: UserReadModel, readModelID?: UUID): ProjectionResult<UserReadModel> { 
+  public static projectUserPost(entity: Post, current?: UserReadModel): ProjectionResult<UserReadModel> { 
     //Here we can adapt the read model to show specific user information related with the Post entity
   }
 }
@@ -688,11 +688,12 @@ export class UserReadModel {
 
 In the previous example we are projecting the `User` entity using the user `id` and also we are projecting the `User` entity based on the `ownerId` of the `Post` entity. Notice that both join keys are references to the `User` identifier, but it's not required that the join key is an identifier.
 
-You can even select arrays of UUIDs as `joinKey`, Booster will execute the projection for all the read models corresponding to those ids contained in the array (projections are completely isolated from each other). So, for example, if we would have a `Group` with an array of users in that group (`users: Array<UUID>`), we can have the following to update each `UserReadModel` accordingly:
+You can even select arrays of UUIDs as `joinKey`, Booster will execute the projection for all the read models corresponding to those ids contained in the array (projections are completely isolated from each other). A subtle difference with non-array `joinKey` is the projection method signature. With array join keys, sometimes, we need extra information to know which is the read model we are projecting (especially for not yet existent read models, where the current argument is not present)
+So, for example, if we would have a `Group` with an array of users in that group (`users: Array<UUID>`), we can have the following to update each `UserReadModel` accordingly:
 
 ```typescript
   @Projects(Group, 'users')
-  public static projectUserGroup(entity: Group, current?: UserReadModel, readModelID?: UUID): ProjectionResult<UserReadModel> { 
+  public static projectUserGroup(entity: Group, readModelID: UUID, current?: UserReadModel): ProjectionResult<UserReadModel> { 
     //Here we can update the read models with group information
     //This logic will be executed for each read model id in the array 
   }

--- a/packages/framework-core/src/services/read-model-store.ts
+++ b/packages/framework-core/src/services/read-model-store.ts
@@ -47,7 +47,7 @@ export class ReadModelStore {
           return
         }
 
-        return readModelIDList.map(async (readModelID: UUID) => {
+        return readModelIDList.map((readModelID: UUID) => {
           this.logger.debug(
             '[ReadModelStore#project] Projecting entity snapshot ',
             entitySnapshotEnvelope,
@@ -55,7 +55,7 @@ export class ReadModelStore {
             sequenceKey ? ` sequencing by ${sequenceKey.name} with value ${sequenceKey.value}` : ''
           )
 
-          return await retryIfError(
+          return retryIfError(
             this.logger,
             () =>
               this.applyProjectionToReadModel(

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -49,7 +49,7 @@ describe('ReadModelStore', () => {
 
   class SomeReadModel {
     public constructor(readonly id: UUID) {}
-    public static someObserver(entity: AnImportantEntity, obj: any, readModelID?: UUID): any {
+    public static someObserver(entity: AnImportantEntity, readModelID: UUID, obj: any): any {
       const count = (obj?.count || 0) + entity.count
       return { id: readModelID, kind: 'some', count: count }
     }

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -13,6 +13,7 @@ import {
   ReadModelAction,
   OptimisticConcurrencyUnexpectedVersionError,
   ProjectionResult,
+  ReadModelInterface,
 } from '@boostercloud/framework-types'
 import { expect } from '../expect'
 import { createInstance } from '@boostercloud/framework-common-helpers'
@@ -34,15 +35,23 @@ describe('ReadModelStore', () => {
     }
   }
 
+  class AnImportantEntityWithArray {
+    public constructor(readonly id: UUID, readonly someKey: Array<UUID>, readonly count: number) {}
+
+    public getPrefixedKey(prefix: string): string {
+      return `${prefix}-${this.someKey.join('-')}`
+    }
+  }
+
   class AnEntity {
     public constructor(readonly id: UUID, readonly someKey: UUID, readonly count: number) {}
   }
 
   class SomeReadModel {
     public constructor(readonly id: UUID) {}
-    public static someObserver(entity: AnImportantEntity, obj: any): any {
+    public static someObserver(entity: AnImportantEntity, obj: any, readModelID?: UUID): any {
       const count = (obj?.count || 0) + entity.count
-      return { id: entity.someKey, kind: 'some', count: count }
+      return { id: readModelID, kind: 'some', count: count }
     }
     public getId(): UUID {
       return this.id
@@ -83,6 +92,7 @@ describe('ReadModelStore', () => {
   } as unknown as ProviderLibrary
   config.entities[AnImportantEntity.name] = { class: AnImportantEntity, authorizeReadEvents: [] }
   config.entities[AnEntity.name] = { class: AnEntity, authorizeReadEvents: [] }
+  config.entities[AnImportantEntityWithArray.name] = { class: AnImportantEntityWithArray, authorizeReadEvents: [] }
   config.readModels[SomeReadModel.name] = {
     class: SomeReadModel,
     authorizedRoles: 'all',
@@ -112,6 +122,13 @@ describe('ReadModelStore', () => {
       joinKey: 'someKey',
     },
   ]
+  config.projections[AnImportantEntityWithArray.name] = [
+    {
+      class: SomeReadModel,
+      methodName: 'someObserver',
+      joinKey: 'someKey',
+    },
+  ]
   config.projections['AnEntity'] = [
     {
       class: SomeReadModel,
@@ -121,6 +138,10 @@ describe('ReadModelStore', () => {
   ]
 
   function eventEnvelopeFor(entityName: string): EventEnvelope {
+    let someKeyValue: any = 'joinColumnID'
+    if (AnImportantEntityWithArray.name == entityName) {
+      someKeyValue = ['joinColumnID', 'anotherJoinColumnID']
+    }
     return {
       version: 1,
       kind: 'snapshot',
@@ -128,7 +149,7 @@ describe('ReadModelStore', () => {
       entityTypeName: entityName,
       value: {
         id: 'importantEntityID',
-        someKey: 'joinColumnID',
+        someKey: someKeyValue,
         count: 123,
       } as any,
       requestID: 'whatever',
@@ -392,6 +413,149 @@ describe('ReadModelStore', () => {
       })
     })
 
+    context('when multiple read models are projected from Array joinKey', () => {
+      it('creates non-existent read models and updates existing read models', async () => {
+        replace(config.provider.readModels, 'store', fake())
+        const readModelStore = new ReadModelStore(config, logger)
+        const someReadModelStoredVersion = 10
+        replace(
+          readModelStore,
+          'fetchReadModel',
+          fake((className: string, id: UUID) => {
+            if (className == SomeReadModel.name) {
+              if (id == 'anotherJoinColumnID') {
+                return null
+              } else {
+                return { id: id, kind: 'some', count: 77, boosterMetadata: { version: someReadModelStoredVersion } }
+              }
+            }
+            return null
+          })
+        )
+        spy(SomeReadModel, 'someObserver')
+        const anEntitySnapshot = eventEnvelopeFor(AnImportantEntityWithArray.name)
+        const entityValue: any = anEntitySnapshot.value
+        const anEntityInstance = new AnImportantEntityWithArray(entityValue.id, entityValue.someKey, entityValue.count)
+        await readModelStore.project(anEntitySnapshot)
+
+        expect(readModelStore.fetchReadModel).to.have.been.calledTwice
+        expect(readModelStore.fetchReadModel).to.have.been.calledWith(SomeReadModel.name, 'joinColumnID')
+        expect(readModelStore.fetchReadModel).to.have.been.calledWith(SomeReadModel.name, 'anotherJoinColumnID')
+        expect(SomeReadModel.someObserver).to.have.been.calledWithMatch(
+          anEntityInstance,
+          {
+            id: 'joinColumnID',
+            kind: 'some',
+            count: 77,
+            boosterMetadata: { version: someReadModelStoredVersion },
+          },
+          'joinColumnID'
+        )
+        expect(SomeReadModel.someObserver).to.have.returned({
+          id: 'joinColumnID',
+          kind: 'some',
+          count: 200,
+          boosterMetadata: { version: someReadModelStoredVersion + 1 },
+        })
+        expect(SomeReadModel.someObserver).to.have.been.calledWithMatch(anEntityInstance, null, 'anotherJoinColumnID')
+        expect(SomeReadModel.someObserver).to.have.returned({
+          id: 'anotherJoinColumnID',
+          kind: 'some',
+          count: 123,
+          boosterMetadata: { version: 1 },
+        })
+
+        expect(config.provider.readModels.store).to.have.been.calledTwice
+        expect(config.provider.readModels.store).to.have.been.calledWith(
+          config,
+          logger,
+          SomeReadModel.name,
+          {
+            id: 'joinColumnID',
+            kind: 'some',
+            count: 200,
+            boosterMetadata: { version: someReadModelStoredVersion + 1 },
+          },
+          someReadModelStoredVersion
+        )
+        expect(config.provider.readModels.store).to.have.been.calledWith(
+          config,
+          logger,
+          SomeReadModel.name,
+          {
+            id: 'anotherJoinColumnID',
+            kind: 'some',
+            count: 123,
+            boosterMetadata: { version: 1 },
+          },
+          0
+        )
+      })
+    })
+
+    context('when there is high contention and optimistic concurrency is needed for Array joinKey projections', () => {
+      it('The retries are independent for all Read Models in the array, retries 5 times when the error OptimisticConcurrencyUnexpectedVersionError happens 4 times', async () => {
+        let tryNumber = 1
+        const expectedAnotherJoinColumnIDTries = 5
+        const expectedJoinColumnIDTries = 1
+        const fakeStore = fake(
+          (
+            config: BoosterConfig,
+            logger: Logger,
+            readModelName: string,
+            readModel: ReadModelInterface
+          ): Promise<unknown> => {
+            if (readModelName === SomeReadModel.name) {
+              if (readModel.id == 'anotherJoinColumnID' && tryNumber < expectedAnotherJoinColumnIDTries) {
+                tryNumber++
+                throw new OptimisticConcurrencyUnexpectedVersionError('test error')
+              }
+            }
+            return Promise.resolve()
+          }
+        )
+        replace(config.provider.readModels, 'store', fakeStore)
+
+        const readModelStore = new ReadModelStore(config, logger)
+        await readModelStore.project(eventEnvelopeFor(AnImportantEntityWithArray.name))
+
+        const someReadModelStoreCalls = fakeStore.getCalls().filter((call) => call.args[2] === SomeReadModel.name)
+        expect(someReadModelStoreCalls).to.be.have.length(expectedJoinColumnIDTries + expectedAnotherJoinColumnIDTries)
+        someReadModelStoreCalls
+          .filter((call) => call.args[3].id == 'joinColumnID')
+          .forEach((call) => {
+            expect(call.args).to.be.deep.equal([
+              config,
+              logger,
+              SomeReadModel.name,
+              {
+                id: 'joinColumnID',
+                kind: 'some',
+                count: 123,
+                boosterMetadata: { version: 1 },
+              },
+              0,
+            ])
+          })
+        someReadModelStoreCalls
+          .filter((call) => call.args[3].id == 'anotherJoinColumnID')
+          .forEach((call) => {
+            expect(call.args).to.be.deep.equal([
+              config,
+              logger,
+              SomeReadModel.name,
+              {
+                id: 'anotherJoinColumnID',
+                kind: 'some',
+                count: 123,
+                boosterMetadata: { version: 1 },
+              },
+              0,
+            ])
+          })
+      })
+    })
+
     context('for read models with defined sequenceKeys', () => {
       beforeEach(() => {
         config.readModelSequenceKeys['AnotherReadModel'] = 'count'
@@ -504,9 +668,9 @@ describe('ReadModelStore', () => {
         const anEntityInstance = createInstance(AnImportantEntity, anEntitySnapshot.value) as any
         const readModelStore = new ReadModelStore(config, logger) as any
 
-        expect(readModelStore.joinKeyForProjection(anEntityInstance, { joinKey: 'someKey' })).to.be.equal(
-          'joinColumnID'
-        )
+        expect(readModelStore.joinKeyForProjection(anEntityInstance, { joinKey: 'someKey' })).to.be.deep.equal([
+          'joinColumnID',
+        ])
       })
     })
 

--- a/packages/framework-integration-tests/src/commands/create-pack.ts
+++ b/packages/framework-integration-tests/src/commands/create-pack.ts
@@ -1,0 +1,16 @@
+import { Command } from '@boostercloud/framework-core'
+import { Register, UUID } from '@boostercloud/framework-types'
+import { UserWithEmail, Admin } from '../roles'
+import { PackCreated } from '../events/pack-created'
+
+@Command({
+  authorize: [Admin, UserWithEmail],
+})
+export class CreatePack {
+  public constructor(readonly name: string, readonly products: Array<UUID>, readonly packID?: UUID) {}
+
+  public static async handle(command: CreatePack, register: Register): Promise<void> {
+    const packID = command.packID ?? UUID.generate()
+    register.events(new PackCreated(packID, command.name, command.products))
+  }
+}

--- a/packages/framework-integration-tests/src/entities/pack.ts
+++ b/packages/framework-integration-tests/src/entities/pack.ts
@@ -3,7 +3,7 @@ import { UUID } from '@boostercloud/framework-types'
 import { PackCreated } from '../events/pack-created'
 
 /**
- * An order object represents a completed order that's ready to be delivered
+ * A pack object represents a group of products that works great together
  */
 @Entity
 export class Pack {

--- a/packages/framework-integration-tests/src/entities/pack.ts
+++ b/packages/framework-integration-tests/src/entities/pack.ts
@@ -1,0 +1,16 @@
+import { Entity, Reduces } from '@boostercloud/framework-core'
+import { UUID } from '@boostercloud/framework-types'
+import { PackCreated } from '../events/pack-created'
+
+/**
+ * An order object represents a completed order that's ready to be delivered
+ */
+@Entity
+export class Pack {
+  public constructor(readonly id: UUID, readonly name: string, readonly products: Array<UUID>) {}
+
+  @Reduces(PackCreated)
+  public static createOrder(event: PackCreated): Pack {
+    return new Pack(event.packID, event.name, event.products)
+  }
+}

--- a/packages/framework-integration-tests/src/events/pack-created.ts
+++ b/packages/framework-integration-tests/src/events/pack-created.ts
@@ -1,0 +1,11 @@
+import { Event } from '@boostercloud/framework-core'
+import { UUID } from '@boostercloud/framework-types'
+
+@Event
+export class PackCreated {
+  public constructor(readonly packID: UUID, readonly name: string, readonly products: Array<UUID>) {}
+
+  public entityID(): UUID {
+    return this.packID
+  }
+}

--- a/packages/framework-integration-tests/src/read-models/product-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/product-read-model.ts
@@ -4,6 +4,7 @@ import { ProjectionResult, ReadModelAction, UUID } from '@boostercloud/framework
 import { Product } from '../entities/product'
 import { SKU } from '../common/sku'
 import { Money } from '../common/money'
+import { Pack } from '../entities/pack'
 
 // This is an example read model for a possible admin-exclusive report to show last and previous updates to products
 @ReadModel({
@@ -17,7 +18,8 @@ export class ProductReadModel {
     readonly description: string,
     readonly availability: number,
     public deleted: boolean,
-    readonly price?: Money
+    readonly price?: Money,
+    readonly packs?: Array<Pack>
   ) {}
 
   @Projects(Product, 'id')
@@ -32,7 +34,37 @@ export class ProductReadModel {
         product.description,
         product.availability,
         product.deleted,
-        product.price
+        product.price,
+        []
+      )
+    }
+  }
+
+  @Projects(Pack, 'products')
+  public static updateWithPack(
+    pack: Pack,
+    currentProductReadModel?: ProductReadModel
+  ): ProjectionResult<ProductReadModel> {
+    if (!currentProductReadModel) {
+      return ReadModelAction.Nothing
+    } else {
+      let packList = currentProductReadModel.packs || []
+      if (packList?.find((existingPack) => existingPack.id == pack.id)) {
+        //Update existing pack in case new products added
+        packList = packList.map((existingPack) => (existingPack.id == pack.id ? pack : existingPack))
+      } else {
+        //Add pack to existing packs
+        packList?.push(pack)
+      }
+      return new ProductReadModel(
+        currentProductReadModel.id,
+        currentProductReadModel.sku,
+        currentProductReadModel.displayName,
+        currentProductReadModel.description,
+        currentProductReadModel.availability,
+        currentProductReadModel.deleted,
+        currentProductReadModel.price,
+        packList
       )
     }
   }

--- a/packages/framework-integration-tests/src/read-models/product-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/product-read-model.ts
@@ -43,6 +43,7 @@ export class ProductReadModel {
   @Projects(Pack, 'products')
   public static updateWithPack(
     pack: Pack,
+    readModelID: UUID,
     currentProductReadModel?: ProductReadModel
   ): ProjectionResult<ProductReadModel> {
     if (!currentProductReadModel) {

--- a/packages/framework-types/src/concepts/projection-metadata.ts
+++ b/packages/framework-types/src/concepts/projection-metadata.ts
@@ -1,10 +1,9 @@
-import { Class } from '..'
+import { AnyClass } from '@boostercloud/framework-types'
 
-export interface ProjectionMetadata {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  class: Class<any>
+export interface ProjectionMetadata<TEntity> {
+  class: AnyClass
   methodName: string
-  joinKey: string
+  joinKey: keyof TEntity
 }
 
 export type ProjectionResult<TReadModel> = TReadModel | ReadModelAction

--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -11,6 +11,7 @@ import {
   EventMetadata,
   TokenVerifierConfig,
   CommandHandlerReturnTypeMetadata,
+  EntityInterface,
 } from './concepts'
 import { ProviderLibrary } from './provider'
 import { Level } from './logger'
@@ -54,7 +55,7 @@ export class BoosterConfig {
   public readonly commandHandlerReturnTypes: Record<CommandName, CommandHandlerReturnTypeMetadata> = {}
   public readonly eventHandlers: Record<EventName, Array<EventHandlerInterface>> = {}
   public readonly readModels: Record<ReadModelName, ReadModelMetadata> = {}
-  public readonly projections: Record<EntityName, Array<ProjectionMetadata>> = {}
+  public readonly projections: Record<EntityName, Array<ProjectionMetadata<EntityInterface>>> = {}
   public readonly readModelSequenceKeys: Record<EntityName, string> = {}
   public readonly roles: Record<RoleName, RoleMetadata> = {}
   public readonly migrations: Record<ConceptName, Map<Version, MigrationMetadata>> = {}


### PR DESCRIPTION
## Description
This PR is related to the need of using array fields in the `joinKey` for read model projections. The implemented behavior is to execute the projection for all the UUIDs in the array independently. So we will call the projection logic for each read model in the array.

The change is backward compatible with previous projections methods, so no changes are required in projects using the previous version.

## Changes

- Update `joinKeyForProjection` method to always return `Array<UUID>` or `undefined` in case the key is missing
- Updated `project` method to process and call `applyProjectionToReadModel` for each UUID in the `joinKey` array
- Add an optional parameter to the `projectionFunction` call in order to pass the current readModelID we are processing from the array
- Adding type checking in projection methods (Compiler will show errors in the projection function signature)
- Adding tests with array `joinKey`
- Adding integration tests with array `joinKey`
- Updating documentation

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Backward compatibility

## Additional information
- Related Issue: https://github.com/boostercloud/booster/issues/1053
