### PR TITLE
fix(local): express body-parser extended warning

### DIFF
--- a/packages/framework-provider-local-infrastructure/src/index.ts
+++ b/packages/framework-provider-local-infrastructure/src/index.ts
@@ -59,7 +59,12 @@ export const Infrastructure = (rocketDescriptors?: RocketDescriptor[]): Provider
           },
         })
       )
-      expressServer.use(express.urlencoded({ limit: '6mb' }))
+      expressServer.use(
+        express.urlencoded({
+          extended: true,
+          limit: '6mb'
+        })
+      )
       expressServer.use(cors())
       expressServer.use(function (req, res, next) {
         res.header('Access-Control-Allow-Origin', '*')


### PR DESCRIPTION
## Description

#1150  (aka. #1155) successfully increased the payload size of the local provider to the next smallest one, i.e. AWS at 6mb.

This PR fixes the warning message that pops up when starting the local provider that is due to express [requiring that the `extended` flag is set explicitly as it is due to change for its the next major version](https://stackoverflow.com/a/25471936).

This PR sets the `extended` flag to `true`, which allows for rich objects and arrays to be encoded into the URL-encoded format, allowing for a JSON-like experience with URL-encoded. For more info see [the docs here](http://expressjs.com/en/api.html#express.urlencoded).

## Changes

Explicitly set express body-parser's `extended` flag to `true` to avoid a warning message when starting the local provider.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly

## Additional information

I tried it out locally this time, so I can confirm that the limit is correctly set to 6mb and no warning shows up with this change.
