### PR TITLE
fix: do not crash if no reducer is found

### DIFF
--- a/packages/framework-core/src/booster-register-handler.ts
+++ b/packages/framework-core/src/booster-register-handler.ts
@@ -8,6 +8,7 @@ import {
   NotFoundError,
   Register,
   SuperKindType,
+  ReducerMetadata,
 } from '@boostercloud/framework-types'
 import { BoosterEntityMigrated } from './core-concepts/data-migration/events/booster-entity-migrated'
 import { BoosterDataMigrationStarted } from './core-concepts/data-migration/events/booster-data-migration-started'
@@ -70,7 +71,7 @@ export class RegisterHandler {
     if (eventTypeName === BoosterEntityMigrated.name) {
       return (event as BoosterEntityMigrated).oldEntityName
     }
-    const reducerInfo = config.reducers[eventTypeName]
-    return reducerInfo.class.name
+    const reducerInfo: ReducerMetadata | undefined = config.reducers[eventTypeName]
+    return reducerInfo?.class?.name
   }
 }


### PR DESCRIPTION
Should fix:
```
[Booster]|BoosterEventDispatcher#dispatch:  Unhandled error while dispatching event:  PromisesError: TypeError: Cannot read properties of undefined (reading 'class')
    at Function.allSettledAndFulfilled (node_modules/@boostercloud/framework-common-helpers/dist/promises.js:31:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at Function.dispatchEntityEventsToEventHandlers (node_modules/@boostercloud/framework-core/dist/booster-event-dispatcher.js:56:13)
    at node_modules/@boostercloud/framework-core/dist/booster-event-dispatcher.js:34:13
    at Function.streamPerEntityEvents (node_modules/@boostercloud/framework-core/dist/services/raw-events-parser.js:16:13)
    at Function.dispatch (node_modules/@boostercloud/framework-core/dist/booster-event-dispatcher.js:24:13)
    at Object.storeEvents [as store] (node_modules/@advantitge/booster-framework-provider-micro/dist/library/events-adapter.js:79:5)
    at BoosterCommandDispatcher.dispatchCommand (node_modules/@boostercloud/framework-core/dist/booster-command-dispatcher.js:47:9)
    at node_modules/@boostercloud/framework-core/dist/services/graphql/graphql-generator.js:60:28
    at BoosterGraphQLDispatcher.handleQueryOrMutation (node_modules/@boostercloud/framework-core/dist/booster-graphql-dispatcher.js:130:24) {
  failedReasons: [
    TypeError: Cannot read properties of undefined (reading 'class')
        at Function.getEntityTypeName (node_modules/@boostercloud/framework-core/dist/booster-register-handler.js:47:28)
        at wrapEvent (node_modules/@boostercloud/framework-core/dist/booster-register-handler.js:15:48)
        at Array.map (<anonymous>)
        at Function.handle (node_modules/@boostercloud/framework-core/dist/booster-register-handler.js:11:64)
        at node_modules/@boostercloud/framework-core/dist/booster-event-dispatcher.js:69:67
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
  ]
}
```