### PR TITLE
Generating optional fields

### DIFF
--- a/packages/cli/src/commands/new/command.ts
+++ b/packages/cli/src/commands/new/command.ts
@@ -2,7 +2,7 @@ import * as Oclif from '@oclif/command'
 import BaseCommand from '../../common/base-command'
 import { Script } from '../../common/script'
 import Brand from '../../common/brand'
-import { generate, template } from '../../services/generator'
+import { generate, prepareFields, template } from '../../services/generator'
 import {
   HasName,
   HasFields,
@@ -30,7 +30,7 @@ export default class Command extends BaseCommand {
   public async run(): Promise<void> {
     const { args, flags } = this.parse(Command)
     try {
-      const fields = flags.fields || []
+      const fields = prepareFields(flags.fields)
       if (!args.commandName) throw "You haven't provided a command name, but it is required, run with --help for usage"
       return run(args.commandName, fields)
     } catch (error) {

--- a/packages/cli/src/commands/new/entity.ts
+++ b/packages/cli/src/commands/new/entity.ts
@@ -13,7 +13,7 @@ import {
   ImportDeclaration,
 } from '../../services/generator/target'
 import * as path from 'path'
-import { generate, template } from '../../services/generator'
+import { generate, prepareFields, template } from '../../services/generator'
 import { checkCurrentDirIsABoosterProject } from '../../services/project-checker'
 import { classNameToFileName } from '../../common/filenames'
 
@@ -39,7 +39,7 @@ export default class Entity extends BaseCommand {
     const { args, flags } = this.parse(Entity)
 
     try {
-      const fields = flags.fields || []
+      const fields = prepareFields(flags.fields)
       const events = flags.reduces || []
       if (!args.entityName) throw "You haven't provided an entity name, but it is required, run with --help for usage"
       return run(args.entityName, fields, events)

--- a/packages/cli/src/commands/new/event.ts
+++ b/packages/cli/src/commands/new/event.ts
@@ -10,7 +10,7 @@ import {
   parseFields,
   ImportDeclaration,
 } from '../../services/generator/target'
-import { generate, template } from '../../services/generator'
+import { generate, prepareFields, template } from '../../services/generator'
 import * as path from 'path'
 import { checkCurrentDirIsABoosterProject } from '../../services/project-checker'
 
@@ -31,7 +31,7 @@ export default class Event extends BaseCommand {
     const { args, flags } = this.parse(Event)
 
     try {
-      const fields = flags.fields || []
+      const fields = prepareFields(flags.fields)
       if (!args.eventName) throw "You haven't provided an event name, but it is required, run with --help for usage"
       return run(args.eventName, fields)
     } catch (error) {

--- a/packages/cli/src/services/generator.ts
+++ b/packages/cli/src/services/generator.ts
@@ -36,6 +36,17 @@ export function filePath<TInfo>(target: FileDir<TInfo>): string {
   return path.join(process.cwd(), target.placementDir, `${fileName}${target.extension}`)
 }
 
+export function prepareFields(fields: string[] = []): string[] {
+  return fields
+    .flatMap((field: string) => field.split(' '))
+    .filter((field: string) => field)
+    .sort((aField: string, bField: string) => {
+      if (aField.includes('?') > bField.includes('?')) return 1
+      if (aField.includes('?') < bField.includes('?')) return -1
+      return 0
+    })
+}
+
 /**
  * Split path string to get resource folder name
  *


### PR DESCRIPTION
## Description
It is possible to generate fields with optional type like this:
`boost new:event ReceiptUpdated --fields id:UUID title:string 'content?:string'`
But to generate more than one optional field developer has to wrap each field in quotes. In order to improve DX this PR will allow to wrap everything in quotes like this:
`boost new:event ReceiptUpdated --fields 'id:UUID title:string content?:string'`

It will also move the optional fields to the end, because eslint should be happy too

## Changes
- added `prepareFields` method

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] ~Updated documentation accordingly~

## Additional information
Related to #1194
