### PR TITLE
Synth operation should take into account project's package-lock.json

### DIFF
--- a/packages/cli/src/common/sandbox.ts
+++ b/packages/cli/src/common/sandbox.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, readdirSync, rmSync, statSync } from 'fs'
-import { copySync } from 'fs-extra'
+import { copySync, existsSync } from 'fs-extra'
 import * as path from 'path'
 
 const copyFolder = (origin: string, destiny: string): void => {
@@ -19,8 +19,12 @@ export const createSandboxProject = (sandboxPath: string, assets?: Array<string>
   mkdirSync(sandboxPath, { recursive: true })
   copyFolder('src', path.join(sandboxPath, 'src'))
 
-  const projectFiles = ['package.json', 'tsconfig.json']
-  projectFiles.forEach((file: string) => copySync(file, path.join(sandboxPath, file)))
+  const projectFiles = ['package.json', 'package-lock.json', 'tsconfig.json']
+  projectFiles.forEach((file: string) => {
+    if (existsSync(file)) {
+      copySync(file, path.join(sandboxPath, file))
+    }
+  })
 
   if (assets) {
     assets.forEach((asset) => {


### PR DESCRIPTION
## Description

Not only on the `synth` process but each time the sandbox project is created we need to copy not only the package.json but also the package-lock.json file

See https://github.com/boostercloud/booster/issues/1135 for more info.

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly


## Additional information

