### PR TITLE
Make event processing concurrent + cache snapshots

### DIFF
--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -65,7 +65,6 @@ export class BoosterEventDispatcher {
       logger.debug('No new snapshot generated, skipping read models projection')
       return
     }
-    await eventStore.storeSnapshot(entitySnapshot)
     logger.debug('Snapshot loaded and started read models projection:', entitySnapshot)
     await readModelStore.project(entitySnapshot)
   }

--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -38,7 +38,7 @@ export class BoosterEventDispatcher {
 
   private static eventProcessor(eventStore: EventStore, readModelStore: ReadModelStore): EventsStreamingCallback {
     return async (entityName, entityID, eventEnvelopes, config) => {
-      // TODO: Separate into two independent processes the snapshotting/read-model generation process from the event handling process`
+      // TODO: Separate the snapshot creation/read-model generation from the event handling into two independent processes.
       await BoosterEventDispatcher.snapshotAndUpdateReadModels(
         config,
         entityName,

--- a/packages/framework-core/src/services/raw-events-parser.ts
+++ b/packages/framework-core/src/services/raw-events-parser.ts
@@ -20,7 +20,7 @@ export class RawEventsParser {
       .filter(isEventKind)
       .reduce(groupByEntity, {})
 
-    const procs = Object.values(eventEnvelopesPerEntity).map(async (entityEnvelopes) => {
+    const processes = Object.values(eventEnvelopesPerEntity).map(async (entityEnvelopes) => {
       const logger = getLogger(config, 'RawEventsParser#streamPerEntityEvents')
       // All envelopes are for the same entity type/ID, so we get the first one to get those values
       if (!entityEnvelopes[0]) {
@@ -33,7 +33,7 @@ export class RawEventsParser {
       )
       await callbackFn(entityTypeName, entityID, entityEnvelopes, config)
     })
-    await Promises.allSettledAndFulfilled(procs)
+    await Promises.allSettledAndFulfilled(processes)
   }
 }
 

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -178,7 +178,7 @@ describe('EventStore', () => {
       })
 
       context('when there is a snapshot and a short list of pending events', () => {
-        it('produces and returns a new snapshot without storing it', async () => {
+        it('produces and returns a new snapshot, storing it', async () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const eventStore = new EventStore(config) as any
           const someSnapshotEnvelope = snapshotEnvelopeFor(someEntity)
@@ -227,7 +227,7 @@ describe('EventStore', () => {
           )
           expect(eventStore.entityReducer.secondCall.args[1]).to.deep.equal(otherEventEnvelope)
 
-          expect(eventStore.storeSnapshot).not.to.have.been.called
+          expect(eventStore.storeSnapshot).to.have.been.called
 
           expect(entity).to.be.deep.equal(
             snapshotEnvelopeFor({
@@ -239,7 +239,7 @@ describe('EventStore', () => {
       })
 
       context('when there is a snapshot and a long list of pending events', () => {
-        it('produces a new snapshot and returns it, but never stores it', async () => {
+        it('produces a new snapshot, stores it and returns it', async () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const eventStore = new EventStore(config) as any
           const someSnapshotEnvelope = snapshotEnvelopeFor(someEntity)
@@ -296,7 +296,7 @@ describe('EventStore', () => {
             expect(eventStore.entityReducer.getCall(index).args[1]).to.deep.equal(pendingEvents[index])
           }
 
-          expect(eventStore.storeSnapshot).to.not.have.been.called
+          expect(eventStore.storeSnapshot).to.have.been.called
 
           expect(entity).to.be.deep.equal(
             snapshotEnvelopeFor({
@@ -308,7 +308,7 @@ describe('EventStore', () => {
       })
 
       context('with no snapshot and a list of more than 5 events', () => {
-        it('produces a new snapshot and returns it, but never stores it', async () => {
+        it('produces a new snapshot, stores it and returns it', async () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const eventStore = new EventStore(config) as any
           const someEventEnvelope = eventEnvelopeFor(someEvent, AnEvent.name)
@@ -360,7 +360,7 @@ describe('EventStore', () => {
             expect(eventStore.entityReducer.getCall(index).args[1]).to.deep.equal(pendingEvents[index])
           }
 
-          expect(eventStore.storeSnapshot).to.not.have.been.called
+          expect(eventStore.storeSnapshot).to.have.been.called
 
           expect(entity).to.be.deep.equal(
             snapshotEnvelopeFor({


### PR DESCRIPTION
### NOTE: THIS PR DEPENDS ON #1116

## Description

This PR makes event processing concurrent in order to avoid cancelling event processing for some entities when a reducer for an unrelated entity fails. 

Also it makes `fetchEntitySnapshot` cache the generated snapshots so they are available for the next time someone requests it.

## Changes

<!-- 

Describe changes you have made:

- Added tests
- Described "amazingMethodName" purpose in the docs
- New method `amazingMethodName`

-->

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] ~~Updated documentation accordingly~~

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
