### PR TITLE
chore: Pull before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Bump version using Rush
         run: node common/scripts/install-run-rush.js version --bump -b main
 
+      - name: Pull before publishing
+        run: git pull --rebase origin main
+
       - name: Publish using Rush
         run: node common/scripts/install-run-rush.js publish --apply --publish --include-all --target-branch origin/main --add-commit-details
 


### PR DESCRIPTION
Fixes #1230 

When `rush bump` is executed, some commits are generated on `origin` but they are not in the GH Actions machine, with this, we should be able to push the required changes after `rush publish`