### PR TITLE
Make readable error message on project creation

### DIFF
--- a/packages/cli/src/commands/new/project.ts
+++ b/packages/cli/src/commands/new/project.ts
@@ -58,6 +58,10 @@ export default class Project extends Command {
       description: 'skip git initialization',
       default: false,
     }),
+    verbose: flags.boolean({
+      description: 'display full error messages',
+      default: false,
+    }),
   }
 
   public static args = [{ name: 'projectName' }]
@@ -66,15 +70,23 @@ export default class Project extends Command {
     const { args, flags } = this.parse(Project)
     const { projectName } = args
 
-    try {
-      if (!projectName) throw "You haven't provided a project name, but it is required, run with --help for usage"
-      assertNameIsCorrect(projectName)
-      await checkProjectAlreadyExists(projectName)
-      const parsedFlags = { projectName, ...flags }
-      await run(parsedFlags as Partial<ProjectInitializerConfig>, this.config.version)
-    } catch (error) {
-      console.error(error)
+    if (!projectName) throw "You haven't provided a project name, but it is required, run with --help for usage"
+    assertNameIsCorrect(projectName)
+    await checkProjectAlreadyExists(projectName)
+    const parsedFlags = { projectName, ...flags }
+    await run(parsedFlags as Partial<ProjectInitializerConfig>, this.config.version)
+  }
+
+  async catch(fullError: Error) {
+    const {
+      flags: { verbose },
+    } = this.parse(Project)
+
+    if (verbose) {
+      console.error(fullError)
     }
+
+    return super.catch(fullError)
   }
 }
 

--- a/packages/cli/src/services/provider-service.ts
+++ b/packages/cli/src/services/provider-service.ts
@@ -1,4 +1,5 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
+import Brand from '../common/brand'
 
 export function assertNameIsCorrect(name: string): void {
   // Current characters max length: 37
@@ -19,8 +20,8 @@ export function assertNameIsCorrect(name: string): void {
 }
 
 class ForbiddenProjectName extends Error {
-  constructor(public name: string, public restrictionText: string) {
-    super(`Project name cannot ${restrictionText}:\n\n    Found: '${name}'`)
+  constructor(public projectName: string, public restrictionText: string) {
+    super(Brand.dangerize(`Your Booster project name cannot ${restrictionText}. You choose "${projectName}"`))
   }
 }
 


### PR DESCRIPTION
## Description
Fixes to make error messages more human readable by removing error stack
<img width="958" alt="Screenshot 2022-10-27 at 22 43 52" src="https://user-images.githubusercontent.com/36774784/198384595-22e628aa-566e-4c2e-8cf0-28211171bb12.png">

## Changes
- `--verbose` flag on `boost new:project` command
- Human readable error messages on project creation
- Removed error stack

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly

## Additional information
Fixes #1195 