### PR TITLE
Improved migrations documentation

### DIFF
--- a/website/docs/03_features/03_data-migrations.md
+++ b/website/docs/03_features/03_data-migrations.md
@@ -4,12 +4,19 @@ description: Learn how to migrate data in Booster
 
 # Migrations
 
+Migrations are a mechanism for updating or transforming the schemas of events and entities as your system evolves. This allows you to make changes to your data model without losing or corrupting existing data. There are two types of migration tools available in Booster: schema migrations and data migrations.
+
+* **Schema migrations** are used to incrementally upgrade an event or entity from a past version to the next. They are applied lazily, meaning that they are performed on-the-fly whenever an event or entity is loaded. This allows you to make changes to your data model without having to manually update all existing artifacts, and makes it possible to apply changes without running lenghty migration processes.
+
+* **Data migrations**, on the other hand, behave as background processes that can actively change the existing values in the database for existing entities and read models. They are particularly useful for data migrations that cannot be performed automatically with schema migrations, or for updating existing read models after a schema change.
+
+Together, schema and data migrations provide a flexible and powerful toolset for managing the evolution of your data model over time.
+
 ## Schema migrations
 
-Booster handles classes annotated with `@Migrates` as **Schema migrations**. The migration process will update an existing object
-from one version to the next one.
+Booster handles classes annotated with `@Migrates` as **schema migrations**. The migration functions defined inside will update an existing artifact (either an event or an entity) from a previous version to a newer one whenever that artifact is visited. Schema migrations are applied to events and entities lazyly, meaning that they are only applied when the event or entity is loaded. This ensures that the migration process is non-disruptive and does not affect the performance of your system. Schema migrations are also performed on-the-fly and the results are not written back to the database, as events are not revisited once the next snapshot is written in the database.
 
-For example, to migrate a `Product` entity from version 1 to version 2 we need the following migration class:
+For example, to upgrade a `Product` entity from version 1 to version 2, you can write the following migration class:
 
 ```typescript
 @Migrates(Product)
@@ -29,7 +36,13 @@ export class ProductMigration {
 }
 ```
 
-The `ProductV1` class is the old version of the `Product` object. You can keep your old clases in the same migration file, for example:
+Notice that we've used the `@ToVersion` decorator in the above example. This decorator not only tells Booster what schema upgrade this migration performs, it also informs it about the existence of a version, which is always an integer number. Booster will always use the latest version known to tag newly created artifacts, defaulting to 1 when no migrations are defined. This ensures that the schema of newly created events and entities is up-to-date and that they can be migrated as needed in the future.
+
+The `@ToVersion` decorator takes two parameters in addition to the version: `fromSchema` and `toSchema`. The fromSchema parameter is set to `ProductV1`, while the `toSchema` parameter is set to `ProductV2`. This tells Booster that the migration is updating the `Product` object from version 1 (as defined by the `ProductV1` schema) to version 2 (as defined by the `ProductV2` schema).
+
+As Booster can easily read the structure of your classes, the schemas are described as plain classes that you can maintain as part of your code. The `ProductV1` class represents the schema of the previous version of the `Product` object with the properties and structure of the `Product` object as it was defined in version 1. The `ProductV2` class is an alias for the latest version of the Product object. You can use the `Product` class here, there's no difference, but it's a good practice to create an alias for clarity.
+
+It's a good practice to define the schema classes (`ProductV1` and `ProductV2`) as non-exported classes in the same migration file. This allows you to see the changes made between versions and helps to understand how the migration works:
 
 ```typescript
 class ProductV1 {
@@ -47,26 +60,55 @@ class ProductV1 {
 class ProductV2 extends Product {}
 ```
 
-## Data migrations
-
-The decorator `@DataMigration` will indicate **Booster** that this class contains data migration code.
+When you want to upgrade your artifacts from V2 to V3, you can add a new function decorated with `@ToVersion` to the same migrations class. You're free to structure the code the way you want, but we recommend keeping all migrations for the same artifact in the same migration class. For instance:
 
 ```typescript
-@DataMigration({
-  order: 2,
-})
+@Migrates(Product)
+export class ProductMigration {
+  @ToVersion(2, { fromSchema: ProductV1, toSchema: ProductV2 })
+  public async changeNameFieldToDisplayName(old: ProductV1): Promise<ProductV2> {
+    return new ProductV2(
+      old.id,
+      old.sku,
+      old.name, // It's now called `displayName`
+      old.description,
+      old.price,
+      old.pictures,
+      old.deleted
+    )
+  }
+
+  @ToVersion(3, { fromSchema: ProductV2, toSchema: ProductV3 })
+  public async addNewField(old: ProductV2): Promise<ProductV3> {
+    return new ProductV3(
+      old.id,
+      old.sku,
+      old.displayName,
+      old.description,
+      old.price,
+      old.pictures,
+      old.deleted,
+      42 // We set a default value to initialize this field
+    )
+  }
+}
 ```
 
-When the method `BoosterDataMigrations.run()` is call by the user, a new `BoosterDataMigrationStarted` event is emitted and **Booster** 
-will check if there are pending migrations and, if so, run them in the order specified by the `order` value.
+In this example, the `changeNameFieldToDisplayName` function updates the `Product` entity from version 1 to version 2 by renaming the `name` field to `displayName`. Then, `addNewField` function updates the `Product` entity from version 2 to version 3 by adding a new field called `newField` to the entity's schema. Notice that at this point, your database could have snapshots set as v1, v2, or v3, so while it might be tempting to redefine the original migration to keep a single 1-to-3 migration, it's usually a good idea to keep the intermediate steps. This way Booster will be able to handle any scenario.
 
-User should emit `BoosterDataMigrationFinished` manually at the end of each `DataMigration.start` method.
+## Data migrations
 
-In `@DataMigration` classes, you can use `Booster.migrateEntity` method. This method will generate an internal event `BoosterEntityMigrated` before migrating the entity data.
+Data migrations can be seen as background processes that can actively update the values of existing entities and read models in the database. They can be useful to perform data migrations that cannot be handled with schema migrations, for example when you need to update the values exposed by the GraphQL API, or to initialize new read models that are projections of previously existing entities.
 
-This method will receive the old entity name, the old entity id and the new entity that we will be persisted. This way, you can migrate an entity id or rename it.
+To create a data migration in Booster, you can use the `@DataMigration` decorator on a class that implements a `start` method. The `@DataMigration` decorator takes an object with a single parameter, `order`, which specifies the order in which the data migration should be run relative to other data migrations.
 
-Example:
+Data migrations are not run automatically, you need to invoke the `BoosterDataMigrations.run()` method from an event handler or a command. This will emit a `BoosterDataMigrationStarted` event, which will make Booster check for any pending migrations and run them in the specified order. A common pattern to be able to run migrations on demand is to add a special command, with access limited to an administrator role which calls this function. 
+
+Take into account that, depending on your cloud provider implementation, data migrations are executed in the context of a lambda or function app, so it's advisable to design these functions in a way that allow to re-run them in case of failures (i.e. lambda timeouts). In order to tell Booster that your migration has been applied successfully, at the end of each `DataMigration.start` method, you must emit a `BoosterDataMigrationFinished` event manually.
+
+Inside your `@DataMigration` classes, you can use the `Booster.migrateEntity` method to update the data for a specific entity. This method takes the old entity name, the old entity ID, and the new entity data as arguments. It will also generate an internal `BoosterEntityMigrated` event before performing the migration.
+
+Here is an example of how you might use the `@DataMigration` decorator and the `Booster.migrateEntity` method to update the quantity of the first item in a cart:
 
 ```typescript
 @DataMigration({


### PR DESCRIPTION
Improved the migrations section of the documentation:

* Added an introduction explaining the purpose and types of migrations in Booster Framework (schema migrations and data migrations)
* Clarified that schema migrations are applied lazily, meaning they are performed on the fly whenever an event or entity is loaded
* Added an example of a schema migration class and explained the `@ToVersion` decorator
* Added a data migration class example and explained the `@DataMigration` decorator and the `Booster.migrateEntity` method
* Clarified that data migrations are run in a specific order, as specified by the order value in the `@DataMigration` decorator

Overall, these changes aim to provide a clearer and more comprehensive explanation of the migration mechanisms in Booster Framework and how to use them in your code.