### PR TITLE
Filter on projections joinKey

### DIFF
--- a/packages/framework-core/src/decorators/projects.ts
+++ b/packages/framework-core/src/decorators/projects.ts
@@ -5,36 +5,44 @@ import {
   ProjectionMetadata,
   ProjectionResult,
   ReadModelInterface,
+  ReadModelJoinKeyFunction,
   UUID,
 } from '@boostercloud/framework-types'
 
-type PropType<TObj, TProp extends keyof TObj> = TObj[TProp]
+type PropertyType<TObj, TProp extends keyof TObj> = TObj[TProp]
+type JoinKeyType<TEntity extends EntityInterface, TReadModel extends ReadModelInterface> =
+  | keyof TEntity
+  | ReadModelJoinKeyFunction<TEntity, TReadModel>
 
 /**
  * Decorator to register a read model method as a projection
  * for a specific entity
  *
  * @param originEntity The entity that this method will react to
+ * @param joinKey
  */
-export function Projects<TEntity extends EntityInterface, TJoinKey extends keyof TEntity>(
+export function Projects<TEntity extends EntityInterface, TReadModel extends ReadModelInterface>(
   originEntity: Class<TEntity>,
-  joinKey: TJoinKey
-): <TReadModel extends ReadModelInterface>(
-  readModelClass: Class<TReadModel>,
+  joinKey: JoinKeyType<TEntity, TReadModel>
+): <TReceivedReadModel extends ReadModelInterface>(
+  readModelClass: Class<TReceivedReadModel>,
   methodName: string,
-  methodDescriptor: ProjectionMethod<TEntity, TReadModel, PropType<TEntity, TJoinKey>>
+  methodDescriptor: ProjectionMethod<TEntity, TReceivedReadModel, JoinKeyType<TEntity, TReceivedReadModel>>
 ) => void {
   return (readModelClass, methodName) => {
     const projectionMetadata = {
-      joinKey,
+      joinKey: joinKey,
       class: readModelClass,
       methodName: methodName,
-    } as ProjectionMetadata<EntityInterface>
+    } as ProjectionMetadata<EntityInterface, ReadModelInterface>
     registerProjection(originEntity.name, projectionMetadata)
   }
 }
 
-function registerProjection(originName: string, projectionMetadata: ProjectionMetadata<EntityInterface>): void {
+function registerProjection(
+  originName: string,
+  projectionMetadata: ProjectionMetadata<EntityInterface, ReadModelInterface>
+): void {
   Booster.configureCurrentEnv((config): void => {
     const entityProjections = config.projections[originName] || []
     if (entityProjections.indexOf(projectionMetadata) < 0) {
@@ -45,6 +53,22 @@ function registerProjection(originName: string, projectionMetadata: ProjectionMe
   })
 }
 
-type ProjectionMethod<TEntity, TReadModel, TPropType> = TPropType extends Array<UUID>
-  ? TypedPropertyDescriptor<(_: TEntity, readModelID: UUID, readModel?: TReadModel) => ProjectionResult<TReadModel>>
-  : TypedPropertyDescriptor<(_: TEntity, readModel?: TReadModel) => ProjectionResult<TReadModel>>
+type ProjectionMethod<
+  TEntity extends EntityInterface,
+  TReadModel extends ReadModelInterface,
+  TJoinKeyType extends JoinKeyType<TEntity, TReadModel>
+> = TJoinKeyType extends ReadModelJoinKeyFunction<TEntity, TReadModel>
+  ? ProjectionMethodWithEntityReadModelIdAndReadModel<TEntity, TReadModel>
+  : TJoinKeyType extends keyof TEntity
+  ? PropertyType<TEntity, TJoinKeyType> extends Array<UUID>
+    ? ProjectionMethodWithEntityReadModelIdAndReadModel<TEntity, TReadModel>
+    : ProjectionMethodWithEntityAndReadModel<TEntity, TReadModel>
+  : never
+
+type ProjectionMethodWithEntityAndReadModel<TEntity extends EntityInterface, TReadModel extends ReadModelInterface> =
+  TypedPropertyDescriptor<(_: TEntity, readModel?: TReadModel) => ProjectionResult<TReadModel>>
+
+type ProjectionMethodWithEntityReadModelIdAndReadModel<
+  TEntity extends EntityInterface,
+  TReadModel extends ReadModelInterface
+> = TypedPropertyDescriptor<(_: TEntity, readModelID: UUID, readModel?: TReadModel) => ProjectionResult<TReadModel>>

--- a/packages/framework-core/src/services/read-model-searcher.ts
+++ b/packages/framework-core/src/services/read-model-searcher.ts
@@ -1,0 +1,59 @@
+import {
+  BoosterConfig,
+  Class,
+  FilterFor,
+  FinderByKeyFunction,
+  ReadModelInterface,
+  ReadOnlyNonEmptyArray,
+  Searcher,
+  SearcherFunction,
+  SequenceKey,
+  SortFor,
+  UUID,
+} from '@boostercloud/framework-types'
+import { createInstances } from '@boostercloud/framework-common-helpers'
+
+export function readModelSearcher<TReadModel extends ReadModelInterface>(
+  config: BoosterConfig,
+  readModelClass: Class<TReadModel>
+): Searcher<TReadModel> {
+  const searchFunction: SearcherFunction<TReadModel> = async (
+    readModelName: string,
+    filters: FilterFor<unknown>,
+    sort?: SortFor<unknown>,
+    limit?: number,
+    afterCursor?: any,
+    paginatedVersion?: boolean
+  ) => {
+    const searchResult = await config.provider.readModels.search(
+      config,
+      readModelName,
+      filters,
+      sort,
+      limit,
+      afterCursor,
+      paginatedVersion
+    )
+
+    if (!Array.isArray(searchResult)) {
+      return {
+        ...searchResult,
+        items: createInstances(readModelClass, searchResult.items),
+      }
+    }
+    return createInstances(readModelClass, searchResult)
+  }
+
+  const finderByIdFunction: FinderByKeyFunction<TReadModel> = async (
+    readModelName: string,
+    id: UUID,
+    sequenceKey?: SequenceKey
+  ) => {
+    const readModels = await config.provider.readModels.fetch(config, readModelName, id, sequenceKey)
+    if (sequenceKey) {
+      return readModels as ReadOnlyNonEmptyArray<TReadModel>
+    }
+    return readModels[0] as TReadModel
+  }
+  return new Searcher(readModelClass, searchFunction, finderByIdFunction)
+}

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -123,31 +123,31 @@ describe('ReadModelStore', () => {
       class: SomeReadModel,
       methodName: 'someObserver',
       joinKey: 'someKey',
-    } as ProjectionMetadata<any>,
+    } as ProjectionMetadata<any, any>,
     {
       class: SomeReadModel,
       methodName: 'projectionThatCallsEntityMethod',
       joinKey: 'someKey',
-    } as ProjectionMetadata<any>,
+    } as ProjectionMetadata<any, any>,
     {
       class: AnotherReadModel,
       methodName: 'anotherObserver',
       joinKey: 'someKey',
-    } as ProjectionMetadata<any>,
+    } as ProjectionMetadata<any, any>,
   ]
   config.projections[AnImportantEntityWithArray.name] = [
     {
       class: SomeReadModel,
       methodName: 'someObserverArray',
       joinKey: 'someKey',
-    } as ProjectionMetadata<any>,
+    } as ProjectionMetadata<any, any>,
   ]
   config.projections['AnEntity'] = [
     {
       class: SomeReadModel,
       methodName: 'projectionThatCallsReadModelMethod',
       joinKey: 'someKey',
-    } as ProjectionMetadata<any>,
+    } as ProjectionMetadata<any, any>,
   ]
 
   function eventEnvelopeFor(entityName: string): EventEnvelope {
@@ -583,7 +583,7 @@ describe('ReadModelStore', () => {
             anEntityInstance,
             projectionMetadata,
             readModelClassName,
-            anEntityInstance[projectionMetadata.joinKey],
+            anEntityInstance[projectionMetadata.joinKey as string],
             readModelClassName === 'AnotherReadModel' ? { name: 'count', value: 123 } : undefined
           )
         }
@@ -661,23 +661,25 @@ describe('ReadModelStore', () => {
 
   describe('the `joinKeyForProjection` private method', () => {
     context('when the joinKey exists', () => {
-      it('returns the joinKey value', () => {
+      it('returns the joinKey value', async () => {
         const anEntitySnapshot = eventEnvelopeFor(AnImportantEntity.name)
         const anEntityInstance = createInstance(AnImportantEntity, anEntitySnapshot.value) as any
         const readModelStore = new ReadModelStore(config) as any
 
-        expect(readModelStore.joinKeyForProjection(anEntityInstance, { joinKey: 'someKey' })).to.be.deep.equal([
-          'joinColumnID',
-        ])
+        const joinKeyForProjection = await readModelStore.joinKeyForProjection(anEntityInstance, { joinKey: 'someKey' })
+        expect(joinKeyForProjection).to.be.deep.equal(['joinColumnID'])
       })
     })
 
     context('when the joinkey does not exist', () => {
-      it('should not throw and error an skip', () => {
+      it('should not throw and error an skip', async () => {
         const anEntitySnapshot = eventEnvelopeFor(AnImportantEntity.name)
         const anEntityInstance = createInstance(AnImportantEntity, anEntitySnapshot.value) as any
         const readModelStore = new ReadModelStore(config) as any
-        expect(readModelStore.joinKeyForProjection(anEntityInstance, { joinKey: 'whatever' })).to.be.undefined
+        const joinKeyForProjection = await readModelStore.joinKeyForProjection(anEntityInstance, {
+          joinKey: 'whatever',
+        })
+        expect(joinKeyForProjection).to.be.undefined
       })
     })
   })

--- a/packages/framework-integration-tests/src/commands/create-promotions.ts
+++ b/packages/framework-integration-tests/src/commands/create-promotions.ts
@@ -1,0 +1,20 @@
+import { Command } from '@boostercloud/framework-core'
+import { Register, UUID } from '@boostercloud/framework-types'
+import { PromotionCreated } from '../events/promotion-created'
+
+@Command({
+  authorize: 'all',
+})
+export class CreatePromotions {
+  public constructor(
+    readonly promotionID: UUID,
+    readonly name: string,
+    readonly productID: UUID,
+    readonly promotionType: 'Product' | 'Other'
+  ) {}
+
+  public static async handle(command: CreatePromotions, register: Register): Promise<void> {
+    const promotionID = command.promotionID ?? UUID.generate()
+    register.events(new PromotionCreated(promotionID, command.name, command.productID, command.promotionType))
+  }
+}

--- a/packages/framework-integration-tests/src/entities/promotion.ts
+++ b/packages/framework-integration-tests/src/entities/promotion.ts
@@ -1,0 +1,18 @@
+import { Entity, Reduces } from '@boostercloud/framework-core'
+import { UUID } from '@boostercloud/framework-types'
+import { PromotionCreated } from '../events/promotion-created'
+
+@Entity
+export class Promotion {
+  public constructor(
+    readonly id: UUID,
+    readonly name: string,
+    readonly productID: UUID,
+    readonly promotionType: 'Product' | 'Other'
+  ) {}
+
+  @Reduces(PromotionCreated)
+  public static createPromotion(event: PromotionCreated): Promotion {
+    return new Promotion(event.promotionID, event.name, event.productID, event.promotionType)
+  }
+}

--- a/packages/framework-integration-tests/src/events/promotion-created.ts
+++ b/packages/framework-integration-tests/src/events/promotion-created.ts
@@ -1,0 +1,16 @@
+import { Event } from '@boostercloud/framework-core'
+import { UUID } from '@boostercloud/framework-types'
+
+@Event
+export class PromotionCreated {
+  public constructor(
+    readonly promotionID: UUID,
+    readonly name: string,
+    readonly productID: UUID,
+    readonly promotionType: 'Product' | 'Other'
+  ) {}
+
+  public entityID(): UUID {
+    return this.promotionID
+  }
+}

--- a/packages/framework-types/src/concepts/projection-metadata.ts
+++ b/packages/framework-types/src/concepts/projection-metadata.ts
@@ -1,9 +1,16 @@
 import { AnyClass } from '../typelevel'
+import { ReadModelInterface } from './read-model'
+import { EntityInterface } from './entity'
+import { FilterFor } from '../searcher'
 
-export interface ProjectionMetadata<TEntity> {
+export type ReadModelJoinKeyFunction<TEntity extends EntityInterface, TReadModel extends ReadModelInterface> = (
+  entity: TEntity
+) => FilterFor<TReadModel> | undefined
+
+export interface ProjectionMetadata<TEntity extends EntityInterface, TReadModel extends ReadModelInterface> {
   class: AnyClass
   methodName: string
-  joinKey: keyof TEntity
+  joinKey: keyof TEntity | ReadModelJoinKeyFunction<TEntity, TReadModel>
 }
 
 export type ProjectionResult<TReadModel> = TReadModel | ReadModelAction

--- a/packages/framework-types/src/config.ts
+++ b/packages/framework-types/src/config.ts
@@ -13,6 +13,7 @@ import {
   EntityInterface,
   DataMigrationMetadata,
   TokenVerifier,
+  ReadModelInterface,
 } from './concepts'
 import { ProviderLibrary } from './provider'
 import { Level } from './logger'
@@ -57,7 +58,7 @@ export class BoosterConfig {
   public readonly commandHandlers: Record<CommandName, CommandMetadata> = {}
   public readonly eventHandlers: Record<EventName, Array<EventHandlerInterface>> = {}
   public readonly readModels: Record<ReadModelName, ReadModelMetadata> = {}
-  public readonly projections: Record<EntityName, Array<ProjectionMetadata<EntityInterface>>> = {}
+  public readonly projections: Record<EntityName, Array<ProjectionMetadata<EntityInterface, ReadModelInterface>>> = {}
   public readonly readModelSequenceKeys: Record<EntityName, string> = {}
   public readonly roles: Record<RoleName, RoleMetadata> = {}
   public readonly schemaMigrations: Record<ConceptName, Map<Version, SchemaMigrationMetadata>> = {}


### PR DESCRIPTION
## Description
Filter on projections joinKey

## Changes
- Add tests
- Refactor readModelSearcher method
- Refactor packages/framework-core/src/decorators/projects.ts
- Update new decorator to accept functions
```typescript
@Projects(SomeEntity, (someEntity: SomeEntity) => {
        return {
          id: {
            eq: someEntity.id,
          } as FilterFor<SomeReadModel>,
        }
      })
```
- Update `Projects` decorator to execute the function to filter

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly
