### PR TITLE
Integration/pr 1105

### DIFF
--- a/packages/framework-provider-local-infrastructure/src/index.ts
+++ b/packages/framework-provider-local-infrastructure/src/index.ts
@@ -53,11 +53,13 @@ export const Infrastructure = (rocketDescriptors?: RocketDescriptor[]): Provider
       }
       expressServer.use(
         express.json({
+          limit: '6mb',
           verify: (req, res, buf) => {
             req.rawBody = buf
           },
         })
       )
+      expressServer.use(express.urlencoded({ limit: '6mb' }))
       expressServer.use(cors())
       expressServer.use(function (req, res, next) {
         res.header('Access-Control-Allow-Origin', '*')


### PR DESCRIPTION
This is an integration branch for PR #1105 by @MichaelHirn

## Description

The payload limit of the local provider is currently the express default (100kb).

Every other provider has a higher limit (aws: 6mb, azure: unlimited, kubernetes: unlimited?) which can lead to friction between local tests and the production environment.

This PR increases the payload limit of the local provider to the next smallest limit, i.e. AWS with 6mb.

Ref: #1105

## Changes

I set the express payload to 6mb as described [here](https://stackoverflow.com/a/19965089).

No tests as the local provider doesn't seem to have any tests yet.

I also haven't verified that this actually increases the limit correctly to 6mb, by using it myself yet. I'm happy to wait to merge until I at least tried it out locally.

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
