### PR TITLE
fix(cli): Make error messages more readable

### DIFF
--- a/common/changes/@boostercloud/framework-core/fix-readable-error-messages-cli_2022-12-15-16-13.json
+++ b/common/changes/@boostercloud/framework-core/fix-readable-error-messages-cli_2022-12-15-16-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "Make CLI error messages more readable",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -482,12 +482,12 @@ importers:
       apollo-link-http: 1.5.17_graphql@15.8.0
       apollo-link-ws: 1.0.20_lzhemntqmrrv32barqm3vevgoi
       apollo-utilities: 1.3.4_graphql@15.8.0
-      cdktf: 0.7.0_constructs@10.1.196
+      cdktf: 0.7.0_constructs@10.1.197
       cdktf-cli: 0.12.3_ink@3.2.0+react@17.0.2
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       child-process-promise: 2.2.1
-      constructs: 10.1.196
+      constructs: 10.1.197
       cross-fetch: 3.1.5
       eslint: 8.30.0
       eslint-config-prettier: 8.3.0_eslint@8.30.0
@@ -660,33 +660,33 @@ importers:
       velocityjs: ^2.0.0
       yaml: 1.10.2
     dependencies:
-      '@aws-cdk/assets': 1.183.0_qjrgixlxwtmbgfb4fwspwgbpwq
-      '@aws-cdk/aws-apigateway': 1.183.0_enidw6wkizd3xsvxqh6cnz5kwe
-      '@aws-cdk/aws-apigatewayv2': 1.183.0_skgq7crkylogcuqujvfguacswq
-      '@aws-cdk/aws-cloudfront': 1.183.0_skgq7crkylogcuqujvfguacswq
-      '@aws-cdk/aws-dynamodb': 1.183.0_gt7snz7gbhxc433or4gdp4hauy
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-events-targets': 1.183.0_o7d7hmthwen5hbhypli7ibz354
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-lambda-event-sources': 1.183.0_5hu2vuqryr466ntk3k5ewozubm
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-s3-deployment': 1.183.0_enrwl5hbw6cxdxffr33yncegfy
-      '@aws-cdk/cloudformation-diff': 1.183.0
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/custom-resources': 1.183.0_jdemlcjbnx5lxnlr6bksodytsm
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/assets': 1.184.0_afuk5sfx5hdxwlsys3ycewghvi
+      '@aws-cdk/aws-apigateway': 1.184.0_b4z73lyzyylw24j4rewft4zwcm
+      '@aws-cdk/aws-apigatewayv2': 1.184.0_isufbo7n5frgco5l3nwvujsagi
+      '@aws-cdk/aws-cloudfront': 1.184.0_isufbo7n5frgco5l3nwvujsagi
+      '@aws-cdk/aws-dynamodb': 1.184.0_mgp4cayxeflaa4rt2pz6i5fzse
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-events-targets': 1.184.0_wjv6zsamcjenf73wchyblkmd64
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-lambda-event-sources': 1.184.0_ncny3tsacj4ukcnpddg55a5rim
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-s3-deployment': 1.184.0_h4avs236xadyxful2oqwgrkpey
+      '@aws-cdk/cloudformation-diff': 1.184.0
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/custom-resources': 1.184.0_j7nktgzqknhwa3hzpbs4fh2zei
+      '@aws-cdk/cx-api': 1.184.0
       '@boostercloud/framework-common-helpers': link:../framework-common-helpers
       '@boostercloud/framework-provider-aws': link:../framework-provider-aws
       '@boostercloud/framework-types': link:../framework-types
       '@effect-ts/core': 0.60.5
       archiver: 5.3.0
-      aws-cdk: 1.183.0
+      aws-cdk: 1.184.0
       aws-sdk: 2.853.0
       cdk-assets: 2.39.1
       colors: 1.4.0
-      constructs: 3.4.191
+      constructs: 3.4.192
       promptly: 3.2.0
       tslib: 2.4.1
       yaml: 1.10.2
@@ -860,16 +860,16 @@ importers:
       '@boostercloud/framework-core': link:../framework-core
       '@boostercloud/framework-provider-azure': link:../framework-provider-azure
       '@boostercloud/framework-types': link:../framework-types
-      '@cdktf/provider-azurerm': 0.2.234_th5d3nxioqaghem2u57s2aajhy
+      '@cdktf/provider-azurerm': 0.2.234_u47zdeb26yvpl6k6cjkjj3wjdq
       '@effect-ts/core': 0.60.5
       '@types/archiver': 5.1.0
       '@types/needle': 2.5.3
       archiver: 5.3.0
-      cdktf: 0.7.0_constructs@10.1.196
+      cdktf: 0.7.0_constructs@10.1.197
       cdktf-cli: 0.12.3_ink@3.2.0+react@17.0.2
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
-      constructs: 10.1.196
+      constructs: 10.1.197
       copyfiles: 2.4.1
       fs-extra: 8.1.0
       ink: 3.2.0_react@17.0.2
@@ -1402,78 +1402,78 @@ packages:
       '@jridgewell/trace-mapping': 0.3.17
     dev: true
 
-  /@aws-cdk/assets/1.183.0_qjrgixlxwtmbgfb4fwspwgbpwq:
-    resolution: {integrity: sha512-h6CN3G/lMPpNoHxTLEVD1yg4wPBc+38IZFH5i7NunqFZtL9BwnasrlKe6j6Q7/+arC0zKYNgJgXzM7UtzARj7w==}
+  /@aws-cdk/assets/1.184.0_afuk5sfx5hdxwlsys3ycewghvi:
+    resolution: {integrity: sha512-FH4xBas8kqldUwMiQP/RHthAec2tZoldWDUEVHYRjrbNUo3MGhsyUUGoqdeetHpqCtS5VAfE7uap5o/FrLhQLQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-acmpca/1.183.0_ihjof7lowhi333cksrwxypekxm:
-    resolution: {integrity: sha512-lJHElE2H8hsA6I69igWMUM9Bswp5zQ882yySyAWPJWemBDPXlKyqc9lwgbhtBnE6ThLYQCBZUojrkFf9kCCYtA==}
+  /@aws-cdk/aws-acmpca/1.184.0_6pq2hh53fqzejgwdatnk7vsk4e:
+    resolution: {integrity: sha512-JSihbWXDavnH8KIUmhm2G54YvMYYJCdkU4ejabHhVKwZCuRJ9ic7BU8BvXNspnOHGf4ngxOgWpcLw13kHw8yPw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-apigateway/1.183.0_enidw6wkizd3xsvxqh6cnz5kwe:
-    resolution: {integrity: sha512-CtHdKe7+r6HPT4PdoF4zo0zWjUhNFY2IZfcEQrVsBQKQRZM0UvkGJ0Yt1vnVgsNYcn6MXbfiNc6ycHC2QqBCqg==}
+  /@aws-cdk/aws-apigateway/1.184.0_b4z73lyzyylw24j4rewft4zwcm:
+    resolution: {integrity: sha512-rG5lsFYf1HDNMce2bEPvsidApiTy9KZSozCN7hGCpcexumP9bv01DMAKkWF2PfEN9BqpzYu+QMQa3WVzmS3TTQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-certificatemanager': 1.183.0_mi7oytqex4bwacgooaynmegqom
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-cognito': 1.183.0_7uamms5wzwtdejwpffibszz6eq
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-elasticloadbalancingv2': 1.183.0_skgq7crkylogcuqujvfguacswq
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-s3-assets': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-stepfunctions': 1.183.0_za6jkin4qwjyd7ryccz524pgka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-certificatemanager': 1.184.0_ynr4gezulliue4ejq4ung3i4qu
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-cognito': 1.184.0_oztneuhrzrtmfkujiacbyn6tza
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_isufbo7n5frgco5l3nwvujsagi
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-s3-assets': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-stepfunctions': 1.184.0_xiumwwsiuspehkzvpmkowrb2ja
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-events'
       - '@aws-cdk/custom-resources'
     dev: false
 
-  /@aws-cdk/aws-apigatewayv2/1.183.0_skgq7crkylogcuqujvfguacswq:
-    resolution: {integrity: sha512-ZU44T8t4+MVPZuMHa5h6X2TifmLxUSIvHCC8LV8leTj+G17I8IuBWUl0rlAReWPR8G3g++KiFVeMJi4+ZQn8Kw==}
+  /@aws-cdk/aws-apigatewayv2/1.184.0_isufbo7n5frgco5l3nwvujsagi:
+    resolution: {integrity: sha512-MY5ksjHac2Xu2FGv8hutbTSbvProHD29RRjyZbOiK/MXRoz2zd3Wl7Gacpi1vwWFI0Nz3TNrReHpjb0fMlgcPQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-certificatemanager': 1.183.0_mi7oytqex4bwacgooaynmegqom
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-certificatemanager': 1.184.0_ynr4gezulliue4ejq4ung3i4qu
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-lambda'
@@ -1482,76 +1482,76 @@ packages:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-applicationautoscaling/1.183.0_ilznwvxp27yag2somatnsfw4tm:
-    resolution: {integrity: sha512-yHn3wzlp+J3ndUa3rLlzOQPTrif5yfhZsW4wvH0Gimmfv+4U5pW0evOUd4v53hE4PM2da+l+AjLSEuWgBNBZ4A==}
+  /@aws-cdk/aws-applicationautoscaling/1.184.0_oysovces7knjd7oo7lc3hhmwfu:
+    resolution: {integrity: sha512-8/o4btT/qPGPo2anHrc1m5NylF76QDUD+iv08ln6H3m628L31GRmeEJFVWpGhroedrARHllnmHdLBMzpWteNxw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-autoscaling-common': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-autoscaling-common': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-autoscaling-common/1.183.0_ilznwvxp27yag2somatnsfw4tm:
-    resolution: {integrity: sha512-OxGFLBuQiKn9GuUMh3e/t56kTVPA9xYeI4KakEpATrB3T//JmGVzrq1FKjBVUhokKChNphaiya4dHfqMohhEog==}
+  /@aws-cdk/aws-autoscaling-common/1.184.0_oysovces7knjd7oo7lc3hhmwfu:
+    resolution: {integrity: sha512-ksto+CMv6rZhSrMgamsnUBEeUghFq9p1OmGSIwiUQuQk5sjbh6b7WSBfJY2EsAXiosSDT+GyRePV0Z5vw0bWKQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-autoscaling-hooktargets/1.183.0_6kn2y3ahwvljvuqgedngucmstu:
-    resolution: {integrity: sha512-xI+IDPuF+hwI0tJyXC5nQf1NrLIQXw4vj1NAlsz7FCkZalUMKueQOQlR2GU03g23s/Ro6WwX3Y/u8IQZB6g5aw==}
+  /@aws-cdk/aws-autoscaling-hooktargets/1.184.0_m6oldxpludbtxdctrgzbxqdh5a:
+    resolution: {integrity: sha512-GUQA3uiLl9AxPjyRWKNMswAX5IiL6FzCHArpLIZMWS+ZYtlFy2oYoVGnytva3TA7w47AzVRirbO/zB4e55E4Tg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-autoscaling': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-kms': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-sns': 1.183.0
-      '@aws-cdk/aws-sns-subscriptions': 1.183.0
-      '@aws-cdk/aws-sqs': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-autoscaling': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-kms': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-sns': 1.184.0
+      '@aws-cdk/aws-sns-subscriptions': 1.184.0
+      '@aws-cdk/aws-sqs': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-autoscaling': 1.183.0_enidw6wkizd3xsvxqh6cnz5kwe
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-sns': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-sns-subscriptions': 1.183.0_hplfleswyk4awlhgkn3pyobmaa
-      '@aws-cdk/aws-sqs': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-autoscaling': 1.184.0_b4z73lyzyylw24j4rewft4zwcm
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-sns': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-sns-subscriptions': 1.184.0_cwew7tg62qugzixu6eqxab5bm4
+      '@aws-cdk/aws-sqs': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-autoscaling/1.183.0_enidw6wkizd3xsvxqh6cnz5kwe:
-    resolution: {integrity: sha512-XvLPylW/IdkGJdswt3rFl1uileEUWtvjszh5nxGQRbmoHgncwj1YJNzoQBCIJASHfHe+WZ2Nk1S5zAjWhBw2ng==}
+  /@aws-cdk/aws-autoscaling/1.184.0_b4z73lyzyylw24j4rewft4zwcm:
+    resolution: {integrity: sha512-2d5nhe0GpY0o/BdtCk+XkDKlxqTC8RzLmG0RH3xR7AANEKf5YLBiXg4t9UlfOkGaIGwq3+vXdlmIN3/H0IZwIA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-autoscaling-common': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-elasticloadbalancing': 1.183.0_hjtkwhwduzzcose76vkhivh6wm
-      '@aws-cdk/aws-elasticloadbalancingv2': 1.183.0_skgq7crkylogcuqujvfguacswq
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-sns': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-autoscaling-common': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-elasticloadbalancing': 1.184.0_ebumgixuyl3efzc3xfk5xymeve
+      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_isufbo7n5frgco5l3nwvujsagi
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-sns': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-events'
@@ -1562,120 +1562,120 @@ packages:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-certificatemanager/1.183.0_mi7oytqex4bwacgooaynmegqom:
-    resolution: {integrity: sha512-zzWLyoNF6iImHG76+3N49wjHJFe93vbqO9GcOnoQvE4JdUnLLBeDXeWM65gmkj16lN5UnjpJeE10wITqnfSAVA==}
+  /@aws-cdk/aws-certificatemanager/1.184.0_ynr4gezulliue4ejq4ung3i4qu:
+    resolution: {integrity: sha512-wTABjyh5ntPhDImOS5lPUyoKrtXiAwgn+2CyLJtGp/mST+y9ofzQn0iHL1lwqvxu2AY/NcA08hjaPstEx0SBkg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-acmpca': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-route53': 1.183.0_druf3jgjycya2cfz77owjaqgra
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-acmpca': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-route53': 1.184.0_f2cynxikbtlaqfd3np55i7mldq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/aws-ec2'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/custom-resources'
     dev: false
 
-  /@aws-cdk/aws-cloudformation/1.183.0_sum2shqcgknuyuddu3t5k2fufu:
-    resolution: {integrity: sha512-xEGjLPLdJLcTlW7+dNZ1UV7Mb1FCxJ50ozPpJSmdd1/bEXOJ2f6e0rFm8MiOBxQJsbIQksfLoS/xEjxWu+XffQ==}
+  /@aws-cdk/aws-cloudformation/1.184.0_kbfyk5hfojsdvoinde74uwt4ay:
+    resolution: {integrity: sha512-dQQazGqGVb3n2DcZ/0QW9oSKRE/+r1RigKSKFHg6M1hrhzM+/SoUU1KTVuHL7B6bNQga9rYb3ZrpL9MBt0W5vw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-sns': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-sns': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/aws-events'
     dev: false
 
-  /@aws-cdk/aws-cloudfront/1.183.0_skgq7crkylogcuqujvfguacswq:
-    resolution: {integrity: sha512-ZPWwHoCAW/Aw0A4KpSCfnffJADwaJq10Ri2Pm8vNXeuJNS55U5pSFyZ+Y1xl+2iq+3pKuUp1eF3FaBt+gR5nuw==}
+  /@aws-cdk/aws-cloudfront/1.184.0_isufbo7n5frgco5l3nwvujsagi:
+    resolution: {integrity: sha512-6NU4mHPnhcCtJZyNfhq/1HriEvMGb+i/WJZyadYNWArJ8oJi68+c7jB3pxQT+QLYff4f3a0vV5lcL93Wcty6Mg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-certificatemanager': 1.183.0_mi7oytqex4bwacgooaynmegqom
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-ssm': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-certificatemanager': 1.184.0_ynr4gezulliue4ejq4ung3i4qu
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-ssm': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/custom-resources'
     dev: false
 
-  /@aws-cdk/aws-cloudwatch/1.183.0_ilznwvxp27yag2somatnsfw4tm:
-    resolution: {integrity: sha512-3VliW6XbMyI44SBp2mQbj9yFdYI3Qd2HyTMfqnBl2lUig9tP5o8M4d94DdTEm0xFagQbGTYiKaaiy2FVlmraNw==}
+  /@aws-cdk/aws-cloudwatch/1.184.0_oysovces7knjd7oo7lc3hhmwfu:
+    resolution: {integrity: sha512-sf2g/rRDhpEipvoMSPE7V1m0aj6ZuvVzAWCtPHuGz5s9eCaxyJMlN+gLJpBy4OvY2EDj7TkHnO4elwzYOganIg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-codebuild/1.183.0_jdemlcjbnx5lxnlr6bksodytsm:
-    resolution: {integrity: sha512-qF6uoz24+7RzkuK1+vwCeGF26V2ZFjAA4c4EoYuj9Hzs9PExUbnN1JaJBnbCzguBClmCicEWq0W1hzRtAmOTQw==}
+  /@aws-cdk/aws-codebuild/1.184.0_j7nktgzqknhwa3hzpbs4fh2zei:
+    resolution: {integrity: sha512-Wn4ZsBPnmBM2DNTE13nHirZYS63MslY+ruysIz9z4FBM+PFnwYrLrnMtFy07TNjHEdjR8hOcgxOFItq527iT1Q==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/assets': 1.183.0
-      '@aws-cdk/aws-events': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/assets': 1.184.0
+      '@aws-cdk/aws-events': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/assets': 1.183.0_qjrgixlxwtmbgfb4fwspwgbpwq
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-codecommit': 1.183.0_62uvidmfblnrk5vtpehedvkn5e
-      '@aws-cdk/aws-codestarnotifications': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-ecr': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-ecr-assets': 1.183.0_62uvidmfblnrk5vtpehedvkn5e
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-s3-assets': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-secretsmanager': 1.183.0_3rxydtitlm6iotca5gpilmavfy
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/region-info': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/assets': 1.184.0_afuk5sfx5hdxwlsys3ycewghvi
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-codecommit': 1.184.0_3mv3lh66jiob54lj7hjqhiclpq
+      '@aws-cdk/aws-codestarnotifications': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-ecr': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-ecr-assets': 1.184.0_3mv3lh66jiob54lj7hjqhiclpq
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-s3-assets': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-secretsmanager': 1.184.0_g72srgrgv53yhrqyfjq7qatcqm
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/region-info': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/aws-lambda'
       - '@aws-cdk/cx-api'
@@ -1683,89 +1683,89 @@ packages:
     bundledDependencies:
       - yaml
 
-  /@aws-cdk/aws-codecommit/1.183.0_62uvidmfblnrk5vtpehedvkn5e:
-    resolution: {integrity: sha512-WEK0YUSHchpv+xi4vcC5kqC2uVKIAsADJ2VIgpuZT7w6Qh4MhsKxqJVupzhH8btp3UyTJbtu/+buKGPuXi6lDg==}
+  /@aws-cdk/aws-codecommit/1.184.0_3mv3lh66jiob54lj7hjqhiclpq:
+    resolution: {integrity: sha512-Jk5qhJZ5ldtxyJDxhkmF9HSrmTiHosP41KLVoX/SH5xKoBC7GBpQSa+np1mOLW6cz76I1nYVvZDyRgzAUuGndQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-events': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-events': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-codestarnotifications': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-s3-assets': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-codestarnotifications': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-s3-assets': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-s3'
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-codeguruprofiler/1.183.0_ilznwvxp27yag2somatnsfw4tm:
-    resolution: {integrity: sha512-Yc9rSWkYrmGj0FWIZI8ovnKBA+OkP/2k6f5/9vXz1HbiPIWtbsV9U969WB8c50VBsIP/5KOI1yxLLT4F+f/NpQ==}
+  /@aws-cdk/aws-codeguruprofiler/1.184.0_oysovces7knjd7oo7lc3hhmwfu:
+    resolution: {integrity: sha512-MSs7YYTV1aGbVy9IQ2NxO5v4SBXj0XL/q7q2y0OnXXlm2GmhJWIr/5xqf+b1DKhT3oUDx3cLyXvuK0FXLUAAvw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-codepipeline/1.183.0_3ii33fuvolpm4yze7hiojwdlbm:
-    resolution: {integrity: sha512-VP9kakot8TU2B0xeO10A6XtHuPdbjE2Buf/7UAqCx6Hvyjtup+CUdAKg0FQWXQqfBoE1aF5atRmDe9KeJDVtiQ==}
+  /@aws-cdk/aws-codepipeline/1.184.0_3vhjadqgtratlsr3osrow4dyya:
+    resolution: {integrity: sha512-Dw/yeutUbkjeQ9XrR1RRGRAujs9MRsyDBo1hTQ4czZfas0rFXP7H7tjkJDsmZjQ9HHXVdHSfhtL7pVg4Icwdcg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-events': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-events': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-codestarnotifications': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-codestarnotifications': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-codestarnotifications/1.183.0_ihjof7lowhi333cksrwxypekxm:
-    resolution: {integrity: sha512-PpeEzLoR743vTekJMFuCcBEpdAmBoe8z83Gw4KpkK+ZeEwJnJ1jXZ28zdV84OxD/h+qrcIo4zsEDKTgp+r727g==}
+  /@aws-cdk/aws-codestarnotifications/1.184.0_6pq2hh53fqzejgwdatnk7vsk4e:
+    resolution: {integrity: sha512-k6P+vTC+I9kAehGmp7bnrsHIua5XoNsbTXc0PDL9/xHf/kcTrSPF8AMqvJTvKYNCTxQAAEi8oqLxD8NalzyKAA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-cognito/1.183.0_7uamms5wzwtdejwpffibszz6eq:
-    resolution: {integrity: sha512-5bi+IB6ACoidIZVE5rX4wMiYymZBkQmAGtxPjVxYN03/v6ImM+6S15cl7oSfdnSvR4Q4uJoPGZQgu0OotO9SXQ==}
+  /@aws-cdk/aws-cognito/1.184.0_oztneuhrzrtmfkujiacbyn6tza:
+    resolution: {integrity: sha512-w1Fg7wK3a2ofm2OGZBiO7pHc04Joflq/r5Qs+LZRLjszp55AL/sgEgeuqc0UPrW6mRd/p80hbkvsLCD02IW3cA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/custom-resources': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/custom-resources': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-certificatemanager': 1.183.0_mi7oytqex4bwacgooaynmegqom
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/custom-resources': 1.183.0_jdemlcjbnx5lxnlr6bksodytsm
-      constructs: 3.4.191
+      '@aws-cdk/aws-certificatemanager': 1.184.0_ynr4gezulliue4ejq4ung3i4qu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/custom-resources': 1.184.0_j7nktgzqknhwa3hzpbs4fh2zei
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/aws-ec2'
       - '@aws-cdk/aws-logs'
@@ -1774,135 +1774,135 @@ packages:
     bundledDependencies:
       - punycode
 
-  /@aws-cdk/aws-dynamodb/1.183.0_gt7snz7gbhxc433or4gdp4hauy:
-    resolution: {integrity: sha512-ZGP4ifb3nC6UpbnYo5Pvv7a/cnGK0vwpMRE1qVaiA1wYGSqPiLBQiOPrZnvFjivq83QNJQYfyTnSLGYA/YfvWQ==}
+  /@aws-cdk/aws-dynamodb/1.184.0_mgp4cayxeflaa4rt2pz6i5fzse:
+    resolution: {integrity: sha512-xEKYxuieauGeuzSkoxH3hgNnErAsP4+EgGoPt6DoHT2BkL0KvMxGKZUVm4trGS3ZvJvwIm/JoPPUkRZ7XDoukQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/custom-resources': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/custom-resources': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-applicationautoscaling': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kinesis': 1.183.0_32rpjv7bzbq6uucfdau33fp4ce
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/custom-resources': 1.183.0_jdemlcjbnx5lxnlr6bksodytsm
-      constructs: 3.4.191
+      '@aws-cdk/aws-applicationautoscaling': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kinesis': 1.184.0_3n6omu652ehmcdelqb243vat4m
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/custom-resources': 1.184.0_j7nktgzqknhwa3hzpbs4fh2zei
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-ec2/1.183.0_ah7muc3vvde5kkfsgcua6dikzm:
-    resolution: {integrity: sha512-7gsPOI3fzUuaBAeTwf9B0qkh+yJCf3PErdFYagv0L1Sy6fSq6D7P5y5JsH/LXjUCcYwPvG980QJlCuQKlFuJHg==}
+  /@aws-cdk/aws-ec2/1.184.0_6aw5klqzusmpfvouqwq5rnef3e:
+    resolution: {integrity: sha512-Z0e1cD6/ultLvAfyQWhwFntfTpVA9ekkPFY+f/t3SV6OYmewyAex4pb40UA4UxraXoNL8JDSPzaaKfE4mPnZ5g==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-s3-assets': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-ssm': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/cloud-assembly-schema': 1.183.0
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      '@aws-cdk/region-info': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-s3-assets': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-ssm': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/cloud-assembly-schema': 1.184.0
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      '@aws-cdk/region-info': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
     dev: false
 
-  /@aws-cdk/aws-ecr-assets/1.183.0_62uvidmfblnrk5vtpehedvkn5e:
-    resolution: {integrity: sha512-lRDJwlsmUyGPlVKSiRsU8jmZvnCUJ1AKE7t9BmyKBJOYHKaqRAhyS+1s7cfvr76+oqnikZgUIrSHnsYnM0jjqw==}
+  /@aws-cdk/aws-ecr-assets/1.184.0_3mv3lh66jiob54lj7hjqhiclpq:
+    resolution: {integrity: sha512-t/liks3dWcLBBEjSFuwtQmeqlkEMN1jMuR7edwR5fGmvsz5yysdSfs7rWOJftHXuVy6+L9L5gMpdl34J2e5YZg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/assets': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/assets': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/assets': 1.183.0_qjrgixlxwtmbgfb4fwspwgbpwq
-      '@aws-cdk/aws-ecr': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/assets': 1.184.0_afuk5sfx5hdxwlsys3ycewghvi
+      '@aws-cdk/aws-ecr': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/aws-events'
     dev: false
 
-  /@aws-cdk/aws-ecr/1.183.0_psiol63vhfkel2lugznsms3lka:
-    resolution: {integrity: sha512-lwn1TbbS/M3xhcsoHXlGkI0/ZmaD2d1al9dhfK/IMi5NZIC92lYuSCsDSXz/xv13xd9/KaSsjavKOaZiz227xQ==}
+  /@aws-cdk/aws-ecr/1.184.0_hqlnsupdj7wlhbmiji67ba5kuq:
+    resolution: {integrity: sha512-MTeolpr49xubLRqpYkw0qcC77TE6oTos/LgloCwlJi52bS6iYq0+bSz+mTK08QRu5UZyUB3EdCgLtf5gA+CCww==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-events': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-events': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-ecs/1.183.0_pae2repx4cbhhttnhibnqomveu:
-    resolution: {integrity: sha512-JVFSqR/saiAdUNz2Kt9LjEwtYVI5pNLZGIG0nvlL5+GOO5P/RFnVYjdaG04PUmGygjqCZ08bQDOhY1ySWZMoSw==}
+  /@aws-cdk/aws-ecs/1.184.0_v4k2uaxxqx2fffj7ruk2pek6fe:
+    resolution: {integrity: sha512-Fg4YKOUUjj4qDJJbDcKiI6IXWQv+DW4T89g7ssmuxHmbo76eTsumjjbKOTyEzMVZLKaxe4FYCSVJoHvDz9nXMw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-applicationautoscaling': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-autoscaling': 1.183.0_enidw6wkizd3xsvxqh6cnz5kwe
-      '@aws-cdk/aws-autoscaling-hooktargets': 1.183.0_6kn2y3ahwvljvuqgedngucmstu
-      '@aws-cdk/aws-certificatemanager': 1.183.0_mi7oytqex4bwacgooaynmegqom
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-ecr': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-ecr-assets': 1.183.0_62uvidmfblnrk5vtpehedvkn5e
-      '@aws-cdk/aws-elasticloadbalancing': 1.183.0_hjtkwhwduzzcose76vkhivh6wm
-      '@aws-cdk/aws-elasticloadbalancingv2': 1.183.0_skgq7crkylogcuqujvfguacswq
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-route53': 1.183.0_druf3jgjycya2cfz77owjaqgra
-      '@aws-cdk/aws-route53-targets': 1.183.0_uub6sywhmbfsdmab5qkoqhta6y
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-s3-assets': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-secretsmanager': 1.183.0_3rxydtitlm6iotca5gpilmavfy
-      '@aws-cdk/aws-servicediscovery': 1.183.0_pwj4fltxrhdb7i5s3iylcs72ry
-      '@aws-cdk/aws-sns': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-sqs': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-ssm': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-applicationautoscaling': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-autoscaling': 1.184.0_b4z73lyzyylw24j4rewft4zwcm
+      '@aws-cdk/aws-autoscaling-hooktargets': 1.184.0_m6oldxpludbtxdctrgzbxqdh5a
+      '@aws-cdk/aws-certificatemanager': 1.184.0_ynr4gezulliue4ejq4ung3i4qu
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-ecr': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-ecr-assets': 1.184.0_3mv3lh66jiob54lj7hjqhiclpq
+      '@aws-cdk/aws-elasticloadbalancing': 1.184.0_ebumgixuyl3efzc3xfk5xymeve
+      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_isufbo7n5frgco5l3nwvujsagi
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-route53': 1.184.0_f2cynxikbtlaqfd3np55i7mldq
+      '@aws-cdk/aws-route53-targets': 1.184.0_6xa7vpjcy6diwcy5erjalstzme
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-s3-assets': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-secretsmanager': 1.184.0_g72srgrgv53yhrqyfjq7qatcqm
+      '@aws-cdk/aws-servicediscovery': 1.184.0_md2fvnqv74y5c2poc5wbr6pcea
+      '@aws-cdk/aws-sns': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-sqs': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-ssm': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-apigateway'
@@ -1912,103 +1912,103 @@ packages:
       - '@aws-cdk/custom-resources'
     dev: false
 
-  /@aws-cdk/aws-efs/1.183.0_ah7muc3vvde5kkfsgcua6dikzm:
-    resolution: {integrity: sha512-aSeZVtnTqDJO1VtixwNjrGkUiq1gNrAZhVbcTLFGiiUxu746u/z8CJ6JBRkPdlskH3PJbbOG1tqvCdphmsL/3A==}
+  /@aws-cdk/aws-efs/1.184.0_6aw5klqzusmpfvouqwq5rnef3e:
+    resolution: {integrity: sha512-0JWQTQoe0POyAoCqhj1gry9oFDg7wsqaR1/ayQwTfBj+bbhGFVbj8C3XFSNxe3EY6DDoRr9hPkitY+6NFYARcg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/cloud-assembly-schema': 1.183.0
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/cloud-assembly-schema': 1.184.0
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/aws-s3'
     dev: false
 
-  /@aws-cdk/aws-elasticloadbalancing/1.183.0_hjtkwhwduzzcose76vkhivh6wm:
-    resolution: {integrity: sha512-R+x8luB9QtlfdtQ7MAsdB9iQdSO7rW5qjPig4WUvQj976BLUrz1isQGyrehFk07crCCWCWSOJNsyv8tjtUlhsg==}
+  /@aws-cdk/aws-elasticloadbalancing/1.184.0_ebumgixuyl3efzc3xfk5xymeve:
+    resolution: {integrity: sha512-ws3kWoXDD3JABakL/T6Xyr0A6x9EJbH5PAEE9gcl6Q7omybFEDykf0Mo88rZYhDqHIUntsPh3xOGoR1+45Z2Ug==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-ec2': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-ec2': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-elasticloadbalancingv2/1.183.0_skgq7crkylogcuqujvfguacswq:
-    resolution: {integrity: sha512-bhNP7UfAQ8Kd6NPt5lPmigYXwFY0zy6pUUUyqPv9zclq9majd7vREJfrJwsyS73MwQ+FwJa44dcheLlBBUnvVw==}
+  /@aws-cdk/aws-elasticloadbalancingv2/1.184.0_isufbo7n5frgco5l3nwvujsagi:
+    resolution: {integrity: sha512-UDASd86i+kFEsgvVU8AFX0Ky1x7bzITW+Au4zWSBoAvMsAFufHXHV7YOSHlfPltUnR45zqEom04jexGgkV6ivw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-certificatemanager': 1.183.0_mi7oytqex4bwacgooaynmegqom
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-route53': 1.183.0_druf3jgjycya2cfz77owjaqgra
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/cloud-assembly-schema': 1.183.0
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      '@aws-cdk/region-info': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-certificatemanager': 1.184.0_ynr4gezulliue4ejq4ung3i4qu
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-route53': 1.184.0_f2cynxikbtlaqfd3np55i7mldq
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/cloud-assembly-schema': 1.184.0
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      '@aws-cdk/region-info': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/custom-resources'
     dev: false
 
-  /@aws-cdk/aws-events-targets/1.183.0_o7d7hmthwen5hbhypli7ibz354:
-    resolution: {integrity: sha512-heZL4A60bmo5WCsSUaqPjlG0W2iWME5Ltdtaul6KW4mzNYSrk8qCM1uI5hJwydoxs0iH9WcXU5Dum++v1WArJA==}
+  /@aws-cdk/aws-events-targets/1.184.0_wjv6zsamcjenf73wchyblkmd64:
+    resolution: {integrity: sha512-2cg5ZsCFE2Nqehplp5040GLIsXOXXoR3G42slGSClmqFKIRJJzuX/s+17PIXOu/4CfjCKUVBE5fVTx2LDFbLHw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-apigateway': 1.183.0
-      '@aws-cdk/aws-events': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/custom-resources': 1.183.0
+      '@aws-cdk/aws-apigateway': 1.184.0
+      '@aws-cdk/aws-events': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/custom-resources': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-apigateway': 1.183.0_enidw6wkizd3xsvxqh6cnz5kwe
-      '@aws-cdk/aws-autoscaling': 1.183.0_enidw6wkizd3xsvxqh6cnz5kwe
-      '@aws-cdk/aws-codebuild': 1.183.0_jdemlcjbnx5lxnlr6bksodytsm
-      '@aws-cdk/aws-codepipeline': 1.183.0_3ii33fuvolpm4yze7hiojwdlbm
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-ecs': 1.183.0_pae2repx4cbhhttnhibnqomveu
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kinesis': 1.183.0_32rpjv7bzbq6uucfdau33fp4ce
-      '@aws-cdk/aws-kinesisfirehose': 1.183.0_3rxydtitlm6iotca5gpilmavfy
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-sns': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-sns-subscriptions': 1.183.0_hplfleswyk4awlhgkn3pyobmaa
-      '@aws-cdk/aws-sqs': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-stepfunctions': 1.183.0_za6jkin4qwjyd7ryccz524pgka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/custom-resources': 1.183.0_jdemlcjbnx5lxnlr6bksodytsm
-      constructs: 3.4.191
+      '@aws-cdk/aws-apigateway': 1.184.0_b4z73lyzyylw24j4rewft4zwcm
+      '@aws-cdk/aws-autoscaling': 1.184.0_b4z73lyzyylw24j4rewft4zwcm
+      '@aws-cdk/aws-codebuild': 1.184.0_j7nktgzqknhwa3hzpbs4fh2zei
+      '@aws-cdk/aws-codepipeline': 1.184.0_3vhjadqgtratlsr3osrow4dyya
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-ecs': 1.184.0_v4k2uaxxqx2fffj7ruk2pek6fe
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kinesis': 1.184.0_3n6omu652ehmcdelqb243vat4m
+      '@aws-cdk/aws-kinesisfirehose': 1.184.0_g72srgrgv53yhrqyfjq7qatcqm
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-sns': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-sns-subscriptions': 1.184.0_cwew7tg62qugzixu6eqxab5bm4
+      '@aws-cdk/aws-sqs': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-stepfunctions': 1.184.0_xiumwwsiuspehkzvpmkowrb2ja
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/custom-resources': 1.184.0_j7nktgzqknhwa3hzpbs4fh2zei
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-cloudfront'
@@ -2016,225 +2016,225 @@ packages:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-events/1.183.0_ilznwvxp27yag2somatnsfw4tm:
-    resolution: {integrity: sha512-j1bgr+H/DFmqzaabBEec6TU0+V2uyB6YMOHFYvju3X6RsitWKeifz1FOgtOpjxbJMlckOOUr6byt+bGRE2i7KA==}
+  /@aws-cdk/aws-events/1.184.0_oysovces7knjd7oo7lc3hhmwfu:
+    resolution: {integrity: sha512-e5rzLzaYUO61Ih/SAArO/q+v8ESpAR0FRdQJW0L5wBWomi5T8H1hpYcpYCYcMkzjLrj/rPG2bCjRpM8O08H5KA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-globalaccelerator/1.183.0_lgtspetbkwhesgjf4hzli4uf7i:
-    resolution: {integrity: sha512-NLGnRJxsasr8+8XgnvoxbiuZe9RcqCmMyBWq0LxmSq9xAkW4yaEnQKAeOZ86ZGWamfkLeawrxNM3EhQD+Rn7ZQ==}
+  /@aws-cdk/aws-globalaccelerator/1.184.0_folaootfscwnimqdag76joazwq:
+    resolution: {integrity: sha512-W0sS7mv5T0Sezj6A5lPasBjwBM/wlktiZGHtK3ssS3UoBm9sK7xGrOzSwltz94qw/NThvuFkblhwFYqKTKRIbQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-ec2': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/custom-resources': 1.183.0
+      '@aws-cdk/aws-ec2': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/custom-resources': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/custom-resources': 1.183.0_jdemlcjbnx5lxnlr6bksodytsm
-      constructs: 3.4.191
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/custom-resources': 1.184.0_j7nktgzqknhwa3hzpbs4fh2zei
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-iam/1.183.0_ihjof7lowhi333cksrwxypekxm:
-    resolution: {integrity: sha512-D3oHKon63ixyzuiZqSMU3Cq3ONA9PxLbTdp5/rnlck5rEYV5xvoGIMBTCZM4ifslZ7x3FveXMFz+KCHYr5htHQ==}
+  /@aws-cdk/aws-iam/1.184.0_6pq2hh53fqzejgwdatnk7vsk4e:
+    resolution: {integrity: sha512-sK+v/fqpnZaTyO5Rc+Oa8NdEGUjUJl6OJKWwV31Vauqf7g459QCM9gLhtIxrVIqoew3rkeJAygmWg2k3Mzgy0g==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      '@aws-cdk/region-info': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      '@aws-cdk/region-info': 1.184.0
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-kinesis/1.183.0_32rpjv7bzbq6uucfdau33fp4ce:
-    resolution: {integrity: sha512-/NgcWxW0vPGB00gSTkhNbrVPUEQdsKv7sQ7qwlsOZt02QOHtF27NV4iRE9BToltb3yu1n2nsH3QEUm5Ds85B7g==}
+  /@aws-cdk/aws-kinesis/1.184.0_3n6omu652ehmcdelqb243vat4m:
+    resolution: {integrity: sha512-RDN3QFiOw921sAFO1B+3IUOyOFBCLErmLlbZmXft2HdEkgrs/g48TvEvpJR1YPGRQME+TpIdi7YdNaAo1VmSPg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-kinesisfirehose/1.183.0_3rxydtitlm6iotca5gpilmavfy:
-    resolution: {integrity: sha512-SnEVxVATfraaUwRh7SPUq8fZClua/WyGNBN5jv9lE0fKwuUHBfgTH+3t0bXGMxWOpsHgIVOAsLo6dtzgdtHEWg==}
+  /@aws-cdk/aws-kinesisfirehose/1.184.0_g72srgrgv53yhrqyfjq7qatcqm:
+    resolution: {integrity: sha512-JoqdL82Kfs/uOFcAQtp6sWH3k0m4nJNIN4tvCVOcQ+z0ZD8q/mfLCpcsP9Y0AhHuQPz2I6eFk+eepjK2iAzvnQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kinesis': 1.183.0_32rpjv7bzbq6uucfdau33fp4ce
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/region-info': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kinesis': 1.184.0_3n6omu652ehmcdelqb243vat4m
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/region-info': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-kms/1.183.0_yj7eqy7354e37mfdflunab3hpm:
-    resolution: {integrity: sha512-M7DcBY9PK4UkmyfQKUi3JT7RZZcVRXyXFFqop9tKoApCmgLxYuiJxJXEq3A+OCQ6UdTtS3X0dQf9sZrpkEahtg==}
+  /@aws-cdk/aws-kms/1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny:
+    resolution: {integrity: sha512-AhBPXN7Q/S94PeUo2EXPhnMjBZrMzRMBkhJ+7yeswwxP+kDM/+FLRx52WaX5/qsCPGYYjp1MH+gqX/G9FKdIEA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/cloud-assembly-schema': 1.183.0
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/cloud-assembly-schema': 1.184.0
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-lambda-event-sources/1.183.0_5hu2vuqryr466ntk3k5ewozubm:
-    resolution: {integrity: sha512-Cd2Paj6Ax80k2G0wENOklALjWB/cXXi/x3wN6yRgobu9nXdjU+2MBhhsCkVeiwVSHS+SlYA9M1BqSi3Jl66HDQ==}
+  /@aws-cdk/aws-lambda-event-sources/1.184.0_ncny3tsacj4ukcnpddg55a5rim:
+    resolution: {integrity: sha512-rDN7FcUPlvnSoRwRWNkjuQqLi6kXncZlyhBCAMnkJADPAxKa7SqeeCgNOLgEYDXBcD1rohtEmcEQwt5CgGV2Xw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-apigateway': 1.183.0
-      '@aws-cdk/aws-dynamodb': 1.183.0
-      '@aws-cdk/aws-events': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-apigateway': 1.184.0
+      '@aws-cdk/aws-dynamodb': 1.184.0
+      '@aws-cdk/aws-events': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-apigateway': 1.183.0_enidw6wkizd3xsvxqh6cnz5kwe
-      '@aws-cdk/aws-dynamodb': 1.183.0_gt7snz7gbhxc433or4gdp4hauy
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kinesis': 1.183.0_32rpjv7bzbq6uucfdau33fp4ce
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-s3-notifications': 1.183.0_sum2shqcgknuyuddu3t5k2fufu
-      '@aws-cdk/aws-secretsmanager': 1.183.0_3rxydtitlm6iotca5gpilmavfy
-      '@aws-cdk/aws-sns': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-sns-subscriptions': 1.183.0_hplfleswyk4awlhgkn3pyobmaa
-      '@aws-cdk/aws-sqs': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-apigateway': 1.184.0_b4z73lyzyylw24j4rewft4zwcm
+      '@aws-cdk/aws-dynamodb': 1.184.0_mgp4cayxeflaa4rt2pz6i5fzse
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kinesis': 1.184.0_3n6omu652ehmcdelqb243vat4m
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-s3-notifications': 1.184.0_kbfyk5hfojsdvoinde74uwt4ay
+      '@aws-cdk/aws-secretsmanager': 1.184.0_g72srgrgv53yhrqyfjq7qatcqm
+      '@aws-cdk/aws-sns': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-sns-subscriptions': 1.184.0_cwew7tg62qugzixu6eqxab5bm4
+      '@aws-cdk/aws-sqs': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-lambda/1.183.0_74llbif432t2lxntlwjg4yiewq:
-    resolution: {integrity: sha512-Vle7b2yRecFJuxuNO7GPY95Fl6/AHC1akuUPjAs0CpcN3n5DeIdmfDXzcYZVDQGrUiCoumy5/WAsn9GSr/ss7Q==}
+  /@aws-cdk/aws-lambda/1.184.0_n65tzhlnp37b3djbpagmmuuaka:
+    resolution: {integrity: sha512-2jTfR18DT0S7A/BarTNSfbs3472fRajUNDg8Chydt/Zm84d6XqzIarv1+9ACeMdSf/f2/1MKzKrOSRfkrB78pw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-events': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-events': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-applicationautoscaling': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-codeguruprofiler': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-ecr': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-ecr-assets': 1.183.0_62uvidmfblnrk5vtpehedvkn5e
-      '@aws-cdk/aws-efs': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-s3-assets': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-signer': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-sns': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-sqs': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      '@aws-cdk/region-info': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-applicationautoscaling': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-codeguruprofiler': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-ecr': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-ecr-assets': 1.184.0_3mv3lh66jiob54lj7hjqhiclpq
+      '@aws-cdk/aws-efs': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-s3-assets': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-signer': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-sns': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-sqs': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      '@aws-cdk/region-info': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
     dev: false
 
-  /@aws-cdk/aws-logs/1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe:
-    resolution: {integrity: sha512-9ZLSuQ5cjbKqcaLTC/NvYh8vXwxYbwb4alvNIWbM4JBkhw2yjG8v7jB0xoIZ5Fc92QB0FqV0Kp5Vyw/Ef4iVBg==}
+  /@aws-cdk/aws-logs/1.184.0_hmnprgzc652nrvmsge3juwilgy:
+    resolution: {integrity: sha512-rgl95V2LmVzK8PGL3lCdNpiy1XTa78s1TyIncMNa/UuaPOYl7O1sJPq3UBJutoOHF1XyQdv8Fw2A8EAfivz8iQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-s3-assets': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-s3-assets': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-s3'
     dev: false
 
-  /@aws-cdk/aws-route53-targets/1.183.0_uub6sywhmbfsdmab5qkoqhta6y:
-    resolution: {integrity: sha512-mnyP0k/aCY2Jh9XUVViLPHdZzWiXul9W6sHhUlly78c8cCpq0VQO0qmmHNNATXDnTvph+/FRvNqwkRR2RK9deQ==}
+  /@aws-cdk/aws-route53-targets/1.184.0_6xa7vpjcy6diwcy5erjalstzme:
+    resolution: {integrity: sha512-xiOLxm9piAv/ESw3E72LBDazk15zf45gIWX9KNtiHoAk4V3cetWnWfkewgsXYFRPMMhjuNwZ3ZMvJd+odDCyUQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-apigateway': 1.183.0
-      '@aws-cdk/aws-cloudfront': 1.183.0
-      '@aws-cdk/aws-ec2': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-apigateway': 1.184.0
+      '@aws-cdk/aws-cloudfront': 1.184.0
+      '@aws-cdk/aws-ec2': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-apigateway': 1.183.0_enidw6wkizd3xsvxqh6cnz5kwe
-      '@aws-cdk/aws-cloudfront': 1.183.0_skgq7crkylogcuqujvfguacswq
-      '@aws-cdk/aws-cognito': 1.183.0_7uamms5wzwtdejwpffibszz6eq
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-elasticloadbalancing': 1.183.0_hjtkwhwduzzcose76vkhivh6wm
-      '@aws-cdk/aws-elasticloadbalancingv2': 1.183.0_skgq7crkylogcuqujvfguacswq
-      '@aws-cdk/aws-globalaccelerator': 1.183.0_lgtspetbkwhesgjf4hzli4uf7i
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-route53': 1.183.0_druf3jgjycya2cfz77owjaqgra
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/region-info': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-apigateway': 1.184.0_b4z73lyzyylw24j4rewft4zwcm
+      '@aws-cdk/aws-cloudfront': 1.184.0_isufbo7n5frgco5l3nwvujsagi
+      '@aws-cdk/aws-cognito': 1.184.0_oztneuhrzrtmfkujiacbyn6tza
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-elasticloadbalancing': 1.184.0_ebumgixuyl3efzc3xfk5xymeve
+      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_isufbo7n5frgco5l3nwvujsagi
+      '@aws-cdk/aws-globalaccelerator': 1.184.0_folaootfscwnimqdag76joazwq
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-route53': 1.184.0_f2cynxikbtlaqfd3np55i7mldq
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/region-info': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-lambda'
@@ -2243,69 +2243,69 @@ packages:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-route53/1.183.0_druf3jgjycya2cfz77owjaqgra:
-    resolution: {integrity: sha512-lqL26p+UjL9T8chqo5OBIlohA8YBpIQmNtuLMLfI0kmgw4Sis53Wuv3npZxdWp2d9sxq2j+6QUwQ5P9r7qUEkw==}
+  /@aws-cdk/aws-route53/1.184.0_f2cynxikbtlaqfd3np55i7mldq:
+    resolution: {integrity: sha512-u2QJ7B1gUzcP6ZOT1gZzSZNfIhoU9BqgYhXxUBoi28/Wd6gkO4GEkuM7+fz1itLBSL9spv9oG97JV4Ow6CcE0A==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-ec2': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/custom-resources': 1.183.0
+      '@aws-cdk/aws-ec2': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/custom-resources': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/cloud-assembly-schema': 1.183.0
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/custom-resources': 1.183.0_jdemlcjbnx5lxnlr6bksodytsm
-      constructs: 3.4.191
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/cloud-assembly-schema': 1.184.0
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/custom-resources': 1.184.0_j7nktgzqknhwa3hzpbs4fh2zei
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-s3-assets/1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe:
-    resolution: {integrity: sha512-obFlOpd886Ty7u8Vm/jtnG32a4JXE37mTze35yL6Dk8omhyQqkwoPBnAQFX8c//PfHK3EWC5Y/0hHNv09DaBmg==}
+  /@aws-cdk/aws-s3-assets/1.184.0_hmnprgzc652nrvmsge3juwilgy:
+    resolution: {integrity: sha512-i8YeXbeVGLre/zFT6PWn3UYQzPLOJDCSk59xrXKtvw9Qh5yLqyLkdVxquLS+S1V0vOdQwtii1V5Nlvurgm1WgA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/assets': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/assets': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/assets': 1.183.0_qjrgixlxwtmbgfb4fwspwgbpwq
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/assets': 1.184.0_afuk5sfx5hdxwlsys3ycewghvi
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-s3-deployment/1.183.0_enrwl5hbw6cxdxffr33yncegfy:
-    resolution: {integrity: sha512-ySz16oH/W1tjWX19+k1N+5elUKBIhiJHQARg6c/wuKAg1NJafhgcOPenKo4JXoiiCvaokMTqD7t2BF1Y0H8WlQ==}
+  /@aws-cdk/aws-s3-deployment/1.184.0_h4avs236xadyxful2oqwgrkpey:
+    resolution: {integrity: sha512-CZCYHfmPDoorwgXUV/V8SGgrgBdw/5LDEilrxKwHV559/X5sq88qjvCPTYlFU01xNNWBk2n0N7QK3KtHutGTBQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-cloudfront': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-cloudfront': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudfront': 1.183.0_skgq7crkylogcuqujvfguacswq
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-efs': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-s3-assets': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/lambda-layer-awscli': 1.183.0_b4lwl6ufm3tx3zr4r3m4kxtyqa
-      constructs: 3.4.191
+      '@aws-cdk/aws-cloudfront': 1.184.0_isufbo7n5frgco5l3nwvujsagi
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-efs': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-s3-assets': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/lambda-layer-awscli': 1.184.0_qhtul47d56vl2xyziuvyqjqvuu
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/cx-api'
@@ -2313,95 +2313,95 @@ packages:
     bundledDependencies:
       - case
 
-  /@aws-cdk/aws-s3-notifications/1.183.0_sum2shqcgknuyuddu3t5k2fufu:
-    resolution: {integrity: sha512-UbnF5Z3kICzK9ijAeRMVfYVbq8SZGFCxbtN3v6oOmFFs0uZ4NzeEcoyNidC+Rldknsl0ZG59HIKZ43cIe/Scjw==}
+  /@aws-cdk/aws-s3-notifications/1.184.0_kbfyk5hfojsdvoinde74uwt4ay:
+    resolution: {integrity: sha512-rvhs2K2onhFOViAPGGl6RlI+jO2YarfY4rbOFvYw44UHlPcHx5ExfFY/UVtxidARze25VbIUK1RCUf2oZ4UgdA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-sns': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-sqs': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-sns': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-sqs': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/aws-events'
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-s3/1.183.0_psiol63vhfkel2lugznsms3lka:
-    resolution: {integrity: sha512-jO+5zMFBNj0YbPUxy1YcLipH7DJ3HAXQWmVF63s0kkEHVYSvv8PyXbYsbhZlK83qCJroic+mqiXFsPQae7cQrg==}
+  /@aws-cdk/aws-s3/1.184.0_hqlnsupdj7wlhbmiji67ba5kuq:
+    resolution: {integrity: sha512-XA24osxnvVoGALmAKycUgsMe/BYqtlZC00O0O4rbWG5A9PYUMhMYuAP06UXdLNOduHUGQBiQ9l8FDaFr8WdvdQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-events': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-events': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-sam/1.183.0_ihjof7lowhi333cksrwxypekxm:
-    resolution: {integrity: sha512-h2sMyn6CMltuj5FyVYLG1IAPmaYa7Po8i47xpffqa+ijPVfdbdhm6/lR1q+ltmBTWPv8G2H6/2jpBfxL8AzGjw==}
+  /@aws-cdk/aws-sam/1.184.0_6pq2hh53fqzejgwdatnk7vsk4e:
+    resolution: {integrity: sha512-hqrzJ1LjVuGUTknbQb3RRzNO4tgi+IVYDtm/kiEMQriCq6rkmfIETRu1/iGLd5P3usNl39YThoXok6CYB+fykg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-secretsmanager/1.183.0_3rxydtitlm6iotca5gpilmavfy:
-    resolution: {integrity: sha512-0qn7TA+WPWZ4kSsQqsgqNI9tA3S+TqB/mgMmbPNxn+QVZncnlhyL9iROCkQy5QoPvvZYhMyG5h2oDRnEiViljw==}
+  /@aws-cdk/aws-secretsmanager/1.184.0_g72srgrgv53yhrqyfjq7qatcqm:
+    resolution: {integrity: sha512-L2D1Syyn3wp5mnDWDJv7N3BNIm8AExUJBfMBfkSsF0AgMXDRpzPuNVKV+NxFWHTOPPxb0NuZobG4admWk2T5Zg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/core': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/core': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-sam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      '@aws-cdk/cx-api': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-sam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      '@aws-cdk/cx-api': 1.184.0
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/aws-s3'
     dev: false
 
-  /@aws-cdk/aws-servicediscovery/1.183.0_pwj4fltxrhdb7i5s3iylcs72ry:
-    resolution: {integrity: sha512-BfXLqwESvKNbilD+tUuiJBLf3nQZ92kZiCkBI3382vqYt0M2l3MQcdRBx7sK6ZuFZhJyn8trMm2L2UUlRD7fNw==}
+  /@aws-cdk/aws-servicediscovery/1.184.0_md2fvnqv74y5c2poc5wbr6pcea:
+    resolution: {integrity: sha512-vpYuLc2sBPPMMhc4zYhmkJDd+GgepWQVicC5RfTUbdOZv6U2HbFHAB9EdSW8Pjsrgb8jh2UHX6vT45+gLwFS1A==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-ec2': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-ec2': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-elasticloadbalancingv2': 1.183.0_skgq7crkylogcuqujvfguacswq
-      '@aws-cdk/aws-route53': 1.183.0_druf3jgjycya2cfz77owjaqgra
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_isufbo7n5frgco5l3nwvujsagi
+      '@aws-cdk/aws-route53': 1.184.0_f2cynxikbtlaqfd3np55i7mldq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-iam'
@@ -2412,122 +2412,122 @@ packages:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-signer/1.183.0_ihjof7lowhi333cksrwxypekxm:
-    resolution: {integrity: sha512-R2yZuE81dt3C8y/8lbRsj6dLwV8G9pT0QcS2vZEPIpn788URGAICP1AqhXVN/+biIZulXmCf2FIHUhG69hyKAA==}
+  /@aws-cdk/aws-signer/1.184.0_6pq2hh53fqzejgwdatnk7vsk4e:
+    resolution: {integrity: sha512-AVuCFiXHSmEvErRXrgYkP6dTXyDZxeSNne+iIK30DTdqmd0++DhD8z74MllSO7hBLqsKm9VFHnEfkE594ZtBAg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/aws-sns-subscriptions/1.183.0_hplfleswyk4awlhgkn3pyobmaa:
-    resolution: {integrity: sha512-pFYURIgrAaEftVClv19aocc1wHU/TcvNIYx/b/psftVDgj7VatWpgBXbPoJhcBiEoBBWpaGApVNGzux7tovQJg==}
+  /@aws-cdk/aws-sns-subscriptions/1.184.0_cwew7tg62qugzixu6eqxab5bm4:
+    resolution: {integrity: sha512-4liYmJmLB2L1ZdS4OO9JEihX9D7dbOBpYuDuoT8Mr3O7QbhSr2uv2X0ntRarERH0GXeZ5AxK1jgLiM+puduQMA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-sns': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/aws-sqs': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-sns': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/aws-sqs': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/aws-events'
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-sns/1.183.0_psiol63vhfkel2lugznsms3lka:
-    resolution: {integrity: sha512-BK9fuyGAC3AO8iaHK9fSEExt2TvQSl/SGjNC01QmLgEiZGx4MI/GJLM5Fmn+7jnwX6tB+RMLqRnylyN1DEvI2A==}
+  /@aws-cdk/aws-sns/1.184.0_hqlnsupdj7wlhbmiji67ba5kuq:
+    resolution: {integrity: sha512-GFAotWD8k1DU0n88BVArlK62qGZ1wXplAf63HBvYgdYVA0hKsDeoA3PgsqxwoeHaH+f/dS1/H5wRPoxFQW6TMA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-events': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-events': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-codestarnotifications': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/aws-sqs': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-codestarnotifications': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/aws-sqs': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-sqs/1.183.0_yj7eqy7354e37mfdflunab3hpm:
-    resolution: {integrity: sha512-OutGHhAMAzhnMoRQyOY7pRblYR+YONlQl1IAJZ5CaHLyb7pptcYanbf18IOjgDP4x0PQSMsUW0Y4dTZL6eelSw==}
+  /@aws-cdk/aws-sqs/1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny:
+    resolution: {integrity: sha512-JV8DbpwJUtTcR0+dHKv+7vl5ozNVNzDsJ1aw5b0Grefa8iRphLv8mA/b0zgxglGHZjgT4GuHQcg1m0nn7pQvdA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-ssm/1.183.0_yj7eqy7354e37mfdflunab3hpm:
-    resolution: {integrity: sha512-lV/pjPuhaH0aoHBBByYg4DPKLa0QRA+umctDt51QZeUOo8qANDTC/38+Mzpd/ochBYDXyhOeJgV0/mzf/1XGDw==}
+  /@aws-cdk/aws-ssm/1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny:
+    resolution: {integrity: sha512-2CdGtArdwteKcoqafWbEDFLt3FqEykjvPNnCPWhNGnUzT3d9Kr9GBjwCbxTZNpYN4jc/jSuW1wi+9+6WDfBlvA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-kms': 1.183.0_yj7eqy7354e37mfdflunab3hpm
-      '@aws-cdk/cloud-assembly-schema': 1.183.0
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-kms': 1.184.0_zbjmuw32kwmwp5lz3j6f3ezgny
+      '@aws-cdk/cloud-assembly-schema': 1.184.0
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-stepfunctions/1.183.0_za6jkin4qwjyd7ryccz524pgka:
-    resolution: {integrity: sha512-3wTlo8duF9vDkrbT47bx24BB79/f9xuJACW2ThzKt/SHdj+s2bqdrHjjgS5N1LSsJvKA3x1kNpYEyQWrO9fb7A==}
+  /@aws-cdk/aws-stepfunctions/1.184.0_xiumwwsiuspehkzvpmkowrb2ja:
+    resolution: {integrity: sha512-eRB1oGNhzqZtuzk/uan5NFYVbhMu7/o1LL59dpYsXnu1J/E5nDTUusOSHpFzbGJ5H3sRAZOVgTv2l/iS+PV72A==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-events': 1.183.0
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/aws-s3': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-events': 1.184.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/aws-s3': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudwatch': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-events': 1.183.0_ilznwvxp27yag2somatnsfw4tm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-s3': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-cloudwatch': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-events': 1.184.0_oysovces7knjd7oo7lc3hhmwfu
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-s3': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/cfnspec/1.183.0:
-    resolution: {integrity: sha512-Mb26KO/RdxlvED2MIiuOLhGDUhO7C/jZLTL1KVlOGuwhVEnqKVqFmLuzig030XAZWQsS0px/WkYcgaKYqPJngA==}
+  /@aws-cdk/cfnspec/1.184.0:
+    resolution: {integrity: sha512-hC6GqZNYObDUxs0gJ25PnzvsFv0uAr2UDfI8V6+T9uAehM1oBgC8LKu1zZr8YzLDvtQ4hkGhyyEf+D+0KTrFEA==}
     dependencies:
       fs-extra: 9.1.0
       md5: 2.3.0
     dev: false
 
-  /@aws-cdk/cloud-assembly-schema/1.183.0:
-    resolution: {integrity: sha512-Mv5aoc79RVlUcoNCvrfu5PfKOWkFIH/5D8lnNvjO01HPPq3L3kuj4HW1DXUNjUD/4cYUISCFAIiwTPRukY0yzg==}
+  /@aws-cdk/cloud-assembly-schema/1.184.0:
+    resolution: {integrity: sha512-k5XxYC1OJOEFsyxB6RrpToi/JPHW0PzOWawhsPmJcnigGlKEAlTHRM3drcaZBNTVLrZ+xD0VLieXBQEg8J3NCA==}
     engines: {node: '>= 14.15.0'}
     dev: false
     bundledDependencies:
@@ -2542,11 +2542,11 @@ packages:
       - jsonschema
       - semver
 
-  /@aws-cdk/cloudformation-diff/1.183.0:
-    resolution: {integrity: sha512-VajLRyFmQmJt0VhGO34xBq1XCxkR7vRHNbpf5vFG2gt+KBwlyo+n4n1vPQVIR6PwY/PkOtfalbRV5CjSOBDccg==}
+  /@aws-cdk/cloudformation-diff/1.184.0:
+    resolution: {integrity: sha512-0IXx7VzkOOVkWB+vw2mVoY+PLps3HzXFGh/tJq2wbH9y8j344RSk/hIlJSy0NukWlF0a3WEtIHWPjqnk1yQmsw==}
     engines: {node: '>= 14.15.0'}
     dependencies:
-      '@aws-cdk/cfnspec': 1.183.0
+      '@aws-cdk/cfnspec': 1.184.0
       '@types/node': 10.17.60
       chalk: 4.1.2
       diff: 5.1.0
@@ -2555,17 +2555,17 @@ packages:
       table: 6.8.1
     dev: false
 
-  /@aws-cdk/core/1.183.0_k3ys5r2lobs3366drs75p45kbe:
-    resolution: {integrity: sha512-SRhRYBpC+NgN0bTSTY/YwioUAn0fXcRdHj0vqNIEyNOWnMQRGPdvOUwq+O9mJmqcOdcTjf+GTp+jOEMcxpzqng==}
+  /@aws-cdk/core/1.184.0_qp75ynaick7qqxnyrosmth35oi:
+    resolution: {integrity: sha512-lwVyC7RAnYGLTqqrtXVw4XS8vSCw/mBMwJnhYEjZ4XIoKtkl+NFHsijt6g/sx4h46T4tUP123aSYx/8MYWH5NA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/cx-api': 1.183.0
+      '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/cloud-assembly-schema': 1.183.0
-      '@aws-cdk/cx-api': 1.183.0
-      '@aws-cdk/region-info': 1.183.0
-      constructs: 3.4.191
+      '@aws-cdk/cloud-assembly-schema': 1.184.0
+      '@aws-cdk/cx-api': 1.184.0
+      '@aws-cdk/region-info': 1.184.0
+      constructs: 3.4.192
     dev: false
     bundledDependencies:
       - fs-extra
@@ -2573,24 +2573,24 @@ packages:
       - '@balena/dockerignore'
       - ignore
 
-  /@aws-cdk/custom-resources/1.183.0_jdemlcjbnx5lxnlr6bksodytsm:
-    resolution: {integrity: sha512-NpjfPwpW2nCemZfz694Twl0Iim7JfBGXt61begjyro46lnCsSWNwcdehA2KDFaExsHnHHO2oND60wIoYyk0pfA==}
+  /@aws-cdk/custom-resources/1.184.0_j7nktgzqknhwa3hzpbs4fh2zei:
+    resolution: {integrity: sha512-7XkPdIwNzeIXQd8U8864jjZ3BTpZzWRld5u5CWfg6MLoEBWRsRbuw2da4wDM96Fa1RotBs7x8raSRPxP2DSGwg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-iam': 1.183.0
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/aws-logs': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-iam': 1.184.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/aws-logs': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudformation': 1.183.0_sum2shqcgknuyuddu3t5k2fufu
-      '@aws-cdk/aws-ec2': 1.183.0_ah7muc3vvde5kkfsgcua6dikzm
-      '@aws-cdk/aws-iam': 1.183.0_ihjof7lowhi333cksrwxypekxm
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/aws-logs': 1.183.0_5rtp7zkv6pi3yml7m5s2kpliwe
-      '@aws-cdk/aws-sns': 1.183.0_psiol63vhfkel2lugznsms3lka
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-cloudformation': 1.184.0_kbfyk5hfojsdvoinde74uwt4ay
+      '@aws-cdk/aws-ec2': 1.184.0_6aw5klqzusmpfvouqwq5rnef3e
+      '@aws-cdk/aws-iam': 1.184.0_6pq2hh53fqzejgwdatnk7vsk4e
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/aws-logs': 1.184.0_hmnprgzc652nrvmsge3juwilgy
+      '@aws-cdk/aws-sns': 1.184.0_hqlnsupdj7wlhbmiji67ba5kuq
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     transitivePeerDependencies:
       - '@aws-cdk/assets'
       - '@aws-cdk/aws-events'
@@ -2598,11 +2598,11 @@ packages:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/cx-api/1.183.0:
-    resolution: {integrity: sha512-r77PMtK7czNAdHYi6AbUQ7kpCBcaJP/3sS1nykofjPIK0Zayqy9u+vzKnMu4PPm4smB29n8VWc8OrQdnxQbVYg==}
+  /@aws-cdk/cx-api/1.184.0:
+    resolution: {integrity: sha512-ZALUsMa7BS4I6RuiZHc6ZaFDPoGdfjnGT5+CKY+/eG7tSZ3OseflUnI1hwuc3PcHMYxmJO2vpC8HkoIo8m9iIw==}
     engines: {node: '>= 14.15.0'}
     dependencies:
-      '@aws-cdk/cloud-assembly-schema': 1.183.0
+      '@aws-cdk/cloud-assembly-schema': 1.184.0
     dev: false
     bundledDependencies:
       - semver
@@ -2616,21 +2616,21 @@ packages:
     bundledDependencies:
       - semver
 
-  /@aws-cdk/lambda-layer-awscli/1.183.0_b4lwl6ufm3tx3zr4r3m4kxtyqa:
-    resolution: {integrity: sha512-1RwRquxwV9881lzyAnILPYft+E9tx41kS0nwN4RqNu/weTHOmXUVqDtD1wX1ETYBeUGiqlFGgfCVSEOdXAedSw==}
+  /@aws-cdk/lambda-layer-awscli/1.184.0_qhtul47d56vl2xyziuvyqjqvuu:
+    resolution: {integrity: sha512-KXdS/tOGYo0RawTOrCKFcDL6ygPmI+oMsiSULJpbudmfq07n82XooRUdSzCHGWhCbzZMIPAVbg1SLixiYvmk5g==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      '@aws-cdk/aws-lambda': 1.183.0
-      '@aws-cdk/core': 1.183.0
+      '@aws-cdk/aws-lambda': 1.184.0
+      '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-lambda': 1.183.0_74llbif432t2lxntlwjg4yiewq
-      '@aws-cdk/core': 1.183.0_k3ys5r2lobs3366drs75p45kbe
-      constructs: 3.4.191
+      '@aws-cdk/aws-lambda': 1.184.0_n65tzhlnp37b3djbpagmmuuaka
+      '@aws-cdk/core': 1.184.0_qp75ynaick7qqxnyrosmth35oi
+      constructs: 3.4.192
     dev: false
 
-  /@aws-cdk/region-info/1.183.0:
-    resolution: {integrity: sha512-yW6xxDrRNzFLhxzNKqrNNjColYbXxJpKxtjWdHpa9wPkaUVx4t0tc1L6J6hCs6+alJGIyqL2+4gosXlzov0ltA==}
+  /@aws-cdk/region-info/1.184.0:
+    resolution: {integrity: sha512-5VwqAcz7yUETNw7A2PyQ/mBTCYmNUWilz+72c8lTEsuQ9fQJaUXNeuihlE7fN/HIwcZUTjvkSfZ3STtZGI9c5g==}
     engines: {node: '>= 14.15.0'}
     dev: false
 
@@ -2835,20 +2835,20 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core/7.20.5:
-    resolution: {integrity: sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==}
+  /@babel/core/7.20.7:
+    resolution: {integrity: sha512-t1ZjCluspe5DW24bn2Rr1CDb2v9rn/hROtg9a2tmd0+QYf4bsloYfLQzjG4qHPNMhWtKdGC33R5AxGR2Af2cBw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.5
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
-      '@babel/helper-module-transforms': 7.20.2
-      '@babel/helpers': 7.20.6
-      '@babel/parser': 7.20.5
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/generator': 7.20.7
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.7
+      '@babel/helper-module-transforms': 7.20.7
+      '@babel/helpers': 7.20.7
+      '@babel/parser': 7.20.7
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.7
+      '@babel/types': 7.20.7
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -2858,24 +2858,25 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/generator/7.20.5:
-    resolution: {integrity: sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==}
+  /@babel/generator/7.20.7:
+    resolution: {integrity: sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.20.7
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
-  /@babel/helper-compilation-targets/7.20.0_@babel+core@7.20.5:
-    resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
+  /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.7:
+    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/compat-data': 7.20.5
-      '@babel/core': 7.20.5
+      '@babel/core': 7.20.7
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
+      lru-cache: 5.1.1
       semver: 6.3.0
     dev: true
 
@@ -2888,26 +2889,26 @@ packages:
     resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.18.10
-      '@babel/types': 7.20.5
+      '@babel/template': 7.20.7
+      '@babel/types': 7.20.7
     dev: true
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.20.7
     dev: true
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.20.7
     dev: true
 
-  /@babel/helper-module-transforms/7.20.2:
-    resolution: {integrity: sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==}
+  /@babel/helper-module-transforms/7.20.7:
+    resolution: {integrity: sha512-FNdu7r67fqMUSVuQpFQGE6BPdhJIhitoxhGzDbAXNcA07uoVG37fOiMk3OSV8rEICuyG6t8LGkd9EE64qIEoIA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.9
@@ -2915,9 +2916,9 @@ packages:
       '@babel/helper-simple-access': 7.20.2
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.7
+      '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2926,14 +2927,14 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.20.7
     dev: true
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.20.7
     dev: true
 
   /@babel/helper-string-parser/7.19.4:
@@ -2949,13 +2950,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helpers/7.20.6:
-    resolution: {integrity: sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==}
+  /@babel/helpers/7.20.7:
+    resolution: {integrity: sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.7
+      '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2968,39 +2969,39 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser/7.20.5:
-    resolution: {integrity: sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==}
+  /@babel/parser/7.20.7:
+    resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  /@babel/template/7.18.10:
-    resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
+  /@babel/template/7.20.7:
+    resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/parser': 7.20.7
+      '@babel/types': 7.20.7
 
-  /@babel/traverse/7.20.5:
-    resolution: {integrity: sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==}
+  /@babel/traverse/7.20.7:
+    resolution: {integrity: sha512-xueOL5+ZKX2dJbg8z8o4f4uTRTqGDRjilva9D1hiRlayJbTY8jBRL+Ph67IeRTIE439/VifHk+Z4g0SwRtQE0A==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.5
+      '@babel/generator': 7.20.7
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/parser': 7.20.7
+      '@babel/types': 7.20.7
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/types/7.20.5:
-    resolution: {integrity: sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==}
+  /@babel/types/7.20.7:
+    resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
@@ -3010,9 +3011,9 @@ packages:
   /@cdktf/hcl2cdk/0.12.3:
     resolution: {integrity: sha512-8LEFkMZPIN2MsGFtZsrGEAbNI6IeFpuYQr0ygr9k35mltJkVrNtPT7Rar0BL5BojFxVR59/2J0xPErUuci4w7Q==}
     dependencies:
-      '@babel/generator': 7.20.5
-      '@babel/template': 7.18.10
-      '@babel/types': 7.20.5
+      '@babel/generator': 7.20.7
+      '@babel/template': 7.20.7
+      '@babel/types': 7.20.7
       '@cdktf/hcl2json': 0.12.3
       '@cdktf/provider-generator': 0.12.3
       camelcase: 6.3.0
@@ -3036,15 +3037,15 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@cdktf/provider-azurerm/0.2.234_th5d3nxioqaghem2u57s2aajhy:
+  /@cdktf/provider-azurerm/0.2.234_u47zdeb26yvpl6k6cjkjj3wjdq:
     resolution: {integrity: sha512-eICKPXlYgup2Y5IpQhVekmzxmfKPnmTrg/9ksqEMyBvfkkIEE7UBrQ6TTBLTeXBhFRobgdBozEac3Vn9FPGS1w==}
     engines: {node: '>= 12.19.0'}
     peerDependencies:
       cdktf: ^0.7
       constructs: ^10.0.0
     dependencies:
-      cdktf: 0.7.0_constructs@10.1.196
-      constructs: 10.1.196
+      cdktf: 0.7.0_constructs@10.1.197
+      constructs: 10.1.197
     dev: false
 
   /@cdktf/provider-generator/0.12.3:
@@ -3055,7 +3056,7 @@ packages:
       deepmerge: 4.2.2
       fs-extra: 8.1.0
       is-valid-domain: 0.1.6
-      jsii-srcmak: 0.1.769
+      jsii-srcmak: 0.1.770
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -4572,16 +4573,16 @@ packages:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
 
-  /aws-cdk/1.183.0:
-    resolution: {integrity: sha512-eFxH4QkIrllFG+s2zC40ocaIEgoDTzMxzRYhXNgke2veRXh0/PtD29u01UOEA6uHLedFnVn8t1mQRu3oZGbc2w==}
+  /aws-cdk/1.184.0:
+    resolution: {integrity: sha512-xQSnWrlxw13Rj2vicYp8hrfHEK6vT7vwZibBh7BTL9Jq7mNfeR09y/fo4pSzDjJIlRN1xiv+hqPsqme47Hx4PQ==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
     dev: false
 
-  /aws-sdk/2.1279.0:
-    resolution: {integrity: sha512-52NbHEZTLlrld6XDLvVaOwEI0p4nYTYVuninX8s4kdkBXeTezaBahsufWT7LmeYh10gp70dnwaUxvja1TjmeRA==}
+  /aws-sdk/2.1280.0:
+    resolution: {integrity: sha512-6Dv/RuMQdye7wps4HwcMZwRw9han51PQVcMXq4e5KUNqzQ9wHmaFMFVI/kY4NIkR7D3IczEg4WoUCoKhj464hA==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       buffer: 4.9.2
@@ -4845,7 +4846,7 @@ packages:
       '@aws-cdk/cloud-assembly-schema': 2.39.1
       '@aws-cdk/cx-api': 2.39.1
       archiver: 5.3.1
-      aws-sdk: 2.1279.0
+      aws-sdk: 2.1280.0
       glob: 7.2.3
       mime: 2.6.0
       yargs: 16.2.0
@@ -4859,9 +4860,9 @@ packages:
       '@cdktf/hcl2json': 0.12.3
       '@sentry/node': 6.19.7
       '@types/yargs': 17.0.17
-      cdktf: 0.12.3_constructs@10.1.196
+      cdktf: 0.12.3_constructs@10.1.197
       codemaker: 1.72.0
-      constructs: 10.1.196
+      constructs: 10.1.197
       cross-spawn: 7.0.3
       https-proxy-agent: 5.0.1
       ink-select-input: 4.2.1_ink@3.2.0+react@17.0.2
@@ -4880,23 +4881,23 @@ packages:
       - react
       - supports-color
 
-  /cdktf/0.12.3_constructs@10.1.196:
+  /cdktf/0.12.3_constructs@10.1.197:
     resolution: {integrity: sha512-3roj6dWTaqNbLMh5S5DXfmjdtBRrKw+K0FIsJvF/av89NfIhL8lhBIN3fd+iOtr2axCe4AZd7SCpQuDBfmF92g==}
     peerDependencies:
       constructs: ^10.0.25
     dependencies:
-      constructs: 10.1.196
+      constructs: 10.1.197
     bundledDependencies:
       - archiver
       - json-stable-stringify
       - semver
 
-  /cdktf/0.7.0_constructs@10.1.196:
+  /cdktf/0.7.0_constructs@10.1.197:
     resolution: {integrity: sha512-AhT3I6O3XAeBh2t2MiiAuPelPXmtaD4P3wIbcDtPxtlAX4gO5jTGVNHqHp11SdwvbncbDuhetdI7Egyor/EsEQ==}
     peerDependencies:
       constructs: ^10.0.0
     dependencies:
-      constructs: 10.1.196
+      constructs: 10.1.197
     bundledDependencies:
       - archiver
 
@@ -5264,12 +5265,12 @@ packages:
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  /constructs/10.1.196:
-    resolution: {integrity: sha512-vgVM3vTWu8ZdHEa/icSzmZZOU5berKI+g8eosPKu+KOoAtS6o/eXqYObXejh79vy+rHyKK7yulUtSGCXU4ynUQ==}
+  /constructs/10.1.197:
+    resolution: {integrity: sha512-YAuSMYDXPQvNqmCrnVBGHXGL1+8WICDDJLH91BUIWfL6PpMEm+LXBXchgGETyREf96nIIGuXC/0lkUURsLSrHA==}
     engines: {node: '>= 14.17.0'}
 
-  /constructs/3.4.191:
-    resolution: {integrity: sha512-+VOHugQAhDFn4ApW32waXHxG6HWkHxuh1dDRu2oNharjvvjbeX7BgMSKF9GR3XnBIc+cHAsHhQMIaQBHadQ+fw==}
+  /constructs/3.4.192:
+    resolution: {integrity: sha512-9rketqo4RmZYzrZ4ap4E+4UuXZ9RexLZmVa6ZYgLYU5uh9wdNQSLfWQWpUD84LnprE3V9zXbJL7DI1nGFsPNJA==}
     engines: {node: '>= 14.17.0'}
     dev: false
 
@@ -7506,7 +7507,7 @@ packages:
     resolution: {integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.20.5
+      '@babel/core': 7.20.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -7674,8 +7675,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /jsii-srcmak/0.1.769:
-    resolution: {integrity: sha512-OaqVQklJxWfiXi+mzCN2bhopOJWL4y6wpz1I9ZTGByJfAEenw+AlejWgxkivEVwbXG7sjfYxP9n8Iehvbv6wVw==}
+  /jsii-srcmak/0.1.770:
+    resolution: {integrity: sha512-hp3W0wcbtcfU8756Ptnc7QfJvmZMtxHkMPl5OoPrJmgNeZJtMBb2C68FY3gCjOoMe+dOYhU3MORAsOf8FtMw5w==}
     hasBin: true
     dependencies:
       fs-extra: 9.1.0
@@ -8092,6 +8093,12 @@ packages:
     dependencies:
       pseudomap: 1.0.2
       yallist: 2.1.2
+
+  /lru-cache/5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    dependencies:
+      yallist: 3.1.1
+    dev: true
 
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -9641,7 +9648,7 @@ packages:
       ajv: 8.11.2
       ajv-formats: 2.1.1
       archiver: 5.3.0
-      aws-sdk: 2.1279.0
+      aws-sdk: 2.1280.0
       bluebird: 3.7.2
       cachedir: 2.3.0
       chalk: 4.1.2
@@ -10843,6 +10850,10 @@ packages:
 
   /yallist/2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
+
+  /yallist/3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    dev: true
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}

--- a/packages/cli/src/common/errors.ts
+++ b/packages/cli/src/common/errors.ts
@@ -13,7 +13,12 @@ export function wrapExecError(e: Error, prefix: string): Error {
 }
 
 export const guardError = (prefix: string) =>
-  orDieWith((err: unknown) => {
-    const reason = err instanceof Error ? err.message : JSON.stringify(err)
-    return new Error(Brand.dangerize(prefix) + '\n' + reason)
+  orDieWith((err: Error) => {
+    return new Error(Brand.dangerize(`[${err.name}] ${prefix}:`) + '\n' + err.message)
   })
+
+/**
+ * Converts an unknown value to an Error. If it's not an error already, it will be stringified.
+ */
+export const unknownToError = (reason: unknown) =>
+  reason instanceof Error ? reason : new Error(JSON.stringify(reason))

--- a/packages/cli/src/common/errors.ts
+++ b/packages/cli/src/common/errors.ts
@@ -13,4 +13,7 @@ export function wrapExecError(e: Error, prefix: string): Error {
 }
 
 export const guardError = (prefix: string) =>
-  orDieWith((reason: unknown) => new Error(Brand.dangerize(prefix) + '\n' + JSON.stringify(reason)))
+  orDieWith((err: unknown) => {
+    const reason = err instanceof Error ? err.message : JSON.stringify(err)
+    return new Error(Brand.dangerize(prefix) + '\n' + reason)
+  })

--- a/packages/cli/src/services/file-system/index.ts
+++ b/packages/cli/src/services/file-system/index.ts
@@ -1,15 +1,14 @@
 import { Effect, tag } from '@boostercloud/framework-types/dist/effect'
 
-export class FileSystemError {
-  readonly _tag = 'FileSystemError'
-  readonly error: Error
-  public constructor(readonly reason: unknown) {
-    this.error = reason instanceof Error ? reason : new Error(JSON.stringify(reason))
-  }
+export class ReadDirectoryContentsError {
+  readonly _tag = 'ReadDirectoryContentsError'
+  constructor(readonly error: Error) {}
 }
 
 export interface FileSystemService {
-  readonly readDirectoryContents: (directoryPath: string) => Effect<unknown, FileSystemError, ReadonlyArray<string>>
+  readonly readDirectoryContents: (
+    directoryPath: string
+  ) => Effect<unknown, ReadDirectoryContentsError, ReadonlyArray<string>>
 }
 
 export const FileSystemService = tag<FileSystemService>()

--- a/packages/cli/src/services/file-system/index.ts
+++ b/packages/cli/src/services/file-system/index.ts
@@ -1,14 +1,12 @@
 import { Effect, tag } from '@boostercloud/framework-types/dist/effect'
 
-export class ReadDirectoryContentsError {
-  readonly _tag = 'ReadDirectoryContentsError'
+export class FileSystemError {
+  readonly _tag = 'FileSystemError'
   constructor(readonly error: Error) {}
 }
 
 export interface FileSystemService {
-  readonly readDirectoryContents: (
-    directoryPath: string
-  ) => Effect<unknown, ReadDirectoryContentsError, ReadonlyArray<string>>
+  readonly readDirectoryContents: (directoryPath: string) => Effect<unknown, FileSystemError, ReadonlyArray<string>>
 }
 
 export const FileSystemService = tag<FileSystemService>()

--- a/packages/cli/src/services/file-system/live.impl.ts
+++ b/packages/cli/src/services/file-system/live.impl.ts
@@ -1,11 +1,16 @@
 import { tryCatchPromise, Layer } from '@boostercloud/framework-types/dist/effect'
-import { FileSystemError, FileSystemService } from '.'
+import { FileSystemService, ReadDirectoryContentsError } from '.'
 import * as fs from 'fs'
 
 const readDirectoryContents = (directoryPath: string) =>
   tryCatchPromise(
     () => fs.promises.readdir(directoryPath),
-    (reason) => new FileSystemError(reason)
+    (reason) =>
+      new ReadDirectoryContentsError(
+        new Error(`There were some issues reading the directory ${directoryPath}:
+
+    ${reason}`)
+      )
   )
 
 export const LiveFileSystem = Layer.fromValue(FileSystemService)({ readDirectoryContents })

--- a/packages/cli/src/services/file-system/live.impl.ts
+++ b/packages/cli/src/services/file-system/live.impl.ts
@@ -1,12 +1,12 @@
 import { tryCatchPromise, Layer } from '@boostercloud/framework-types/dist/effect'
-import { FileSystemService, ReadDirectoryContentsError } from '.'
+import { FileSystemService, FileSystemError } from '.'
 import * as fs from 'fs'
 
 const readDirectoryContents = (directoryPath: string) =>
   tryCatchPromise(
     () => fs.promises.readdir(directoryPath),
     (reason) =>
-      new ReadDirectoryContentsError(
+      new FileSystemError(
         new Error(`There were some issues reading the directory ${directoryPath}:
 
     ${reason}`)

--- a/packages/cli/src/services/package-manager/index.ts
+++ b/packages/cli/src/services/package-manager/index.ts
@@ -1,18 +1,17 @@
 import { Effect, tag } from '@boostercloud/framework-types/dist/effect'
 
+type Reason = 'ProjectRootNotSet' | 'DependencyInstallationFailed' | 'ScriptExecutionError'
+
 export class PackageManagerError {
   readonly _tag = 'PackageManagerError'
-  readonly error: Error
-  public constructor(readonly reason: unknown) {
-    this.error = reason instanceof Error ? reason : new Error(JSON.stringify(reason))
-  }
+  public constructor(readonly reason: Reason, readonly error: unknown) {}
 }
 
 export interface PackageManagerService {
-  readonly setProjectRoot: (projectRoot: string) => Effect<unknown, unknown, void>
-  readonly installProductionDependencies: () => Effect<unknown, unknown, void>
-  readonly installAllDependencies: () => Effect<unknown, unknown, void>
-  readonly runScript: (scriptName: string, args: ReadonlyArray<string>) => Effect<unknown, unknown, string>
+  readonly setProjectRoot: (projectRoot: string) => Effect<unknown, PackageManagerError, void>
+  readonly installProductionDependencies: () => Effect<unknown, PackageManagerError, void>
+  readonly installAllDependencies: () => Effect<unknown, PackageManagerError, void>
+  readonly runScript: (scriptName: string, args: ReadonlyArray<string>) => Effect<unknown, PackageManagerError, string>
 }
 
 export const PackageManagerService = tag<PackageManagerService>()

--- a/packages/cli/src/services/package-manager/index.ts
+++ b/packages/cli/src/services/package-manager/index.ts
@@ -1,17 +1,22 @@
 import { Effect, tag } from '@boostercloud/framework-types/dist/effect'
 
-type Reason = 'ProjectRootNotSet' | 'DependencyInstallationFailed' | 'ScriptExecutionError'
+export type PackageManagerError = InstallDependenciesError | RunScriptError
 
-export class PackageManagerError {
-  readonly _tag = 'PackageManagerError'
-  public constructor(readonly reason: Reason, readonly error: unknown) {}
+export class InstallDependenciesError {
+  readonly _tag = 'InstallDependenciesError'
+  constructor(readonly error: Error) {}
+}
+
+export class RunScriptError {
+  readonly _tag = 'RunScriptError'
+  constructor(readonly error: Error) {}
 }
 
 export interface PackageManagerService {
-  readonly setProjectRoot: (projectRoot: string) => Effect<unknown, PackageManagerError, void>
-  readonly installProductionDependencies: () => Effect<unknown, PackageManagerError, void>
-  readonly installAllDependencies: () => Effect<unknown, PackageManagerError, void>
-  readonly runScript: (scriptName: string, args: ReadonlyArray<string>) => Effect<unknown, PackageManagerError, string>
+  readonly setProjectRoot: (projectRoot: string) => Effect<unknown, never, void>
+  readonly installProductionDependencies: () => Effect<unknown, InstallDependenciesError, void>
+  readonly installAllDependencies: () => Effect<unknown, InstallDependenciesError, void>
+  readonly runScript: (scriptName: string, args: ReadonlyArray<string>) => Effect<unknown, RunScriptError, string>
 }
 
 export const PackageManagerService = tag<PackageManagerService>()

--- a/packages/cli/src/services/process/index.ts
+++ b/packages/cli/src/services/process/index.ts
@@ -1,18 +1,13 @@
 import { Effect, tag } from '@boostercloud/framework-types/dist/effect'
 
-export class ExecError {
-  readonly _tag = 'ExecError'
-  constructor(readonly error: Error) {}
-}
-
-export class CwdError {
-  readonly _tag = 'CwdError'
+export class ProcessError {
+  readonly _tag = 'ProcessError'
   constructor(readonly error: Error) {}
 }
 
 export interface ProcessService {
-  readonly exec: (command: string, cwd?: string) => Effect<unknown, ExecError, string>
-  readonly cwd: () => Effect<unknown, CwdError, string>
+  readonly exec: (command: string, cwd?: string) => Effect<unknown, ProcessError, string>
+  readonly cwd: () => Effect<unknown, ProcessError, string>
 }
 
 export const ProcessService = tag<ProcessService>()

--- a/packages/cli/src/services/process/index.ts
+++ b/packages/cli/src/services/process/index.ts
@@ -1,13 +1,18 @@
 import { Effect, tag } from '@boostercloud/framework-types/dist/effect'
 
-export class ProcessError {
-  readonly _tag = 'ProcessError'
-  public constructor(readonly reason: unknown) {}
+export class ExecError {
+  readonly _tag = 'ExecError'
+  constructor(readonly error: Error) {}
+}
+
+export class CwdError {
+  readonly _tag = 'CwdError'
+  constructor(readonly error: Error) {}
 }
 
 export interface ProcessService {
-  readonly exec: (command: string, cwd?: string) => Effect<unknown, ProcessError, string>
-  readonly cwd: () => Effect<unknown, ProcessError, string>
+  readonly exec: (command: string, cwd?: string) => Effect<unknown, ExecError, string>
+  readonly cwd: () => Effect<unknown, CwdError, string>
 }
 
 export const ProcessService = tag<ProcessService>()

--- a/packages/cli/src/services/process/live.impl.ts
+++ b/packages/cli/src/services/process/live.impl.ts
@@ -1,6 +1,6 @@
 import * as childProcess from 'child-process-promise'
 import * as process from 'process'
-import { ProcessService, ProcessError } from '.'
+import { CwdError, ExecError, ProcessService } from '.'
 import { Layer, tryCatch, tryCatchPromise } from '@boostercloud/framework-types/dist/effect'
 
 const exec = (command: string, cwd?: string) =>
@@ -13,13 +13,23 @@ ${stdout}
 `
       return result
     },
-    (reason) => new ProcessError(reason)
+    (reason) =>
+      new ExecError(
+        new Error(`There were some issues running the command ${command}:
+
+    ${reason}`)
+      )
   )
 
 const cwd = () =>
   tryCatch(
     () => process.cwd(),
-    (reason) => new ProcessError(reason)
+    (reason) =>
+      new CwdError(
+        new Error(`There were some issues getting the current working directory:
+
+    ${reason}`)
+      )
   )
 
 export const LiveProcess = Layer.fromValue(ProcessService)({ exec, cwd })

--- a/packages/cli/test/services/file-system/live.test.ts
+++ b/packages/cli/test/services/file-system/live.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs'
 import { fake, replace } from 'sinon'
-import { gen, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
+import { gen, mapError, pipe, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
 import { expect } from '../../expect'
 import { FileSystemService } from '../../../src/services/file-system'
 import { LiveFileSystem } from '../../../src/services/file-system/live.impl'
@@ -17,10 +17,16 @@ describe('FileSystem - Live Implementation', () => {
       const { readDirectoryContents } = yield* $(FileSystemService)
       return yield* $(readDirectoryContents(directoryPath))
     })
-    await unsafeRunEffect(effect, {
-      layer: LiveFileSystem,
-      onError: guardError('An error ocurred'),
-    })
+    await unsafeRunEffect(
+      pipe(
+        effect,
+        mapError((e) => e.error)
+      ),
+      {
+        layer: LiveFileSystem,
+        onError: guardError('An error ocurred'),
+      }
+    )
     expect(fs.promises.readdir).to.have.been.calledWith(directoryPath)
   })
 })

--- a/packages/cli/test/services/package-manager/live.test.ts
+++ b/packages/cli/test/services/package-manager/live.test.ts
@@ -1,5 +1,5 @@
 import { fake } from 'sinon'
-import { gen, Layer, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
+import { gen, Layer, mapError, pipe, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
 import { expect } from '../../expect'
 import { makeTestFileSystem } from '../file-system/test.impl'
 import { makeTestProcess } from '../process/test.impl'
@@ -14,10 +14,15 @@ describe('PackageManager - Live Implementation (with inference)', () => {
     TestProcess.reset()
   })
 
-  const runScript = gen(function* ($) {
+  const effect = gen(function* ($) {
     const { runScript } = yield* $(PackageManagerService)
     return yield* $(runScript('script', []))
   })
+
+  const runScript = pipe(
+    effect,
+    mapError((e) => e.error)
+  )
 
   it('infers Rush when a `.rush` folder is present', async () => {
     const TestFileSystem = makeTestFileSystem({ readDirectoryContents: fake.returns(['.rush']) })

--- a/packages/cli/test/services/package-manager/npm.test.ts
+++ b/packages/cli/test/services/package-manager/npm.test.ts
@@ -1,5 +1,5 @@
 import { fake } from 'sinon'
-import { gen, Layer, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
+import { Effect, gen, Layer, mapError, pipe, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
 import { expect } from '../../expect'
 import { makeTestFileSystem } from '../file-system/test.impl'
 import { makeTestProcess } from '../process/test.impl'
@@ -9,6 +9,12 @@ import { PackageManagerService } from '../../../src/services/package-manager'
 
 const TestFileSystem = makeTestFileSystem()
 const TestProcess = makeTestProcess()
+
+const mapEffError = <R, A>(effect: Effect<R, { error: Error }, A>) =>
+  pipe(
+    effect,
+    mapError((e) => e.error)
+  )
 
 describe('PackageManager - npm Implementation', () => {
   beforeEach(() => {})
@@ -23,7 +29,7 @@ describe('PackageManager - npm Implementation', () => {
       return yield* $(runScript(script, args))
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(NpmPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -42,7 +48,7 @@ describe('PackageManager - npm Implementation', () => {
       yield* $(runScript('script', []))
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(NpmPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -57,7 +63,7 @@ describe('PackageManager - npm Implementation', () => {
       return yield* $(installProductionDependencies())
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(NpmPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -73,7 +79,7 @@ describe('PackageManager - npm Implementation', () => {
       return yield* $(installAllDependencies())
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(NpmPackageManager),
       onError: guardError('An error ocurred'),
     })

--- a/packages/cli/test/services/package-manager/pnpm.test.ts
+++ b/packages/cli/test/services/package-manager/pnpm.test.ts
@@ -1,5 +1,5 @@
 import { fake } from 'sinon'
-import { gen, Layer, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
+import { Effect, gen, Layer, mapError, pipe, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
 import { expect } from '../../expect'
 import { makeTestFileSystem } from '../file-system/test.impl'
 import { makeTestProcess } from '../process/test.impl'
@@ -9,6 +9,12 @@ import { PackageManagerService } from '../../../src/services/package-manager'
 
 const TestFileSystem = makeTestFileSystem()
 const TestProcess = makeTestProcess()
+
+const mapEffError = <R, A>(effect: Effect<R, { error: Error }, A>) =>
+  pipe(
+    effect,
+    mapError((e) => e.error)
+  )
 
 describe('PackageManager - Pnpm Implementation', () => {
   it('run arbitrary scripts from package.json', async () => {
@@ -21,7 +27,7 @@ describe('PackageManager - Pnpm Implementation', () => {
       return yield* $(runScript(script, args))
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(PnpmPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -40,7 +46,7 @@ describe('PackageManager - Pnpm Implementation', () => {
       yield* $(runScript('script', []))
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(PnpmPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -55,7 +61,7 @@ describe('PackageManager - Pnpm Implementation', () => {
       return yield* $(installProductionDependencies())
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(PnpmPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -71,7 +77,7 @@ describe('PackageManager - Pnpm Implementation', () => {
       return yield* $(installAllDependencies())
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(PnpmPackageManager),
       onError: guardError('An error ocurred'),
     })

--- a/packages/cli/test/services/package-manager/rush.test.ts
+++ b/packages/cli/test/services/package-manager/rush.test.ts
@@ -1,5 +1,5 @@
 import { fake } from 'sinon'
-import { gen, Layer, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
+import { Effect, gen, Layer, mapError, pipe, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
 import { expect } from '../../expect'
 import { makeTestFileSystem } from '../file-system/test.impl'
 import { makeTestProcess } from '../process/test.impl'
@@ -9,6 +9,12 @@ import { PackageManagerService } from '../../../src/services/package-manager'
 
 const TestFileSystem = makeTestFileSystem()
 const TestProcess = makeTestProcess()
+
+const mapEffError = <R, A>(effect: Effect<R, { error: Error }, A>) =>
+  pipe(
+    effect,
+    mapError((e) => e.error)
+  )
 
 describe('PackageManager - Rush Implementation', () => {
   beforeEach(() => {
@@ -26,7 +32,7 @@ describe('PackageManager - Rush Implementation', () => {
       return yield* $(runScript(script, args))
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(RushPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -45,7 +51,7 @@ describe('PackageManager - Rush Implementation', () => {
       yield* $(runScript('script', []))
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(RushPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -61,7 +67,7 @@ describe('PackageManager - Rush Implementation', () => {
     })
 
     return expect(
-      unsafeRunEffect(effect, {
+      unsafeRunEffect(mapEffError(effect), {
         layer: Layer.using(testLayer)(RushPackageManager),
         onError: guardError('An error ocurred'),
       })
@@ -76,7 +82,7 @@ describe('PackageManager - Rush Implementation', () => {
       return yield* $(installAllDependencies())
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(RushPackageManager),
       onError: guardError('An error ocurred'),
     })

--- a/packages/cli/test/services/package-manager/yarn.test.ts
+++ b/packages/cli/test/services/package-manager/yarn.test.ts
@@ -1,5 +1,5 @@
 import { fake } from 'sinon'
-import { gen, Layer, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
+import { Effect, gen, Layer, mapError, pipe, unsafeRunEffect } from '@boostercloud/framework-types/dist/effect'
 import { expect } from '../../expect'
 import { makeTestFileSystem } from '../file-system/test.impl'
 import { makeTestProcess } from '../process/test.impl'
@@ -9,6 +9,12 @@ import { PackageManagerService } from '../../../src/services/package-manager'
 
 const TestFileSystem = makeTestFileSystem()
 const TestProcess = makeTestProcess()
+
+const mapEffError = <R, A>(effect: Effect<R, { error: Error }, A>) =>
+  pipe(
+    effect,
+    mapError((e) => e.error)
+  )
 
 describe('PackageManager - Yarn Implementation', () => {
   beforeEach(() => {})
@@ -23,7 +29,7 @@ describe('PackageManager - Yarn Implementation', () => {
       return yield* $(runScript(script, args))
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(YarnPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -42,7 +48,7 @@ describe('PackageManager - Yarn Implementation', () => {
       yield* $(runScript('script', []))
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(YarnPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -57,7 +63,7 @@ describe('PackageManager - Yarn Implementation', () => {
       return yield* $(installProductionDependencies())
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(YarnPackageManager),
       onError: guardError('An error ocurred'),
     })
@@ -73,7 +79,7 @@ describe('PackageManager - Yarn Implementation', () => {
       return yield* $(installAllDependencies())
     })
 
-    await unsafeRunEffect(effect, {
+    await unsafeRunEffect(mapEffError(effect), {
       layer: Layer.using(testLayer)(YarnPackageManager),
       onError: guardError('An error ocurred'),
     })

--- a/packages/framework-types/src/effect/index.ts
+++ b/packages/framework-types/src/effect/index.ts
@@ -563,6 +563,8 @@ export { orDieWith } from '@effect-ts/core/Effect'
  */
 export { dieMessage } from '@effect-ts/core/Effect'
 
+export { mapError } from '@effect-ts/core/Effect'
+
 /*************************************************
  *                                               *
  *             DEPENDENCY INJECTION              *

--- a/packages/framework-types/src/effect/index.ts
+++ b/packages/framework-types/src/effect/index.ts
@@ -246,6 +246,47 @@ export { succeed } from '@effect-ts/core/Effect'
 export { succeedWith } from '@effect-ts/core/Effect'
 
 /**
+ * Function: fail
+ * ==============
+ *
+ * If you want to return an error from an effect, you can use the `fail` function.
+ * It is equivalent to `Promise.reject`.
+ *
+ * This function is useful when you want to return an error from an effect, but don't
+ * want to do any computation.
+ *
+ * Example:
+ *
+ * const foo = fail(new Error('something went wrong'))
+ *
+ * Here, `foo` is an effect that fails with the error `new Error('something went wrong')`.
+ *
+ * Takeaway: Use `fail` to return an error from an effect.
+ */
+export { fail } from '@effect-ts/core/Effect'
+
+/**
+ * Function: failWith
+ * ==================
+ *
+ * If you want to return an error from an effect, but you want to run some code to
+ * create the error, you can use the `failWith` function.
+ *
+ * You pass a function that runs what you need to run, and failWith will return
+ * an effect that will run the function, and then return the result.
+ *
+ * Example:
+ *
+ * const log = failWith(() => new Error('something went wrong'))
+ *
+ * In this example, the effect `log` will run the side effect of creating the error,
+ * and then return the result of the call, which is an error.
+ *
+ * Takeaway: Use `failWith` to wrap effectful code that doesn't return a promise.
+ */
+export { failWith } from '@effect-ts/core/Effect'
+
+/**
  * Function: tryCatch
  * ==================
  *
@@ -846,9 +887,9 @@ import { Layer } from '@effect-ts/core/Effect/Layer'
 import { Effect, provideSomeLayer, runPromise } from '@effect-ts/core/Effect'
 import { Has } from '@effect-ts/core/Has'
 
-type RunWithLayerOpts<R> = {
+type RunWithLayerOpts<R, E> = {
   readonly layer: Layer<unknown, never, Has<R>>
-  readonly onError: (eff: Effect<Has<R>, unknown, void>) => Effect<Has<R>, never, void>
+  readonly onError: (eff: Effect<Has<R>, E, void>) => Effect<Has<R>, never, void>
 }
 
 /**
@@ -858,9 +899,9 @@ type RunWithLayerOpts<R> = {
  * @param opts.onError The function to handle errors
  * @returns void
  */
-export const unsafeRunEffect = <R>(
-  effect: Effect<Has<R>, unknown, void>,
-  { layer, onError }: RunWithLayerOpts<R>
+export const unsafeRunEffect = <R, E>(
+  effect: Effect<Has<R>, E, void>,
+  { layer, onError }: RunWithLayerOpts<R, E>
 ): Promise<void> => {
   return pipe(effect, onError, provideSomeLayer(layer), runPromise)
 }


### PR DESCRIPTION

## Description

After 1.0, the CLI error messages became a bit more unreadable, because they were being stringified. This PR fixes that

## Changes

Reworked error bubbling as well as printing

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
