### PR TITLE
fix: add UUID and Date types to GraphQL sort generator

### DIFF
--- a/packages/framework-core/src/services/graphql/query-helpers/graphql-query-sort-builder.ts
+++ b/packages/framework-core/src/services/graphql/query-helpers/graphql-query-sort-builder.ts
@@ -25,11 +25,12 @@ export class GraphqlQuerySortBuilder {
 
   private generateSortFor(prop: PropertyMetadata): GraphQLInputObjectType | GraphQLEnumType {
     let sortByName = `${prop.typeInfo.name}PropertySortBy`
-    sortByName = sortByName.charAt(0).toUpperCase() + sortByName.substr(1).replace(/\[]/g, '')
+    sortByName = sortByName.charAt(0).toUpperCase() + sortByName.substring(1).replace(/\[]/g, '')
 
     if (this.generatedSortByByTypeName[sortByName]) return this.generatedSortByByTypeName[sortByName]
     if (!prop.typeInfo.type || typeof prop.typeInfo.type === 'object') return this.orderType
     if (prop.typeInfo.typeGroup === 'Array') return this.orderType
+    if (prop.typeInfo.name === 'UUID' || prop.typeInfo.name === 'Date') return this.orderType
 
     let fields: Thunk<GraphQLInputFieldConfigMap> = {}
 


### PR DESCRIPTION
Similar to the filter generation, UUID and Date need to be filtered because they have typeGroup `Class` and we don't want `getClassMetadata` to be executed.