### PR TITLE
Promisified public key field in the token verifier config

### DIFF
--- a/packages/framework-core/src/booster-token-verifier.ts
+++ b/packages/framework-core/src/booster-token-verifier.ts
@@ -51,7 +51,7 @@ class TokenVerifierClient {
     let key: jwt.Secret | jwt.GetPublicKeyOrSecret = getKey
     if (!this.client) {
       if (this.tokenVerifierConfig.publicKey) {
-        key = this.tokenVerifierConfig.publicKey
+        key = await this.tokenVerifierConfig.publicKey
       } else {
         throw new Error('Token verifier not well configured')
       }

--- a/packages/framework-integration-tests/src/config/config.ts
+++ b/packages/framework-integration-tests/src/config/config.ts
@@ -10,13 +10,15 @@ Booster.configure('local', (config: BoosterConfig): void => {
     {
       issuer: 'booster',
       // Read the content of the public RS256 cert, used to sign the JWT tokens
-      publicKey: fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8'),
+      publicKey: fs.readFile(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8'),
       rolesClaim: 'booster:role',
     },
     {
       issuer: 'booster',
       // Read the content of the public RS256 cert, used to sign the JWT tokens
-      publicKey: fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8'),
+      publicKey: Promise.resolve(
+        fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8')
+      ),
       rolesClaim: 'booster:role',
       extraValidation: async (jwtToken, _rawToken) => {
         throw new Error('Unauthorized')
@@ -53,13 +55,17 @@ Booster.configure('production', (config: BoosterConfig): void => {
     {
       issuer: 'booster',
       // Read the content of the public RS256 cert, used to sign the JWT tokens
-      publicKey: fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8'),
+      publicKey: Promise.resolve(
+        fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8')
+      ),
       rolesClaim: 'booster:role',
     },
     {
       issuer: 'booster',
       // Read the content of the public RS256 cert, used to sign the JWT tokens
-      publicKey: fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8'),
+      publicKey: Promise.resolve(
+        fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8')
+      ),
       rolesClaim: 'booster:role',
       extraValidation: async (jwtToken, _rawToken) => {
         throw new Error('Unauthorized')
@@ -84,13 +90,17 @@ Booster.configure('azure', (config: BoosterConfig): void => {
     {
       issuer: 'booster',
       // Read the content of the public RS256 cert, used to sign the JWT tokens
-      publicKey: fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8'),
+      publicKey: Promise.resolve(
+        fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8')
+      ),
       rolesClaim: 'booster:role',
     },
     {
       issuer: 'booster',
       // Read the content of the public RS256 cert, used to sign the JWT tokens
-      publicKey: fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8'),
+      publicKey: Promise.resolve(
+        fs.readFileSync(path.join(__dirname, '..', '..', 'assets', 'certs', 'public.key'), 'utf8')
+      ),
       rolesClaim: 'booster:role',
       extraValidation: async (jwtToken, _rawToken) => {
         throw new Error('Unauthorized')

--- a/packages/framework-types/src/concepts/token-verifier-config.ts
+++ b/packages/framework-types/src/concepts/token-verifier-config.ts
@@ -1,7 +1,7 @@
 export type TokenVerifierConfig = {
   issuer: string
   jwksUri?: string
-  publicKey?: string
+  publicKey?: Promise<string>
   rolesClaim?: string
   extraValidation?: (jwtToken: Record<string, unknown>, rawToken: string) => Promise<void>
 }


### PR DESCRIPTION
Promisified the `publicKey` field in `TokenVerifierConfig` to allow async ways to load the public key (like reading it from a key vault or a file)