### PR TITLE
fix: added default graphQL JSON scalar type as fallback for unrecognized types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
 				"js-yaml": "^3.14.0",
 				"jsonwebtoken": "8.5.1",
 				"jwks-rsa": "2.0.3",
-				"metadata-booster": "0.4.1",
+				"metadata-booster": "0.4.3",
 				"mocha-skip-if": "0.0.3",
 				"mock-jwks": "1.0.3",
 				"ms-rest-azure": "^3.0.0",
@@ -2829,12 +2829,12 @@
 			}
 		},
 		"node_modules/@boostercloud/framework-common-helpers": {
-			"version": "0.28.5",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.28.5.tgz",
-			"integrity": "sha512-GNo2/DwMjWDUBGuYapB0ZQmxy3vDB6zYUZ68q4yrSeIqK/pNOd7rEkyA5N44NkamrBHKvVnJPsJRPideCfNkrQ==",
+			"version": "0.29.6",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.29.6.tgz",
+			"integrity": "sha512-STKHxXaP5PXo+9Irfp4D/02FZxKHvpsjbmUn8Xr+4aaKPz4443tGl8SuutGM4ZoYYrnzxZFmhgeyo8EazvIz4g==",
 			"dev": true,
 			"dependencies": {
-				"@boostercloud/framework-types": "^0.28.5",
+				"@boostercloud/framework-types": "^0.29.6",
 				"child-process-promise": "^2.2.1",
 				"tslib": "2.3.1"
 			}
@@ -2844,9 +2844,9 @@
 			"link": true
 		},
 		"node_modules/@boostercloud/framework-types": {
-			"version": "0.28.5",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.28.5.tgz",
-			"integrity": "sha512-pl6zjQegEDNzqeODk36+KaKSN5p91U8RdJF4nbieRj16a7URlfk3ecw8uwmERviQuMJ9RmDlzq0T4nzz5y/CXA==",
+			"version": "0.29.6",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.29.6.tgz",
+			"integrity": "sha512-H/fOwzUjBuuwzORR54XnnXtShBlW6QSNODhXipe6WACwJABMOe5QuhV86PKH2l1QcrH3SRfFqrWTucuqXP1gTQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/graphql": "14.5.0",
@@ -20034,9 +20034,9 @@
 			}
 		},
 		"node_modules/metadata-booster": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/metadata-booster/-/metadata-booster-0.4.1.tgz",
-			"integrity": "sha512-FlQF6Yi/JumuY1hyVqd+KnqOzOXVWrGtDcTo9DNKB4jeItjDbo3n5yqS2pM+HEMh3m7zeJNUeMnlnYDH7/Pouw==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/metadata-booster/-/metadata-booster-0.4.3.tgz",
+			"integrity": "sha512-fYFam2FxudWLZLBm7AroJ6jHA57zOczqO6klYGvgKyPaORmXjZ4UTybi/ZzNuqitaRNAZhguULhffNKpwWY1uQ==",
 			"dependencies": {
 				"reflect-metadata": "0.1.13",
 				"ts-morph": "13.0.2",
@@ -27454,12 +27454,12 @@
 		},
 		"packages/framework-provider-local": {
 			"name": "@boostercloud/framework-provider-local",
-			"version": "0.28.5",
+			"version": "0.29.6",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@boostercloud/framework-common-helpers": "^0.28.5",
-				"@boostercloud/framework-types": "^0.28.5",
+				"@boostercloud/framework-common-helpers": "^0.29.6",
+				"@boostercloud/framework-types": "^0.29.6",
 				"@types/nedb": "^1.8.11",
 				"nedb": "^1.8.0",
 				"tslib": "2.3.1"
@@ -29218,12 +29218,12 @@
 			}
 		},
 		"@boostercloud/framework-common-helpers": {
-			"version": "0.28.5",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.28.5.tgz",
-			"integrity": "sha512-GNo2/DwMjWDUBGuYapB0ZQmxy3vDB6zYUZ68q4yrSeIqK/pNOd7rEkyA5N44NkamrBHKvVnJPsJRPideCfNkrQ==",
+			"version": "0.29.6",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-common-helpers/-/framework-common-helpers-0.29.6.tgz",
+			"integrity": "sha512-STKHxXaP5PXo+9Irfp4D/02FZxKHvpsjbmUn8Xr+4aaKPz4443tGl8SuutGM4ZoYYrnzxZFmhgeyo8EazvIz4g==",
 			"dev": true,
 			"requires": {
-				"@boostercloud/framework-types": "^0.28.5",
+				"@boostercloud/framework-types": "^0.29.6",
 				"child-process-promise": "^2.2.1",
 				"tslib": "2.3.1"
 			}
@@ -29231,8 +29231,8 @@
 		"@boostercloud/framework-provider-local": {
 			"version": "file:packages/framework-provider-local",
 			"requires": {
-				"@boostercloud/framework-common-helpers": "^0.28.5",
-				"@boostercloud/framework-types": "^0.28.5",
+				"@boostercloud/framework-common-helpers": "^0.29.6",
+				"@boostercloud/framework-types": "^0.29.6",
 				"@types/express": "4.17.12",
 				"@types/faker": "5.1.5",
 				"@types/nedb": "^1.8.11",
@@ -29248,9 +29248,9 @@
 			}
 		},
 		"@boostercloud/framework-types": {
-			"version": "0.28.5",
-			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.28.5.tgz",
-			"integrity": "sha512-pl6zjQegEDNzqeODk36+KaKSN5p91U8RdJF4nbieRj16a7URlfk3ecw8uwmERviQuMJ9RmDlzq0T4nzz5y/CXA==",
+			"version": "0.29.6",
+			"resolved": "https://registry.npmjs.org/@boostercloud/framework-types/-/framework-types-0.29.6.tgz",
+			"integrity": "sha512-H/fOwzUjBuuwzORR54XnnXtShBlW6QSNODhXipe6WACwJABMOe5QuhV86PKH2l1QcrH3SRfFqrWTucuqXP1gTQ==",
 			"dev": true,
 			"requires": {
 				"@types/graphql": "14.5.0",
@@ -42103,9 +42103,9 @@
 			"version": "1.4.1"
 		},
 		"metadata-booster": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/metadata-booster/-/metadata-booster-0.4.1.tgz",
-			"integrity": "sha512-FlQF6Yi/JumuY1hyVqd+KnqOzOXVWrGtDcTo9DNKB4jeItjDbo3n5yqS2pM+HEMh3m7zeJNUeMnlnYDH7/Pouw==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/metadata-booster/-/metadata-booster-0.4.3.tgz",
+			"integrity": "sha512-fYFam2FxudWLZLBm7AroJ6jHA57zOczqO6klYGvgKyPaORmXjZ4UTybi/ZzNuqitaRNAZhguULhffNKpwWY1uQ==",
 			"requires": {
 				"reflect-metadata": "0.1.13",
 				"ts-morph": "13.0.2",

--- a/packages/framework-core/package.json
+++ b/packages/framework-core/package.json
@@ -34,8 +34,8 @@
     "@boostercloud/framework-types": "^0.29.6",
     "fp-ts": "2.10.5",
     "graphql": "^15.5.1",
+    "graphql-scalars": "^1.17.0",
     "graphql-subscriptions": "1.2.1",
-    "graphql-type-json": "0.3.2",
     "inflected": "2.1.0",
     "iterall": "1.3.0",
     "jsonwebtoken": "8.5.1",
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@types/faker": "5.1.5",
-    "@types/graphql-type-json": "0.3.2",
     "@types/inflected": "1.1.29",
     "@types/jsonwebtoken": "8.5.1",
     "@types/validator": "13.1.3",

--- a/packages/framework-core/src/services/graphql/graphql-type-informer.ts
+++ b/packages/framework-core/src/services/graphql/graphql-type-informer.ts
@@ -13,7 +13,7 @@ import {
   GraphQLString,
   GraphQLType,
 } from 'graphql'
-import { GraphQLJSONObject } from 'graphql-type-json'
+import { GraphQLJSON } from 'graphql-scalars'
 import { ClassMetadata, ClassType, TypeMetadata } from 'metadata-booster'
 import { DateScalar, isExternalType } from './common'
 import { Logger } from '@boostercloud/framework-types'
@@ -83,7 +83,7 @@ export class GraphQLTypeInformer {
       const metadata = getClassMetadata(typeMetadata.type)
       return this.createObjectType(metadata, inputType)
     }
-    return GraphQLJSONObject
+    return GraphQLJSON
   }
 
   private createEnumType(typeMetadata: TypeMetadata): GraphQLEnumType {

--- a/packages/framework-core/src/services/graphql/query-generators/graphql-query-events-generator.ts
+++ b/packages/framework-core/src/services/graphql/query-generators/graphql-query-events-generator.ts
@@ -10,7 +10,7 @@ import {
   GraphQLString,
 } from 'graphql'
 import { buildGraphqlSimpleEnumFor, GraphQLResolverContext, ResolverBuilder } from '../common'
-import { GraphQLJSONObject } from 'graphql-type-json'
+import { GraphQLJSON } from 'graphql-scalars'
 import { BoosterConfig } from '@boostercloud/framework-types'
 
 export class GraphqlQueryEventsGenerator {
@@ -71,7 +71,7 @@ export class GraphqlQueryEventsGenerator {
             }),
           },
           createdAt: { type: new GraphQLNonNull(GraphQLString) },
-          value: { type: new GraphQLNonNull(GraphQLJSONObject) },
+          value: { type: new GraphQLNonNull(GraphQLJSON) },
         },
       })
     )

--- a/packages/framework-core/src/services/graphql/query-generators/graphql-query-listed-generator.ts
+++ b/packages/framework-core/src/services/graphql/query-generators/graphql-query-listed-generator.ts
@@ -9,7 +9,8 @@ import {
 } from 'graphql'
 import { GraphQLResolverContext, ResolverBuilder } from '../common'
 import * as inflected from 'inflected'
-import { GraphQLJSONObject } from 'graphql-type-json'
+import { GraphQLJSON } from 'graphql-scalars'
+
 import { GraphQLTypeInformer } from '../graphql-type-informer'
 import { GraphqlQuerySortBuilder } from '../query-helpers/graphql-query-sort-builder'
 import { GraphqlQueryFilterArgumentsBuilder } from '../query-helpers/graphql-query-filter-arguments-builder'
@@ -43,7 +44,7 @@ export class GraphqlQueryListedGenerator {
             fields: {
               items: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(graphQLType))) },
               count: { type: new GraphQLNonNull(GraphQLInt) },
-              cursor: { type: GraphQLJSONObject },
+              cursor: { type: GraphQLJSON },
             },
           })
         ),
@@ -76,7 +77,7 @@ export class GraphqlQueryListedGenerator {
       filter: { type: filter },
       limit: { type: GraphQLInt },
       sortBy: { type: sort },
-      afterCursor: { type: GraphQLJSONObject },
+      afterCursor: { type: GraphQLJSON },
     }
   }
 }

--- a/packages/framework-core/src/services/graphql/query-helpers/graphql-query-filter-arguments-builder.ts
+++ b/packages/framework-core/src/services/graphql/query-helpers/graphql-query-filter-arguments-builder.ts
@@ -12,7 +12,7 @@ import {
 } from 'graphql'
 import { getClassMetadata } from '../../../decorators/metadata'
 import { PropertyMetadata, TypeMetadata } from 'metadata-booster'
-import { GraphQLJSONObject } from 'graphql-type-json'
+import { GraphQLJSON } from 'graphql-scalars'
 import { AnyClass, UUID } from '@boostercloud/framework-types'
 import { GraphQLTypeInformer } from '../graphql-type-informer'
 import { DateScalar, isExternalType } from '../common'
@@ -46,10 +46,10 @@ export class GraphqlQueryFilterArgumentsBuilder {
     if (prop.typeInfo.name === 'UUID' || prop.typeInfo.name === 'Date') {
       fields = this.generateFilterInputTypes(prop.typeInfo)
     } else if (prop.typeInfo.type && (prop.typeInfo.typeGroup === 'Class' || prop.typeInfo.typeGroup === 'Object')) {
-      if (isExternalType(prop.typeInfo)) return GraphQLJSONObject
+      if (isExternalType(prop.typeInfo)) return GraphQLJSON
       let nestedProperties: GraphQLInputFieldConfigMap = {}
       const metadata = getClassMetadata(prop.typeInfo.type)
-      if (metadata.fields.length === 0) return GraphQLJSONObject
+      if (metadata.fields.length === 0) return GraphQLJSON
 
       this.typeInformer.generateGraphQLTypeForClass(prop.typeInfo.type, true)
 
@@ -67,7 +67,7 @@ export class GraphqlQueryFilterArgumentsBuilder {
     } else if (prop.typeInfo.type && prop.typeInfo.type.name !== 'Object') {
       fields = this.generateFilterInputTypes(prop.typeInfo)
     } else {
-      return GraphQLJSONObject
+      return GraphQLJSON
     }
     this.generatedFiltersByTypeName[filterName] = new GraphQLInputObjectType({ name: filterName, fields })
     return this.generatedFiltersByTypeName[filterName]
@@ -93,7 +93,7 @@ export class GraphqlQueryFilterArgumentsBuilder {
             graphqlType = GraphQLFloat
             break
           default:
-            graphqlType = param.type === UUID ? GraphQLID : GraphQLJSONObject
+            graphqlType = param.type === UUID ? GraphQLID : GraphQLJSON
             break
         }
         propFilters.includes = { type: graphqlType }

--- a/packages/framework-core/test/services/graphql/graphql-query-generator.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-query-generator.test.ts
@@ -17,7 +17,7 @@ import {
   GraphQLList,
 } from 'graphql'
 import { random } from 'faker'
-import GraphQLJSON from 'graphql-type-json'
+import { GraphQLJSON } from 'graphql-scalars'
 import { AnyClass, BoosterConfig } from '@boostercloud/framework-types'
 import { ClassMetadata } from 'metadata-booster'
 import * as metadata from '../../../src/decorators/metadata'

--- a/packages/framework-core/test/services/graphql/graphql-type-informer.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-type-informer.test.ts
@@ -12,7 +12,7 @@ import {
   GraphQLString,
 } from 'graphql'
 import { TypeMetadata } from 'metadata-booster'
-import { GraphQLJSONObject } from 'graphql-type-json'
+import { GraphQLJSON } from 'graphql-scalars'
 import { random } from 'faker'
 import { GraphQLEnumValueConfig, GraphQLEnumValueConfigMap } from 'graphql/type/definition'
 import { DateScalar } from '../../../src/services/graphql/common'
@@ -63,9 +63,9 @@ describe('GraphQLTypeInformer', () => {
       const otherParameterValue =
         result instanceof GraphQLObjectType ? result.getFields()['otherParameter'].type : undefined
       expect(someParametersValue).to.be.deep.equal(
-        GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLJSONObject)))))
+        GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLJSON)))))
       )
-      expect(otherParameterValue).to.be.deep.equal(GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLJSONObject))))
+      expect(otherParameterValue).to.be.deep.equal(GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLJSON))))
     })
 
     describe('Get or create GraphQLType', () => {
@@ -163,13 +163,13 @@ describe('GraphQLTypeInformer', () => {
         expect(result).to.be.deep.equal(GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLBoolean))))
       })
 
-      it('should return GraphQLJSONObject', () => {
+      it('should return Any', () => {
         const result = sut.getOrCreateGraphQLType({
           name: 'MyObject',
           typeGroup: 'Object',
         } as TypeMetadata)
 
-        expect(result).to.be.deep.equal(GraphQLNonNull(GraphQLJSONObject))
+        expect(result).to.be.deep.equal(GraphQLNonNull(GraphQLJSON))
       })
 
       describe('default', () => {
@@ -179,7 +179,7 @@ describe('GraphQLTypeInformer', () => {
           mockType = random.arrayElement(['Float32Array', 'Float32Array', 'Uint8Array', 'Promise'])
         })
 
-        it('should return GraphQLJSONObject', () => {
+        it('should return Any', () => {
           const result = sut.getOrCreateGraphQLType({
             name: `MyObject${mockType}`,
             typeGroup: mockType,
@@ -187,7 +187,7 @@ describe('GraphQLTypeInformer', () => {
             isNullable: false,
           } as TypeMetadata)
 
-          expect(result).to.be.deep.equal(GraphQLNonNull(GraphQLJSONObject))
+          expect(result).to.be.deep.equal(GraphQLNonNull(GraphQLJSON))
         })
       })
     })

--- a/packages/framework-core/test/services/graphql/graphql-type-informer.test.ts
+++ b/packages/framework-core/test/services/graphql/graphql-type-informer.test.ts
@@ -163,7 +163,7 @@ describe('GraphQLTypeInformer', () => {
         expect(result).to.be.deep.equal(GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLBoolean))))
       })
 
-      it('should return Any', () => {
+      it('should return GraphQLJSON', () => {
         const result = sut.getOrCreateGraphQLType({
           name: 'MyObject',
           typeGroup: 'Object',
@@ -179,7 +179,7 @@ describe('GraphQLTypeInformer', () => {
           mockType = random.arrayElement(['Float32Array', 'Float32Array', 'Uint8Array', 'Promise'])
         })
 
-        it('should return Any', () => {
+        it('should return GraphQLJSON', () => {
           const result = sut.getOrCreateGraphQLType({
             name: `MyObject${mockType}`,
             typeGroup: mockType,

--- a/packages/framework-integration-tests/integration/provider-unaware/end-to-end/cart.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/end-to-end/cart.integration.ts
@@ -4,6 +4,7 @@ import { random, commerce, finance, lorem, internet } from 'faker'
 import { expect } from 'chai'
 import gql from 'graphql-tag'
 import { CartItem } from '../../../src/common/cart-item'
+import { ProductType } from '../../../src/entities/product'
 import { sleep, waitForIt } from '../../helper/sleep'
 import { applicationUnderTest } from './setup'
 import {
@@ -257,6 +258,8 @@ describe('Cart end-to-end tests', () => {
       let mockDescription: string
       let mockPriceInCents: number
       let mockCurrency: string
+      let mockProductDetails: Record<string, unknown>
+      let mockProductType: ProductType
 
       let productId: string
 
@@ -266,6 +269,11 @@ describe('Cart end-to-end tests', () => {
         mockDescription = lorem.paragraph()
         mockPriceInCents = random.number({ min: 1 })
         mockCurrency = finance.currencyCode()
+        mockProductDetails = {
+          color: commerce.color(),
+          size: commerce.productAdjective(),
+        }
+        mockProductType = 'Furniture'
 
         // Add one item
         await client.mutate({
@@ -275,6 +283,8 @@ describe('Cart end-to-end tests', () => {
             description: mockDescription,
             priceInCents: mockPriceInCents,
             currency: mockCurrency,
+            productDetails: mockProductDetails,
+            productType: mockProductType,
           },
           mutation: gql`
             mutation CreateProduct(
@@ -283,6 +293,8 @@ describe('Cart end-to-end tests', () => {
               $description: String!
               $priceInCents: Float!
               $currency: String!
+              $productDetails: JSON
+              $productType: JSON
             ) {
               CreateProduct(
                 input: {
@@ -291,6 +303,8 @@ describe('Cart end-to-end tests', () => {
                   description: $description
                   priceInCents: $priceInCents
                   currency: $currency
+                  productDetails: $productDetails
+                  productType: $productType
                 }
               )
             }
@@ -314,6 +328,8 @@ describe('Cart end-to-end tests', () => {
                     }
                     availability
                     deleted
+                    productDetails
+                    productType
                   }
                 }
               `,
@@ -340,6 +356,8 @@ describe('Cart end-to-end tests', () => {
           },
           availability: 0,
           deleted: false,
+          productDetails: mockProductDetails,
+          productType: mockProductType,
         }
 
         expect(product).to.be.deep.equal(expectedResult)

--- a/packages/framework-integration-tests/integration/provider-unaware/end-to-end/entities.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/end-to-end/entities.integration.ts
@@ -7,6 +7,7 @@ import { sleep, waitForIt } from '../../helper/sleep'
 import { applicationUnderTest } from './setup'
 import { UUID } from '@boostercloud/framework-types'
 import { NEW_CART_IDS, QUANTITY_AFTER_DATA_MIGRATION_V2, QUANTITY_TO_MIGRATE_DATA } from '../../../src/constants'
+import { ProductType } from '../../../src/entities/product'
 
 const secs = 10
 
@@ -26,6 +27,8 @@ describe('Entities end-to-end tests', () => {
     let mockDescription: string
     let mockPriceInCents: number
     let mockCurrency: string
+    let mockProductType: ProductType
+    let mockProductDetails
 
     let productId: string
 
@@ -35,6 +38,11 @@ describe('Entities end-to-end tests', () => {
       mockDescription = lorem.paragraph()
       mockPriceInCents = random.number({ min: 1 })
       mockCurrency = finance.currencyCode()
+      mockProductType = 'Clothing'
+      mockProductDetails = {
+        color: commerce.color(),
+        material: commerce.productMaterial(),
+      }
 
       // Add one item
       await client.mutate({
@@ -44,6 +52,8 @@ describe('Entities end-to-end tests', () => {
           description: mockDescription,
           priceInCents: mockPriceInCents,
           currency: mockCurrency,
+          productDetails: mockProductDetails,
+          productType: mockProductType,
         },
         mutation: gql`
           mutation CreateProduct(
@@ -52,6 +62,8 @@ describe('Entities end-to-end tests', () => {
             $description: String!
             $priceInCents: Float!
             $currency: String!
+            $productDetails: JSON
+            $productType: JSON
           ) {
             CreateProduct(
               input: {
@@ -60,6 +72,8 @@ describe('Entities end-to-end tests', () => {
                 description: $description
                 priceInCents: $priceInCents
                 currency: $currency
+                productDetails: $productDetails
+                productType: $productType
               }
             )
           }
@@ -83,6 +97,8 @@ describe('Entities end-to-end tests', () => {
                   }
                   availability
                   deleted
+                  productDetails
+                  productType
                 }
               }
             `,
@@ -107,6 +123,8 @@ describe('Entities end-to-end tests', () => {
         },
         availability: 0,
         deleted: false,
+        productDetails: mockProductDetails,
+        productType: mockProductType,
       }
 
       expect(product).to.be.deep.equal(expectedResult)
@@ -155,6 +173,8 @@ describe('Entities end-to-end tests', () => {
                   }
                   availability
                   deleted
+                  productDetails
+                  productType
                 }
               }
             `,

--- a/packages/framework-integration-tests/integration/provider-unaware/end-to-end/events.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/end-to-end/events.integration.ts
@@ -662,7 +662,7 @@ describe('Events end-to-end tests', () => {
               afterCursor: cursor,
             },
             mutation: gql`
-              mutation EntitiesIdsFinder($entityName: String!, $limit: Float!, $afterCursor: JSONObject) {
+              mutation EntitiesIdsFinder($entityName: String!, $limit: Float!, $afterCursor: JSON) {
                 EntitiesIdsFinder(input: { entityName: $entityName, limit: $limit, afterCursor: $afterCursor })
               }
             `,

--- a/packages/framework-integration-tests/integration/provider-unaware/end-to-end/read-models.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/end-to-end/read-models.integration.ts
@@ -1354,7 +1354,7 @@ describe('Read models end-to-end tests', () => {
                   afterCursor: cursor,
                 },
                 query: gql`
-                  query ListCartReadModels($limit: Int, $afterCursor: JSONObject) {
+                  query ListCartReadModels($limit: Int, $afterCursor: JSON) {
                     ListCartReadModels(limit: $limit, afterCursor: $afterCursor) {
                       cursor
                       items {
@@ -1618,6 +1618,8 @@ describe('Read models end-to-end tests', () => {
                   packs {
                     id
                   }
+                  productDetails
+                  productType
                 }
               }
             `,
@@ -1674,6 +1676,8 @@ describe('Read models end-to-end tests', () => {
                     name
                     products
                   }
+                  productDetails
+                  productType
                 }
               }
             `,

--- a/packages/framework-integration-tests/integration/provider-unaware/functionality/schema.filter.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/functionality/schema.filter.integration.ts
@@ -13,7 +13,7 @@ const DATE_PROPERTY_FILTER = 'DatePropertyFilter'
 const STRING_ARRAY_PROPERTY_FILTER = 'StringArrayPropertyFilter'
 const STRING_PROPERTY_FILTER = 'StringPropertyFilter'
 const SCALAR = 'SCALAR'
-const JSON_OBJECT = 'JSONObject'
+const JSON_OBJECT = 'JSON'
 const BASE_CLASS_PROPERTY_FILTER = 'BaseClassPropertyFilter'
 
 describe('schemas', async () => {

--- a/packages/framework-integration-tests/integration/provider-unaware/functionality/schema.search.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/functionality/schema.search.integration.ts
@@ -7,7 +7,7 @@ import { applicationUnderTest } from '../end-to-end/setup'
 
 const __TYPE = '__Type'
 const SCALAR = 'SCALAR'
-const JSON_OBJECT = 'JSONObject'
+const JSON_OBJECT = 'JSON'
 const NON_NULL = 'NON_NULL'
 const __Field = '__Field'
 const ID = 'ID'

--- a/packages/framework-integration-tests/src/commands/create-product.ts
+++ b/packages/framework-integration-tests/src/commands/create-product.ts
@@ -2,6 +2,7 @@ import { Command } from '@boostercloud/framework-core'
 import { ProductCreated } from '../events/product-created'
 import { Register, UUID } from '@boostercloud/framework-types'
 import { UserWithEmail, Admin } from '../roles'
+import { ProductType } from '../entities/product'
 
 @Command({
   authorize: [Admin, UserWithEmail],
@@ -13,16 +14,26 @@ export class CreateProduct {
     readonly description: string,
     readonly priceInCents: number,
     readonly currency: string,
-    readonly productID?: UUID
+    readonly productID?: UUID,
+    readonly productDetails?: Record<string, unknown>,
+    readonly productType?: ProductType
   ) {}
 
   public static async handle(command: CreateProduct, register: Register): Promise<void> {
     const productID = command.productID ?? UUID.generate()
     register.events(
-      new ProductCreated(productID, command.sku, command.displayName, command.description, {
-        cents: command.priceInCents,
-        currency: command.currency,
-      })
+      new ProductCreated(
+        productID,
+        command.sku,
+        command.displayName,
+        command.description,
+        {
+          cents: command.priceInCents,
+          currency: command.currency,
+        },
+        command.productDetails,
+        command.productType
+      )
     )
   }
 }

--- a/packages/framework-integration-tests/src/commands/update-product.ts
+++ b/packages/framework-integration-tests/src/commands/update-product.ts
@@ -4,6 +4,7 @@ import { ProductUpdated, ProductUpdateReason } from '../events/product-updated'
 import { Money } from '../common/money'
 import { UUID } from '@boostercloud/framework-types'
 import { Picture } from '../common/picture'
+import { ProductType } from '../entities/product'
 
 @Command({
   authorize: 'all',
@@ -18,7 +19,9 @@ export class UpdateProduct {
     readonly price: Money,
     readonly pictures: Array<Picture>,
     readonly deleted: boolean = false,
-    readonly reason: ProductUpdateReason = ProductUpdateReason.CatalogChange
+    readonly reason: ProductUpdateReason = ProductUpdateReason.CatalogChange,
+    readonly productDetails?: Record<string, unknown>,
+    readonly productType?: ProductType
   ) {}
 
   public static async handle(command: UpdateProduct, register: Register): Promise<void> {
@@ -31,7 +34,9 @@ export class UpdateProduct {
         command.price,
         command.pictures,
         command.deleted,
-        command.reason
+        command.reason,
+        command.productDetails,
+        command.productType
       )
     )
   }

--- a/packages/framework-integration-tests/src/entities/product.ts
+++ b/packages/framework-integration-tests/src/entities/product.ts
@@ -8,6 +8,8 @@ import { Picture } from '../common/picture'
 import { ProductAvailabilityChanged } from '../events/product-availability-changed'
 import { UserWithEmail } from '../roles'
 
+export type ProductType = 'Furniture' | 'Electronics' | 'Books' | 'Clothing' | 'Other'
+
 /**
  * A product is the representation of a sellable unit in our sample store
  */
@@ -23,7 +25,9 @@ export class Product {
     readonly price: Money,
     readonly pictures: Array<Picture>,
     public deleted: boolean = false,
-    public availability: number = 0
+    public availability: number = 0,
+    readonly productDetails: Record<string, unknown> = {},
+    readonly productType: ProductType = 'Other'
   ) {}
 
   public getId(): UUID {
@@ -31,12 +35,34 @@ export class Product {
   }
   @Reduces(ProductCreated)
   public static create(event: ProductCreated): Product {
-    return new Product(event.productId, event.sku, event.displayName, event.description, event.price, [])
+    return new Product(
+      event.productId,
+      event.sku,
+      event.displayName,
+      event.description,
+      event.price,
+      [],
+      false,
+      0,
+      event.productDetails,
+      event.productType
+    )
   }
 
   @Reduces(ProductUpdated)
   public static update(event: ProductUpdated): Product {
-    return new Product(event.id, event.sku, event.name, event.description, event.price, event.pictures, event.deleted)
+    return new Product(
+      event.id,
+      event.sku,
+      event.name,
+      event.description,
+      event.price,
+      event.pictures,
+      event.deleted,
+      0,
+      event.productDetails,
+      event.productType
+    )
   }
 
   @Reduces(ProductDeleted)

--- a/packages/framework-integration-tests/src/events/product-created.ts
+++ b/packages/framework-integration-tests/src/events/product-created.ts
@@ -1,6 +1,7 @@
 import { Event } from '@boostercloud/framework-core'
 import { UUID } from '@boostercloud/framework-types'
 import { Money } from '../common/money'
+import { ProductType } from '../entities/product'
 
 @Event
 export class ProductCreated {

--- a/packages/framework-integration-tests/src/events/product-created.ts
+++ b/packages/framework-integration-tests/src/events/product-created.ts
@@ -9,7 +9,9 @@ export class ProductCreated {
     readonly sku: string,
     readonly displayName: string,
     readonly description: string,
-    readonly price: Money
+    readonly price: Money,
+    readonly productDetails: Record<string, unknown> = {},
+    readonly productType: ProductType = 'Other'
   ) {}
 
   public entityID(): UUID {

--- a/packages/framework-integration-tests/src/events/product-updated.ts
+++ b/packages/framework-integration-tests/src/events/product-updated.ts
@@ -2,6 +2,7 @@ import { Event } from '@boostercloud/framework-core'
 import { UUID } from '@boostercloud/framework-types'
 import { Money } from '../common/money'
 import { Picture } from '../common/picture'
+import { ProductType } from '../entities/product'
 
 export enum ProductUpdateReason {
   CatalogChange = 'CatalogChange',

--- a/packages/framework-integration-tests/src/events/product-updated.ts
+++ b/packages/framework-integration-tests/src/events/product-updated.ts
@@ -19,7 +19,9 @@ export class ProductUpdated {
     readonly price: Money,
     readonly pictures: Array<Picture>,
     readonly deleted: boolean = false,
-    readonly reason: ProductUpdateReason
+    readonly reason: ProductUpdateReason,
+    readonly productDetails: Record<string, unknown> = {},
+    readonly productType: ProductType = 'Other'
   ) {}
 
   public entityID(): UUID {

--- a/packages/framework-integration-tests/src/migrations/read-models/ProductReadModel/migrations.ts
+++ b/packages/framework-integration-tests/src/migrations/read-models/ProductReadModel/migrations.ts
@@ -13,6 +13,8 @@ export class ProductReadModelMigration {
       old.description,
       1000,
       old.deleted,
+      {},
+      'Other',
       old.price,
       []
     )

--- a/packages/framework-integration-tests/src/read-models/product-read-model.ts
+++ b/packages/framework-integration-tests/src/read-models/product-read-model.ts
@@ -1,7 +1,7 @@
 import { Projects, ReadModel } from '@boostercloud/framework-core'
 import { UserWithEmail } from '../roles'
 import { ProjectionResult, ReadModelAction, UUID } from '@boostercloud/framework-types'
-import { Product } from '../entities/product'
+import { Product, ProductType } from '../entities/product'
 import { Money } from '../common/money'
 import { Pack } from '../entities/pack'
 
@@ -17,6 +17,8 @@ export class ProductReadModel {
     readonly description: string,
     readonly availability: number,
     public deleted: boolean,
+    readonly productDetails: Record<string, unknown>,
+    readonly productType: ProductType = 'Other',
     readonly price?: Money,
     readonly packs?: Array<Pack>
   ) {}
@@ -33,6 +35,8 @@ export class ProductReadModel {
         product.description,
         product.availability,
         product.deleted,
+        product.productDetails,
+        product.productType,
         product.price,
         []
       )
@@ -63,6 +67,8 @@ export class ProductReadModel {
         currentProductReadModel.description,
         currentProductReadModel.availability,
         currentProductReadModel.deleted,
+        currentProductReadModel.productDetails,
+        currentProductReadModel.productType,
         currentProductReadModel.price,
         packList
       )


### PR DESCRIPTION
## Description

For unrecognized types, we were using a scalar which enforced the usage of a **strictly JSON Object**. We found some scenarios where that approach didn't work i.e. if we have a `productType: 'A' | 'B' | 'C'`, that productType was resolved as a strictly JSON Object scalar, which later on caused some problems in mutations because the productType isn't a real JSON Object, in fact, is a string, so the internal serializer couldn't parse the value. 

## Changes

Added a loosely JSON type as a fallback which works as an ANY type. Instead of creating our own type, we are using the one that works from https://www.graphql-scalars.dev/     

For more information about custom scalar types:

* https://kamranicus.com/handling-multiple-scalar-types-in-graphql/
* https://www.apollographql.com/docs/apollo-server/schema/custom-scalars/

## Checks
- [ ] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly


