### PR TITLE
chore(cicd): Try caching build and dependencies

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -15,7 +15,6 @@ runs:
         key: ${{ runner.os }}-rush-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}-${{ hashFiles('.github/cache-version.yml') }}
 
     - uses: ./.github/actions/call-rush
-      if: steps.cache-rush.outputs.cache-hit != 'true'
       with:
         command: install
 

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -3,7 +3,19 @@ name: Build
 runs:
   using: 'composite'
   steps:
+    # First we cache the rush project, to ensure we don't build multiple times, nor we download more dependencies than needed
+    - name: Cache Rush project
+      id: cache-rush
+      uses: actions/cache@v3
+      with:
+        path: |
+          common/temp
+          common/config/rush
+          common/config/rush/pnpm-lock.yaml
+        key: ${{ runner.os }}-rush-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}-${{ hashFiles('.github/cache-version.yml') }}
+
     - uses: ./.github/actions/call-rush
+      if: steps.cache-rush.outputs.cache-hit != 'true'
       with:
         command: install
 

--- a/.github/actions/test-integration-run-one/action.yml
+++ b/.github/actions/test-integration-run-one/action.yml
@@ -47,6 +47,10 @@ inputs:
     required: true
     type: string
 
+  github_token:
+    required: true
+    type: string
+
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/re_test-integration-aws.yml
+++ b/.github/workflows/re_test-integration-aws.yml
@@ -24,6 +24,7 @@ jobs:
 
       - uses: ./.github/actions/test-integration-run-one
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           integration-test: aws-deploy
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           aws-region: ${{ inputs.aws-region }}
@@ -43,6 +44,7 @@ jobs:
 
       - uses: ./.github/actions/test-integration-run-one
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           integration-test: ${{ matrix.integration-test }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           aws-region: ${{ inputs.aws-region }}
@@ -61,6 +63,7 @@ jobs:
 
       - uses: ./.github/actions/test-integration-run-one
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           integration-test: aws-nuke
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/re_test-integration-azure.yml
+++ b/.github/workflows/re_test-integration-azure.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Run integration test
         uses: ./.github/actions/test-integration-run-one
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           integration-test: azure-deploy
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           azure-region: ${{ inputs.azure-region }}
@@ -64,6 +65,7 @@ jobs:
       - name: Run integration test
         uses: ./.github/actions/test-integration-run-one
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           integration-test: ${{ matrix.integration-test }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           azure-region: ${{ inputs.azure-region }}
@@ -88,6 +90,7 @@ jobs:
       - name: Run integration test
         uses: ./.github/actions/test-integration-run-one
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           integration-test: azure-nuke
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           azure-region: ${{ inputs.azure-region }}

--- a/.github/workflows/re_test-integration-cli.yml
+++ b/.github/workflows/re_test-integration-cli.yml
@@ -14,5 +14,6 @@ jobs:
       - name: Run integration test
         uses: ./.github/actions/test-integration-run-one
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           integration-test: cli
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/re_test-integration-local.yml
+++ b/.github/workflows/re_test-integration-local.yml
@@ -14,5 +14,6 @@ jobs:
       - name: Run integration test
         uses: ./.github/actions/test-integration-run-one
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           integration-test: local
           gh_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

We spend like 10 minutes for installing and building for each job in the CICD, this PR mitigates that by caching.

## Changes

Caches the Rush project before building

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
