### PR TITLE
added a configuration to control the availability of graphQL instrospection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,7 @@
   "version": "0.2.0",
   "configurations": [
 
+
     {
       "type": "node",
       "request": "launch",
@@ -327,6 +328,24 @@
       "internalConsoleOptions": "neverOpen",
       "protocol": "inspector",
       "runtimeArgs": ["--preserve-symlinks"]
-    }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Server in debug mode",
+      "cwd": "${workspaceFolder}/packages/framework-integration-tests/local-project-integration-sandbox",
+      "skipFiles": [
+      ],
+      "program": "${workspaceFolder}/packages/cli/bin/run",
+      "args": [
+          "start",
+          "-e",
+          "local"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "protocol": "inspector",
+      "runtimeArgs": ["--preserve-symlinks"]
+  }
   ]
 }

--- a/docs/chapters/05_going-deeper.md
+++ b/docs/chapters/05_going-deeper.md
@@ -67,6 +67,8 @@ The following is the list of the fields you can configure:
 
 - **providerPackage:** This field contains the name of the provider package that Booster will use when deploying or running your application.
 
+-**enableGraphQLIntrospection** This field allows to enable/disable get information about the GraphQL schema of your application from client side. By default is enabled but it is recommended to disable for security reasons in production applications.  
+
 - **assets**: This is an array of _relative_ paths from the root of the project pointing to files and folders with static assets. They will be included among the deployed files to the cloud provider.
   For example, imagine you are using the `dotenv` module so that all the environment variables you have in your `.env` files are loaded into memory in runtime. In order for this to work, you need to include your `.env` files as assets of your project, so that they are included when deploying. Assuming you only have a `.env` file in the root of your project, you should add the following to your configuration:
   ```typescript

--- a/packages/framework-core/src/booster-graphql-dispatcher.ts
+++ b/packages/framework-core/src/booster-graphql-dispatcher.ts
@@ -109,6 +109,14 @@ export class BoosterGraphQLDispatcher {
         throw errors
       }
       const operationData = graphql.getOperationAST(queryDocument, operation.operationName)
+      const isIntrospectionQuery =
+        operation.operationName === 'IntrospectionQuery' || operation.query.includes('__schema')
+      if (isIntrospectionQuery && !this.config.enableGraphQLIntrospection) {
+        throw new InvalidProtocolError(
+          'Instrospection queries are disabled. Check the configuration if you want to enable them.'
+        )
+      }
+
       if (!operationData) {
         throw new InvalidParameterError(
           'Could not extract GraphQL operation. ' +

--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -35,6 +35,7 @@ export class BoosterConfig {
     maxConnectionDurationInSeconds: 7 * 24 * 60 * 60, // 7 days
     maxDurationInSeconds: 2 * 24 * 60 * 60, // 2 days
   }
+  public enableGraphQLIntrospection = true
   private _userProjectRootPath?: string
   public readonly codeRelativePath: string = 'dist'
   public readonly eventDispatcherHandler: string = path.join(this.codeRelativePath, 'index.boosterEventDispatcher')


### PR DESCRIPTION
## Description
Added a flag to enable/disable graphQL introspection (a.k. a. get the schema) in `Booster.Config`

## Changes
- Added flag to `Booster.Config`
- Modified graphQL dispatch to use the flag and return an error to tell the user what's happening with the schema
- Added Tests
- Added a new configuration to `launch.json` to launch the local debugger using the sandbox app under the integration test package 

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly