### PR TITLE
style(cli): eslint prettier fix code formatting

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -28,12 +28,14 @@ export default class Build extends BaseCommand {
   }
 
   async catch(fullError: Error) {
-    const { flags: { verbose } } = this.parse(Build)
+    const {
+      flags: { verbose },
+    } = this.parse(Build)
 
     if (verbose) {
       console.error(fullError.message)
     }
- 
+
     return super.catch(fullError)
   }
 }

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -28,12 +28,14 @@ export default class Clean extends BaseCommand {
   }
 
   async catch(fullError: Error) {
-    const { flags: { verbose } } = this.parse(Clean)
+    const {
+      flags: { verbose },
+    } = this.parse(Clean)
 
     if (verbose) {
       console.error(fullError.message)
     }
- 
+
     return super.catch(fullError)
   }
 }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -47,12 +47,14 @@ export default class Deploy extends BaseCommand {
   }
 
   async catch(fullError: Error) {
-    const { flags: { verbose } } = this.parse(Deploy)
+    const {
+      flags: { verbose },
+    } = this.parse(Deploy)
 
     if (verbose) {
       console.error(fullError.message)
     }
- 
+
     return super.catch(fullError)
   }
 }

--- a/packages/cli/src/commands/nuke.ts
+++ b/packages/cli/src/commands/nuke.ts
@@ -69,12 +69,14 @@ export default class Nuke extends BaseCommand {
   }
 
   async catch(fullError: Error) {
-    const { flags: { verbose } } = this.parse(Nuke)
+    const {
+      flags: { verbose },
+    } = this.parse(Nuke)
 
     if (verbose) {
       console.error(fullError.message)
     }
- 
+
     return super.catch(fullError)
   }
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -46,12 +46,14 @@ export default class Start extends BaseCommand {
   }
 
   async catch(fullError: Error) {
-    const { flags: { verbose } } = this.parse(Start)
+    const {
+      flags: { verbose },
+    } = this.parse(Start)
 
     if (verbose) {
       console.error(fullError.message)
     }
- 
+
     return super.catch(fullError)
   }
 }

--- a/packages/cli/src/commands/synth.ts
+++ b/packages/cli/src/commands/synth.ts
@@ -47,12 +47,14 @@ export default class Synth extends BaseCommand {
   }
 
   async catch(fullError: Error) {
-    const { flags: { verbose } } = this.parse(Synth)
+    const {
+      flags: { verbose },
+    } = this.parse(Synth)
 
     if (verbose) {
       console.error(fullError.message)
     }
- 
+
     return super.catch(fullError)
   }
 }

--- a/packages/cli/src/common/base-command.ts
+++ b/packages/cli/src/common/base-command.ts
@@ -8,7 +8,7 @@ export default abstract class BaseCommand extends Command {
   }
 
   async catch(fullError: Error) {
-    const errorMessage = fullError.message.split('\n')[0].replace('Error:','')
+    const errorMessage = fullError.message.split('\n')[0].replace('Error:', '')
     const logRefMessage = '\n(You can see the full error logs in ./errors.log)'
     const errorForFile = `\nboost ${this.id} ${this.argv.join(' ')}\n${fullError.message}`
     appendOnErrorsFile(errorForFile)

--- a/packages/cli/src/services/logger.ts
+++ b/packages/cli/src/services/logger.ts
@@ -14,6 +14,9 @@ export const logger: Logger = {
 
 export function appendOnErrorsFile(data: string): void {
   const errorsFile = path.join(process.cwd(), 'errors.log')
-  const transformedData = data.split("\n").map(line => `[${new Date().toISOString()}] ${line}`).join("\n")
+  const transformedData = data
+    .split('\n')
+    .map((line) => `[${new Date().toISOString()}] ${line}`)
+    .join('\n')
   appendFileSync(errorsFile, transformedData)
 }

--- a/packages/cli/src/services/project-checker.ts
+++ b/packages/cli/src/services/project-checker.ts
@@ -76,7 +76,7 @@ export async function checkCurrentDirBoosterVersion(version: string): Promise<vo
 }
 
 async function checkBoosterVersion(cliVersion: string, projectPath: string): Promise<void> {
-  const projectVersion = await getBoosterVersion(projectPath)  
+  const projectVersion = await getBoosterVersion(projectPath)
   await compareVersionsAndDisplayMessages(cliVersion, projectVersion)
 }
 

--- a/packages/cli/test/services/logger.test.ts
+++ b/packages/cli/test/services/logger.test.ts
@@ -5,46 +5,46 @@ import { restore, replace, fake } from 'sinon'
 import { expect } from '../expect'
 
 describe('Booster logger', (): void => {
-    afterEach(() => {
-       restore()
-    }) 
-  
-    describe('logger', () => {
-        const message: string = 'this is a message for the logger'
+  afterEach(() => {
+    restore()
+  })
 
-        beforeEach(() => {
-            replace(oraLogger,'warn', fake.resolves({}))
-            replace(oraLogger,'info', fake.resolves({}))
-            replace(oraLogger,'fail', fake.resolves({}))
-        }) 
+  describe('logger', () => {
+    const message: string = 'this is a message for the logger'
 
-        it('log a debug message', async () => {
-            logger.debug(message) 
-            expect(oraLogger.warn).to.have.been.calledWith(message)
-        })
-    
-        it('log a info message', async () => {
-            logger.info(message) 
-            expect(oraLogger.info).to.have.been.calledWith(message)
-        })
-        
-        it('log a error message', async () => {
-            logger.error(message) 
-            expect(oraLogger.fail).to.have.been.calledWith(message)
-        })
+    beforeEach(() => {
+      replace(oraLogger, 'warn', fake.resolves({}))
+      replace(oraLogger, 'info', fake.resolves({}))
+      replace(oraLogger, 'fail', fake.resolves({}))
     })
 
-    describe('appendOnErrorsFile', () => {
-        beforeEach(() => {
-            replace(fs, 'appendFileSync', fake.returns(true))
-        })
-
-        it('writes in error.log file', async () => {
-            const data = "this is a message\nseparated with new line"
-            const errorsFile = path.join(process.cwd(), 'errors.log')
-            appendOnErrorsFile(data) 
-            expect(fs.appendFileSync).to.have.been.calledWithMatch(errorsFile, /this is a message/)
-            expect(fs.appendFileSync).to.have.been.calledWithMatch(errorsFile, /separated with new line/)
-        })
+    it('log a debug message', async () => {
+      logger.debug(message)
+      expect(oraLogger.warn).to.have.been.calledWith(message)
     })
+
+    it('log a info message', async () => {
+      logger.info(message)
+      expect(oraLogger.info).to.have.been.calledWith(message)
+    })
+
+    it('log a error message', async () => {
+      logger.error(message)
+      expect(oraLogger.fail).to.have.been.calledWith(message)
+    })
+  })
+
+  describe('appendOnErrorsFile', () => {
+    beforeEach(() => {
+      replace(fs, 'appendFileSync', fake.returns(true))
+    })
+
+    it('writes in error.log file', async () => {
+      const data = 'this is a message\nseparated with new line'
+      const errorsFile = path.join(process.cwd(), 'errors.log')
+      appendOnErrorsFile(data)
+      expect(fs.appendFileSync).to.have.been.calledWithMatch(errorsFile, /this is a message/)
+      expect(fs.appendFileSync).to.have.been.calledWithMatch(errorsFile, /separated with new line/)
+    })
+  })
 })


### PR DESCRIPTION
## Description
When I worked on #1074, I noticed that I got more changes than I made because ESLint fixed the code style from the recently merged feature, but I decided to leave those changes for a separate PR.

PR to fix the code style for feature that was introduced in #651.
It seems that sometimes the ESLint action added in #658 doesn't work?? And because of this, the code is left with the wrong code style

## Changes
- Fixed code style

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] ~Updated documentation accordingly~