### PR TITLE
Implemented a fallback to check the existence of a 'compile' command in the project package.json file for backwards compatibility

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -245,23 +245,11 @@
       "runtimeArgs": ["--preserve-symlinks"]
     },
     {
-      "type": "node",
-      "request": "launch",
+      "command": "rushx integration/cli",
       "name": "CLI Integration Tests",
-      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "args": [
-        "--colors",
-        "--forbid-only",
-        "--full-stack",
-        "--config",
-        "${workspaceFolder}/packages/framework-integration-tests/integration/provider-unaware/cli/.mocharc.yml",
-        "${workspaceFolder}/packages/framework-integration-tests/integration/provider-unaware/cli/**/*.integration.ts"
-      ],
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "protocol": "inspector",
+      "request": "launch",
+      "type": "node-terminal",
       "cwd": "${workspaceFolder}/packages/framework-integration-tests",
-      "runtimeArgs": ["--preserve-symlinks"],
     },
     {
       "type": "node",

--- a/booster.code-workspace
+++ b/booster.code-workspace
@@ -1,6 +1,10 @@
 {
   "folders": [
     {
+      "name": "✨ root",
+      "path": "."
+    },
+    {
       "name": "📦 @boostercloud/application-tester",
       "path": "packages/application-tester"
     },

--- a/common/changes/@boostercloud/framework-core/fix-issue-1307-backwards-compatibility-with-projects-that-define-a-compile-script_2023-01-23-20-32.json
+++ b/common/changes/@boostercloud/framework-core/fix-issue-1307-backwards-compatibility-with-projects-that-define-a-compile-script_2023-01-23-20-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "Implemented a fallback to check the existence of a 'compile' command in the project package.json file for backwards compatibility",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
   ../../packages/application-tester:
     specifiers:
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@types/jsonwebtoken': ^8.5.8
       '@types/node': 16.11.7
@@ -78,10 +78,10 @@ importers:
 
   ../../packages/cli:
     specifiers:
-      '@boostercloud/application-tester': workspace:^1.3.5
+      '@boostercloud/application-tester': workspace:^1.4.0
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-core': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-core': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@oclif/command': ^1.8
       '@oclif/config': ^1.18
@@ -198,7 +198,7 @@ importers:
   ../../packages/framework-common-helpers:
     specifiers:
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -267,9 +267,9 @@ importers:
   ../../packages/framework-core:
     specifiers:
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-common-helpers': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
-      '@boostercloud/metadata-booster': workspace:^1.3.5
+      '@boostercloud/framework-common-helpers': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
+      '@boostercloud/metadata-booster': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -365,21 +365,21 @@ importers:
 
   ../../packages/framework-integration-tests:
     specifiers:
-      '@boostercloud/application-tester': workspace:^1.3.5
-      '@boostercloud/cli': workspace:^1.3.5
+      '@boostercloud/application-tester': workspace:^1.4.0
+      '@boostercloud/cli': workspace:^1.4.0
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-common-helpers': workspace:^1.3.5
-      '@boostercloud/framework-core': workspace:^1.3.5
-      '@boostercloud/framework-provider-aws': workspace:^1.3.5
-      '@boostercloud/framework-provider-aws-infrastructure': workspace:^1.3.5
-      '@boostercloud/framework-provider-azure': workspace:^1.3.5
-      '@boostercloud/framework-provider-azure-infrastructure': workspace:^1.3.5
-      '@boostercloud/framework-provider-kubernetes': workspace:^1.3.5
-      '@boostercloud/framework-provider-kubernetes-infrastructure': workspace:^1.3.5
-      '@boostercloud/framework-provider-local': workspace:^1.3.5
-      '@boostercloud/framework-provider-local-infrastructure': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
-      '@boostercloud/metadata-booster': workspace:^1.3.5
+      '@boostercloud/framework-common-helpers': workspace:^1.4.0
+      '@boostercloud/framework-core': workspace:^1.4.0
+      '@boostercloud/framework-provider-aws': workspace:^1.4.0
+      '@boostercloud/framework-provider-aws-infrastructure': workspace:^1.4.0
+      '@boostercloud/framework-provider-azure': workspace:^1.4.0
+      '@boostercloud/framework-provider-azure-infrastructure': workspace:^1.4.0
+      '@boostercloud/framework-provider-kubernetes': workspace:^1.4.0
+      '@boostercloud/framework-provider-kubernetes-infrastructure': workspace:^1.4.0
+      '@boostercloud/framework-provider-local': workspace:^1.4.0
+      '@boostercloud/framework-provider-local-infrastructure': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
+      '@boostercloud/metadata-booster': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@kubernetes/client-node': ^0.17.0
       '@types/aws-lambda': 8.10.48
@@ -519,8 +519,8 @@ importers:
   ../../packages/framework-provider-aws:
     specifiers:
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-common-helpers': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-common-helpers': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@types/aws-lambda': 8.10.48
       '@types/chai': 4.2.18
@@ -615,9 +615,9 @@ importers:
       '@aws-cdk/custom-resources': ^1.170.0
       '@aws-cdk/cx-api': ^1.170.0
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-common-helpers': workspace:^1.3.5
-      '@boostercloud/framework-provider-aws': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-common-helpers': workspace:^1.4.0
+      '@boostercloud/framework-provider-aws': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@types/archiver': 5.1.0
       '@types/aws-lambda': 8.10.48
@@ -662,20 +662,20 @@ importers:
     dependencies:
       '@aws-cdk/assets': 1.184.0_qqs6td3aenohjkmkxicqewfqhm
       '@aws-cdk/aws-apigateway': 1.184.0_xsucqykjuwmq7rof7g3ywzkpxu
-      '@aws-cdk/aws-apigatewayv2': 1.184.0_kx2cvhnr3ibn63arnbczci6a24
-      '@aws-cdk/aws-cloudfront': 1.184.0_kx2cvhnr3ibn63arnbczci6a24
+      '@aws-cdk/aws-apigatewayv2': 1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4
+      '@aws-cdk/aws-cloudfront': 1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4
       '@aws-cdk/aws-dynamodb': 1.184.0_iknl2dvfz7yvpbcv5m4fpzjqk4
       '@aws-cdk/aws-events': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-events-targets': 1.184.0_q7h7kazvf5fg7ifdmuquw6y67i
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
-      '@aws-cdk/aws-lambda-event-sources': 1.184.0_zyml73mza3tiblfo3bpmz7ck2m
+      '@aws-cdk/aws-lambda-event-sources': 1.184.0_77rnkllymvedxlxiru3yiftemy
       '@aws-cdk/aws-logs': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
       '@aws-cdk/aws-s3': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/aws-s3-deployment': 1.184.0_yeq2euairwjoisoscfxe55irzy
       '@aws-cdk/cloudformation-diff': 1.184.0
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
-      '@aws-cdk/custom-resources': 1.184.0_vukta6eup7qakgbqr2luchzb64
+      '@aws-cdk/custom-resources': 1.184.0_kgzklihmvjesyhluh6hdccihku
       '@aws-cdk/cx-api': 1.184.0
       '@boostercloud/framework-common-helpers': link:../framework-common-helpers
       '@boostercloud/framework-provider-aws': link:../framework-provider-aws
@@ -730,8 +730,8 @@ importers:
       '@azure/functions': ^1.2.2
       '@azure/identity': ~2.1.0
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-common-helpers': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-common-helpers': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -802,10 +802,10 @@ importers:
       '@azure/cosmos': ^3.17.0
       '@azure/identity': ~2.1.0
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-common-helpers': workspace:^1.3.5
-      '@boostercloud/framework-core': workspace:^1.3.5
-      '@boostercloud/framework-provider-azure': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-common-helpers': workspace:^1.4.0
+      '@boostercloud/framework-core': workspace:^1.4.0
+      '@boostercloud/framework-provider-azure': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@cdktf/provider-azurerm': ^0.2.179
       '@effect-ts/core': ^0.60.4
       '@types/archiver': 5.1.0
@@ -911,8 +911,8 @@ importers:
   ../../packages/framework-provider-kubernetes:
     specifiers:
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-common-helpers': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-common-helpers': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@types/body-parser': ~1.19.2
       '@types/chai': 4.2.18
@@ -990,8 +990,8 @@ importers:
   ../../packages/framework-provider-kubernetes-infrastructure:
     specifiers:
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-common-helpers': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-common-helpers': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@kubernetes/client-node': ^0.17.0
       '@types/archiver': 5.1.0
@@ -1093,8 +1093,8 @@ importers:
   ../../packages/framework-provider-local:
     specifiers:
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-common-helpers': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-common-helpers': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -1170,9 +1170,9 @@ importers:
   ../../packages/framework-provider-local-infrastructure:
     specifiers:
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/framework-common-helpers': workspace:^1.3.5
-      '@boostercloud/framework-provider-local': workspace:^1.3.5
-      '@boostercloud/framework-types': workspace:^1.3.5
+      '@boostercloud/framework-common-helpers': workspace:^1.4.0
+      '@boostercloud/framework-provider-local': workspace:^1.4.0
+      '@boostercloud/framework-types': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -1257,7 +1257,7 @@ importers:
   ../../packages/framework-types:
     specifiers:
       '@boostercloud/eslint-config': workspace:^1.0.0
-      '@boostercloud/metadata-booster': workspace:^1.3.5
+      '@boostercloud/metadata-booster': workspace:^1.4.0
       '@effect-ts/core': ^0.60.4
       '@effect-ts/node': ~0.39.0
       '@types/chai': 4.2.18
@@ -1441,8 +1441,8 @@ packages:
       '@aws-cdk/aws-certificatemanager': 1.184.0_ntyyh4ri24qfshlvap73evzzam
       '@aws-cdk/aws-cloudwatch': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-cognito': 1.184.0_6j73r5euiwksa4akgjkxlqziu4
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
-      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_kx2cvhnr3ibn63arnbczci6a24
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
+      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
       '@aws-cdk/aws-logs': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
@@ -1458,7 +1458,7 @@ packages:
       - '@aws-cdk/custom-resources'
     dev: false
 
-  /@aws-cdk/aws-apigatewayv2/1.184.0_kx2cvhnr3ibn63arnbczci6a24:
+  /@aws-cdk/aws-apigatewayv2/1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4:
     resolution: {integrity: sha512-MY5ksjHac2Xu2FGv8hutbTSbvProHD29RRjyZbOiK/MXRoz2zd3Wl7Gacpi1vwWFI0Nz3TNrReHpjb0fMlgcPQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -1469,13 +1469,12 @@ packages:
     dependencies:
       '@aws-cdk/aws-certificatemanager': 1.184.0_ntyyh4ri24qfshlvap73evzzam
       '@aws-cdk/aws-cloudwatch': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-s3': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/aws-lambda'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/custom-resources'
@@ -1524,7 +1523,7 @@ packages:
       '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-autoscaling': 1.184.0_xsucqykjuwmq7rof7g3ywzkpxu
+      '@aws-cdk/aws-autoscaling': 1.184.0_vnxbpxtxjespykyhnhu4kbbpde
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
@@ -1535,7 +1534,7 @@ packages:
       constructs: 3.4.193
     dev: false
 
-  /@aws-cdk/aws-autoscaling/1.184.0_xsucqykjuwmq7rof7g3ywzkpxu:
+  /@aws-cdk/aws-autoscaling/1.184.0_vnxbpxtxjespykyhnhu4kbbpde:
     resolution: {integrity: sha512-2d5nhe0GpY0o/BdtCk+XkDKlxqTC8RzLmG0RH3xR7AANEKf5YLBiXg4t9UlfOkGaIGwq3+vXdlmIN3/H0IZwIA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -1545,15 +1544,14 @@ packages:
     dependencies:
       '@aws-cdk/aws-autoscaling-common': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-cloudwatch': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-elasticloadbalancing': 1.184.0_56tm4dtuxd6aij7xlisxhmb7ra
-      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_kx2cvhnr3ibn63arnbczci6a24
+      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-sns': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/aws-events'
       - '@aws-cdk/aws-lambda'
       - '@aws-cdk/aws-logs'
@@ -1606,7 +1604,7 @@ packages:
       - '@aws-cdk/aws-events'
     dev: false
 
-  /@aws-cdk/aws-cloudfront/1.184.0_kx2cvhnr3ibn63arnbczci6a24:
+  /@aws-cdk/aws-cloudfront/1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4:
     resolution: {integrity: sha512-6NU4mHPnhcCtJZyNfhq/1HriEvMGb+i/WJZyadYNWArJ8oJi68+c7jB3pxQT+QLYff4f3a0vV5lcL93Wcty6Mg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -1619,7 +1617,7 @@ packages:
     dependencies:
       '@aws-cdk/aws-certificatemanager': 1.184.0_ntyyh4ri24qfshlvap73evzzam
       '@aws-cdk/aws-cloudwatch': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
@@ -1629,7 +1627,6 @@ packages:
       '@aws-cdk/cx-api': 1.184.0
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/custom-resources'
     dev: false
@@ -1663,8 +1660,8 @@ packages:
       '@aws-cdk/aws-cloudwatch': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-codecommit': 1.184.0_xkrl3se23lz2q6pjn2srw3yete
       '@aws-cdk/aws-codestarnotifications': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
-      '@aws-cdk/aws-ecr': 1.184.0_invfyvx3kzsekj3k3o3y4j2vna
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
+      '@aws-cdk/aws-ecr': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/aws-ecr-assets': 1.184.0_xkrl3se23lz2q6pjn2srw3yete
       '@aws-cdk/aws-events': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
@@ -1672,7 +1669,7 @@ packages:
       '@aws-cdk/aws-logs': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
       '@aws-cdk/aws-s3': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/aws-s3-assets': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
-      '@aws-cdk/aws-secretsmanager': 1.184.0_3ecfoyhx5soks3o37lsvya3aiu
+      '@aws-cdk/aws-secretsmanager': 1.184.0_azd6pychcr4kbbbx2rrxd2kmo4
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
       '@aws-cdk/region-info': 1.184.0
       constructs: 3.4.193
@@ -1765,7 +1762,7 @@ packages:
       '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
-      '@aws-cdk/custom-resources': 1.184.0_vukta6eup7qakgbqr2luchzb64
+      '@aws-cdk/custom-resources': 1.184.0_kgzklihmvjesyhluh6hdccihku
       constructs: 3.4.193
       punycode: 2.1.1
     transitivePeerDependencies:
@@ -1793,14 +1790,14 @@ packages:
       '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
-      '@aws-cdk/custom-resources': 1.184.0_vukta6eup7qakgbqr2luchzb64
+      '@aws-cdk/custom-resources': 1.184.0_kgzklihmvjesyhluh6hdccihku
       constructs: 3.4.193
     transitivePeerDependencies:
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-ec2/1.184.0_m2wnwuh7kqsf7sxvlonhpltm64:
+  /@aws-cdk/aws-ec2/1.184.0_fmnoc2utkuhcw6xedz44qprjqe:
     resolution: {integrity: sha512-Z0e1cD6/ultLvAfyQWhwFntfTpVA9ekkPFY+f/t3SV6OYmewyAex4pb40UA4UxraXoNL8JDSPzaaKfE4mPnZ5g==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -1811,20 +1808,14 @@ packages:
       '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudwatch': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
-      '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/aws-logs': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
       '@aws-cdk/aws-s3': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
-      '@aws-cdk/aws-s3-assets': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
       '@aws-cdk/aws-ssm': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/cloud-assembly-schema': 1.184.0
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
       '@aws-cdk/cx-api': 1.184.0
-      '@aws-cdk/region-info': 1.184.0
       constructs: 3.4.193
-    transitivePeerDependencies:
-      - '@aws-cdk/assets'
     dev: false
 
   /@aws-cdk/aws-ecr-assets/1.184.0_xkrl3se23lz2q6pjn2srw3yete:
@@ -1839,7 +1830,7 @@ packages:
       constructs: ^3.3.69
     dependencies:
       '@aws-cdk/assets': 1.184.0_qqs6td3aenohjkmkxicqewfqhm
-      '@aws-cdk/aws-ecr': 1.184.0_invfyvx3kzsekj3k3o3y4j2vna
+      '@aws-cdk/aws-ecr': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-s3': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
@@ -1849,7 +1840,7 @@ packages:
       - '@aws-cdk/aws-events'
     dev: false
 
-  /@aws-cdk/aws-ecr/1.184.0_invfyvx3kzsekj3k3o3y4j2vna:
+  /@aws-cdk/aws-ecr/1.184.0_d6tbnp5fcqq7uq2j3427xw35se:
     resolution: {integrity: sha512-MTeolpr49xubLRqpYkw0qcC77TE6oTos/LgloCwlJi52bS6iYq0+bSz+mTK08QRu5UZyUB3EdCgLtf5gA+CCww==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -1860,8 +1851,11 @@ packages:
     dependencies:
       '@aws-cdk/aws-events': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
+      '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
       constructs: 3.4.193
+    transitivePeerDependencies:
+      - '@aws-cdk/cx-api'
     dev: false
 
   /@aws-cdk/aws-ecs/1.184.0_k7ah2oire47c5fgburwry3j4py:
@@ -1877,25 +1871,25 @@ packages:
       constructs: ^3.3.69
     dependencies:
       '@aws-cdk/aws-applicationautoscaling': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
-      '@aws-cdk/aws-autoscaling': 1.184.0_xsucqykjuwmq7rof7g3ywzkpxu
+      '@aws-cdk/aws-autoscaling': 1.184.0_vnxbpxtxjespykyhnhu4kbbpde
       '@aws-cdk/aws-autoscaling-hooktargets': 1.184.0_26vx2mhtjz3aydsqlf3hxnkrem
       '@aws-cdk/aws-certificatemanager': 1.184.0_ntyyh4ri24qfshlvap73evzzam
       '@aws-cdk/aws-cloudwatch': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
-      '@aws-cdk/aws-ecr': 1.184.0_invfyvx3kzsekj3k3o3y4j2vna
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
+      '@aws-cdk/aws-ecr': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/aws-ecr-assets': 1.184.0_xkrl3se23lz2q6pjn2srw3yete
       '@aws-cdk/aws-elasticloadbalancing': 1.184.0_56tm4dtuxd6aij7xlisxhmb7ra
-      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_kx2cvhnr3ibn63arnbczci6a24
+      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
       '@aws-cdk/aws-logs': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
       '@aws-cdk/aws-route53': 1.184.0_ghwjxw3mvmzhhjdre2u5szktye
-      '@aws-cdk/aws-route53-targets': 1.184.0_qbuedpzm4bz6shrxt2rhjdrku4
+      '@aws-cdk/aws-route53-targets': 1.184.0_m2ogoxqttnr2ms5qasfyng5wle
       '@aws-cdk/aws-s3': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/aws-s3-assets': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
-      '@aws-cdk/aws-secretsmanager': 1.184.0_3ecfoyhx5soks3o37lsvya3aiu
-      '@aws-cdk/aws-servicediscovery': 1.184.0_xmb2ajcb3jhfjjawinxxeyj2ty
+      '@aws-cdk/aws-secretsmanager': 1.184.0_azd6pychcr4kbbbx2rrxd2kmo4
+      '@aws-cdk/aws-servicediscovery': 1.184.0_3lwilrjl7p72oqh2746prpqsdy
       '@aws-cdk/aws-sns': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/aws-sqs': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/aws-ssm': 1.184.0_22keh33mwgayl25ncpc4ioktxa
@@ -1911,7 +1905,7 @@ packages:
       - '@aws-cdk/custom-resources'
     dev: false
 
-  /@aws-cdk/aws-efs/1.184.0_m2wnwuh7kqsf7sxvlonhpltm64:
+  /@aws-cdk/aws-efs/1.184.0_fmnoc2utkuhcw6xedz44qprjqe:
     resolution: {integrity: sha512-0JWQTQoe0POyAoCqhj1gry9oFDg7wsqaR1/ayQwTfBj+bbhGFVbj8C3XFSNxe3EY6DDoRr9hPkitY+6NFYARcg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -1920,7 +1914,7 @@ packages:
       '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/cloud-assembly-schema': 1.184.0
@@ -1928,7 +1922,6 @@ packages:
       '@aws-cdk/cx-api': 1.184.0
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/aws-s3'
     dev: false
@@ -1941,12 +1934,12 @@ packages:
       '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
       constructs: 3.4.193
     dev: false
 
-  /@aws-cdk/aws-elasticloadbalancingv2/1.184.0_kx2cvhnr3ibn63arnbczci6a24:
+  /@aws-cdk/aws-elasticloadbalancingv2/1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4:
     resolution: {integrity: sha512-UDASd86i+kFEsgvVU8AFX0Ky1x7bzITW+Au4zWSBoAvMsAFufHXHV7YOSHlfPltUnR45zqEom04jexGgkV6ivw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -1959,7 +1952,7 @@ packages:
     dependencies:
       '@aws-cdk/aws-certificatemanager': 1.184.0_ntyyh4ri24qfshlvap73evzzam
       '@aws-cdk/aws-cloudwatch': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
       '@aws-cdk/aws-route53': 1.184.0_ghwjxw3mvmzhhjdre2u5szktye
@@ -1970,7 +1963,6 @@ packages:
       '@aws-cdk/region-info': 1.184.0
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/custom-resources'
     dev: false
@@ -1989,15 +1981,15 @@ packages:
       constructs: ^3.3.69
     dependencies:
       '@aws-cdk/aws-apigateway': 1.184.0_xsucqykjuwmq7rof7g3ywzkpxu
-      '@aws-cdk/aws-autoscaling': 1.184.0_xsucqykjuwmq7rof7g3ywzkpxu
+      '@aws-cdk/aws-autoscaling': 1.184.0_vnxbpxtxjespykyhnhu4kbbpde
       '@aws-cdk/aws-codebuild': 1.184.0_vukta6eup7qakgbqr2luchzb64
       '@aws-cdk/aws-codepipeline': 1.184.0_gtrf5fk2k3oj4r5wo7mj3tb7ye
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-ecs': 1.184.0_k7ah2oire47c5fgburwry3j4py
       '@aws-cdk/aws-events': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-kinesis': 1.184.0_vbr2a4oo4g4voccxqbmalihit4
-      '@aws-cdk/aws-kinesisfirehose': 1.184.0_3ecfoyhx5soks3o37lsvya3aiu
+      '@aws-cdk/aws-kinesisfirehose': 1.184.0_azd6pychcr4kbbbx2rrxd2kmo4
       '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
       '@aws-cdk/aws-logs': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
@@ -2006,7 +1998,7 @@ packages:
       '@aws-cdk/aws-sqs': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/aws-stepfunctions': 1.184.0_a3hz74fqch5t5y5igv6bdfj33m
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
-      '@aws-cdk/custom-resources': 1.184.0_vukta6eup7qakgbqr2luchzb64
+      '@aws-cdk/custom-resources': 1.184.0_kgzklihmvjesyhluh6hdccihku
       constructs: 3.4.193
     transitivePeerDependencies:
       - '@aws-cdk/assets'
@@ -2037,9 +2029,9 @@ packages:
       '@aws-cdk/custom-resources': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
-      '@aws-cdk/custom-resources': 1.184.0_vukta6eup7qakgbqr2luchzb64
+      '@aws-cdk/custom-resources': 1.184.0_kgzklihmvjesyhluh6hdccihku
       constructs: 3.4.193
     dev: false
 
@@ -2075,7 +2067,7 @@ packages:
       - '@aws-cdk/cx-api'
     dev: false
 
-  /@aws-cdk/aws-kinesisfirehose/1.184.0_3ecfoyhx5soks3o37lsvya3aiu:
+  /@aws-cdk/aws-kinesisfirehose/1.184.0_azd6pychcr4kbbbx2rrxd2kmo4:
     resolution: {integrity: sha512-JoqdL82Kfs/uOFcAQtp6sWH3k0m4nJNIN4tvCVOcQ+z0ZD8q/mfLCpcsP9Y0AhHuQPz2I6eFk+eepjK2iAzvnQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2087,7 +2079,7 @@ packages:
       constructs: ^3.3.69
     dependencies:
       '@aws-cdk/aws-cloudwatch': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-kinesis': 1.184.0_vbr2a4oo4g4voccxqbmalihit4
       '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
@@ -2098,7 +2090,6 @@ packages:
       '@aws-cdk/region-info': 1.184.0
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/cx-api'
     dev: false
 
@@ -2118,7 +2109,7 @@ packages:
       constructs: 3.4.193
     dev: false
 
-  /@aws-cdk/aws-lambda-event-sources/1.184.0_zyml73mza3tiblfo3bpmz7ck2m:
+  /@aws-cdk/aws-lambda-event-sources/1.184.0_77rnkllymvedxlxiru3yiftemy:
     resolution: {integrity: sha512-rDN7FcUPlvnSoRwRWNkjuQqLi6kXncZlyhBCAMnkJADPAxKa7SqeeCgNOLgEYDXBcD1rohtEmcEQwt5CgGV2Xw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2133,21 +2124,20 @@ packages:
     dependencies:
       '@aws-cdk/aws-apigateway': 1.184.0_xsucqykjuwmq7rof7g3ywzkpxu
       '@aws-cdk/aws-dynamodb': 1.184.0_iknl2dvfz7yvpbcv5m4fpzjqk4
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-events': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-kinesis': 1.184.0_vbr2a4oo4g4voccxqbmalihit4
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
       '@aws-cdk/aws-s3': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/aws-s3-notifications': 1.184.0_iuqj3rrxdl67kr6pjq2kvwgmri
-      '@aws-cdk/aws-secretsmanager': 1.184.0_3ecfoyhx5soks3o37lsvya3aiu
+      '@aws-cdk/aws-secretsmanager': 1.184.0_azd6pychcr4kbbbx2rrxd2kmo4
       '@aws-cdk/aws-sns': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/aws-sns-subscriptions': 1.184.0_bawu4bgszhmukrbgfwa75tzhfe
       '@aws-cdk/aws-sqs': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/cx-api'
     dev: false
@@ -2167,10 +2157,10 @@ packages:
       '@aws-cdk/aws-applicationautoscaling': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-cloudwatch': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-codeguruprofiler': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
-      '@aws-cdk/aws-ecr': 1.184.0_invfyvx3kzsekj3k3o3y4j2vna
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
+      '@aws-cdk/aws-ecr': 1.184.0_d6tbnp5fcqq7uq2j3427xw35se
       '@aws-cdk/aws-ecr-assets': 1.184.0_xkrl3se23lz2q6pjn2srw3yete
-      '@aws-cdk/aws-efs': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-efs': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-events': 1.184.0_imlu2ikbfk3pt4y2qusvey6rtu
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
@@ -2209,7 +2199,7 @@ packages:
       - '@aws-cdk/aws-s3'
     dev: false
 
-  /@aws-cdk/aws-route53-targets/1.184.0_qbuedpzm4bz6shrxt2rhjdrku4:
+  /@aws-cdk/aws-route53-targets/1.184.0_m2ogoxqttnr2ms5qasfyng5wle:
     resolution: {integrity: sha512-xiOLxm9piAv/ESw3E72LBDazk15zf45gIWX9KNtiHoAk4V3cetWnWfkewgsXYFRPMMhjuNwZ3ZMvJd+odDCyUQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2222,11 +2212,11 @@ packages:
       constructs: ^3.3.69
     dependencies:
       '@aws-cdk/aws-apigateway': 1.184.0_xsucqykjuwmq7rof7g3ywzkpxu
-      '@aws-cdk/aws-cloudfront': 1.184.0_kx2cvhnr3ibn63arnbczci6a24
+      '@aws-cdk/aws-cloudfront': 1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4
       '@aws-cdk/aws-cognito': 1.184.0_6j73r5euiwksa4akgjkxlqziu4
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-elasticloadbalancing': 1.184.0_56tm4dtuxd6aij7xlisxhmb7ra
-      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_kx2cvhnr3ibn63arnbczci6a24
+      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4
       '@aws-cdk/aws-globalaccelerator': 1.184.0_ng6wg44qv63hicspnbila6cfqu
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-route53': 1.184.0_ghwjxw3mvmzhhjdre2u5szktye
@@ -2235,7 +2225,6 @@ packages:
       '@aws-cdk/region-info': 1.184.0
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/aws-lambda'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/custom-resources'
@@ -2253,12 +2242,12 @@ packages:
       '@aws-cdk/custom-resources': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-logs': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
       '@aws-cdk/cloud-assembly-schema': 1.184.0
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
-      '@aws-cdk/custom-resources': 1.184.0_vukta6eup7qakgbqr2luchzb64
+      '@aws-cdk/custom-resources': 1.184.0_kgzklihmvjesyhluh6hdccihku
       constructs: 3.4.193
     dev: false
 
@@ -2294,9 +2283,9 @@ packages:
       '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-cloudfront': 1.184.0_kx2cvhnr3ibn63arnbczci6a24
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
-      '@aws-cdk/aws-efs': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-cloudfront': 1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
+      '@aws-cdk/aws-efs': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
       '@aws-cdk/aws-logs': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
@@ -2365,7 +2354,7 @@ packages:
       constructs: 3.4.193
     dev: false
 
-  /@aws-cdk/aws-secretsmanager/1.184.0_3ecfoyhx5soks3o37lsvya3aiu:
+  /@aws-cdk/aws-secretsmanager/1.184.0_azd6pychcr4kbbbx2rrxd2kmo4:
     resolution: {integrity: sha512-L2D1Syyn3wp5mnDWDJv7N3BNIm8AExUJBfMBfkSsF0AgMXDRpzPuNVKV+NxFWHTOPPxb0NuZobG4admWk2T5Zg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2375,7 +2364,7 @@ packages:
       '@aws-cdk/cx-api': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-kms': 1.184.0_22keh33mwgayl25ncpc4ioktxa
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
@@ -2384,12 +2373,11 @@ packages:
       '@aws-cdk/cx-api': 1.184.0
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/aws-logs'
       - '@aws-cdk/aws-s3'
     dev: false
 
-  /@aws-cdk/aws-servicediscovery/1.184.0_xmb2ajcb3jhfjjawinxxeyj2ty:
+  /@aws-cdk/aws-servicediscovery/1.184.0_3lwilrjl7p72oqh2746prpqsdy:
     resolution: {integrity: sha512-vpYuLc2sBPPMMhc4zYhmkJDd+GgepWQVicC5RfTUbdOZv6U2HbFHAB9EdSW8Pjsrgb8jh2UHX6vT45+gLwFS1A==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2397,13 +2385,12 @@ packages:
       '@aws-cdk/core': 1.184.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
-      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_kx2cvhnr3ibn63arnbczci6a24
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
+      '@aws-cdk/aws-elasticloadbalancingv2': 1.184.0_lsdlwnpisoik7ffzpd5oc5fyj4
       '@aws-cdk/aws-route53': 1.184.0_ghwjxw3mvmzhhjdre2u5szktye
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/aws-iam'
       - '@aws-cdk/aws-lambda'
       - '@aws-cdk/aws-logs'
@@ -2540,6 +2527,9 @@ packages:
   /@aws-cdk/cloud-assembly-schema/2.39.1:
     resolution: {integrity: sha512-lSVaaedXWeK08uoq0IXDCspz9U/H4qIERemdsMQrMUDTiUe/JBby7vtmyMvOdEscE8GMAmiOzoPmAE0Uf+yw5A==}
     engines: {node: '>= 14.15.0'}
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.3.8
     dev: false
     bundledDependencies:
       - jsonschema
@@ -2580,7 +2570,7 @@ packages:
       - '@balena/dockerignore'
       - ignore
 
-  /@aws-cdk/custom-resources/1.184.0_vukta6eup7qakgbqr2luchzb64:
+  /@aws-cdk/custom-resources/1.184.0_kgzklihmvjesyhluh6hdccihku:
     resolution: {integrity: sha512-7XkPdIwNzeIXQd8U8864jjZ3BTpZzWRld5u5CWfg6MLoEBWRsRbuw2da4wDM96Fa1RotBs7x8raSRPxP2DSGwg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2591,7 +2581,7 @@ packages:
       constructs: ^3.3.69
     dependencies:
       '@aws-cdk/aws-cloudformation': 1.184.0_iuqj3rrxdl67kr6pjq2kvwgmri
-      '@aws-cdk/aws-ec2': 1.184.0_m2wnwuh7kqsf7sxvlonhpltm64
+      '@aws-cdk/aws-ec2': 1.184.0_fmnoc2utkuhcw6xedz44qprjqe
       '@aws-cdk/aws-iam': 1.184.0_rzudzuad5afy77xhglc4x2xrhi
       '@aws-cdk/aws-lambda': 1.184.0_huqejh452piaafbgu7eygp45yy
       '@aws-cdk/aws-logs': 1.184.0_xwtgc7oo4aiwabr435sqa4g4ce
@@ -2599,7 +2589,6 @@ packages:
       '@aws-cdk/core': 1.184.0_faxhqvroc6gcqql5kmmny4subm
       constructs: 3.4.193
     transitivePeerDependencies:
-      - '@aws-cdk/assets'
       - '@aws-cdk/aws-events'
       - '@aws-cdk/aws-s3'
       - '@aws-cdk/cx-api'
@@ -2620,6 +2609,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 2.39.1
+      semver: 7.3.8
     dev: false
     bundledDependencies:
       - semver

--- a/packages/cli/src/services/config-service.ts
+++ b/packages/cli/src/services/config-service.ts
@@ -57,10 +57,10 @@ export async function compileProject(projectPath: string): Promise<void> {
 
 const compileProjectEff = (projectPath: string) =>
   gen(function* ($) {
-    const { setProjectRoot, runScript } = yield* $(PackageManagerService)
+    const { setProjectRoot, build } = yield* $(PackageManagerService)
     yield* $(setProjectRoot(projectPath))
     yield* $(cleanProjectEff(projectPath))
-    return yield* $(runScript('build', []))
+    return yield* $(build([]))
   })
 
 export async function cleanProject(projectPath: string): Promise<void> {

--- a/packages/cli/src/services/file-system/index.ts
+++ b/packages/cli/src/services/file-system/index.ts
@@ -7,6 +7,7 @@ export class FileSystemError {
 
 export interface FileSystemService {
   readonly readDirectoryContents: (directoryPath: string) => Effect<unknown, FileSystemError, ReadonlyArray<string>>
+  readonly readFileContents: (filePath: string) => Effect<unknown, FileSystemError, string>
 }
 
 export const FileSystemService = tag<FileSystemService>()

--- a/packages/cli/src/services/file-system/live.impl.ts
+++ b/packages/cli/src/services/file-system/live.impl.ts
@@ -6,11 +6,13 @@ const readDirectoryContents = (directoryPath: string) =>
   tryCatchPromise(
     () => fs.promises.readdir(directoryPath),
     (reason) =>
-      new FileSystemError(
-        new Error(`There were some issues reading the directory ${directoryPath}:
-
-    ${reason}`)
-      )
+      new FileSystemError(new Error(`There were some issues reading the directory ${directoryPath}: ${reason}`))
   )
 
-export const LiveFileSystem = Layer.fromValue(FileSystemService)({ readDirectoryContents })
+const readFileContents = (filePath: string) =>
+  tryCatchPromise(
+    () => fs.promises.readFile(filePath, 'utf8'),
+    (reason) => new FileSystemError(new Error(`There were some issues reading the file ${filePath}: ${reason}`))
+  )
+
+export const LiveFileSystem = Layer.fromValue(FileSystemService)({ readDirectoryContents, readFileContents })

--- a/packages/cli/src/services/package-manager/common.ts
+++ b/packages/cli/src/services/package-manager/common.ts
@@ -26,10 +26,7 @@ const checkScriptExists = (processService: ProcessService, fileSystemService: Fi
     const pwd = yield* $(cwd())
     const packageJson = yield* $(readFileContents(`${pwd}/package.json`))
     const packageJsonContents = JSON.parse(packageJson)
-    if (!packageJsonContents.scripts || !packageJsonContents.scripts[scriptName]) {
-      return false
-    }
-    return true
+    return !packageJsonContents.scripts || !packageJsonContents.scripts[scriptName]
   })
 
 const effectfulRun = (processService: ProcessService, command: string, projectDirRef: Ref.Ref<string>) => {
@@ -58,10 +55,8 @@ export const makeScopedBuild = (command: string, projectDirRef: Ref.Ref<string>)
     const processService = yield* $(ProcessService)
     const fileSystemService = yield* $(FileSystemService)
     const scriptExists = yield* $(checkScriptExists(processService, fileSystemService, 'compile'))
-    if (scriptExists) {
-      return effectfulRun(processService, command, projectDirRef).bind(null, 'compile')
-    }
-    return effectfulRun(processService, command, projectDirRef).bind(null, 'build')
+    const scriptName = scriptExists ? 'compile' : 'build'
+    return effectfulRun(processService, command, projectDirRef).bind(null, scriptName)
   })
 
 export const makePackageManager = (packageManagerCommand: string) =>

--- a/packages/cli/src/services/package-manager/common.ts
+++ b/packages/cli/src/services/package-manager/common.ts
@@ -40,8 +40,8 @@ const makeRunBuildScript = (command: string, projectDirRef: Ref.Ref<string>) =>
     return (args: ReadonlyArray<string>) =>
       gen(function* ($) {
         const scriptExists = yield* $(checkScriptExists(processService, fileSystemService, 'compile'))
-        const scriptName = scriptExists ? 'run compile' : 'build'
-        return yield* $(run(scriptName, null, args))
+        const scriptName = scriptExists ? 'compile' : 'build'
+        return yield* $(run('run', scriptName, args))
       })
   })
 

--- a/packages/cli/src/services/package-manager/common.ts
+++ b/packages/cli/src/services/package-manager/common.ts
@@ -1,6 +1,7 @@
 import { mapError, gen, pipe, Ref } from '@boostercloud/framework-types/dist/effect'
 import { InstallDependenciesError, PackageManagerService, RunScriptError } from '.'
 import { ProcessService } from '../process'
+import { FileSystemService } from '../file-system'
 
 /**
  * Gets the project root directory from the reference.
@@ -16,17 +17,51 @@ const ensureProjectDir = (processService: ProcessService, projectDirRef: Ref.Ref
   })
 
 /**
+ * Checks that the script exists in the package.json file
+ */
+const checkScriptExists = (processService: ProcessService, fileSystemService: FileSystemService, scriptName: string) =>
+  gen(function* ($) {
+    const { cwd } = processService
+    const { readFileContents } = fileSystemService
+    const pwd = yield* $(cwd())
+    const packageJson = yield* $(readFileContents(`${pwd}/package.json`))
+    const packageJsonContents = JSON.parse(packageJson)
+    if (!packageJsonContents.scripts || !packageJsonContents.scripts[scriptName]) {
+      return false
+    }
+    return true
+  })
+
+const effectfulRun = (processService: ProcessService, command: string, projectDirRef: Ref.Ref<string>) => {
+  const { exec } = processService
+  return (scriptName: string, args: ReadonlyArray<string>) =>
+    gen(function* ($) {
+      const projectDir = yield* $(ensureProjectDir(processService, projectDirRef))
+      return yield* $(exec(`${command} ${scriptName} ${args.join(' ')}`.trim(), projectDir))
+    })
+}
+
+/**
  * Returns a function that executes a package manager command in the project directory.
  */
 export const makeScopedRun = (command: string, projectDirRef: Ref.Ref<string>) =>
   gen(function* ($) {
     const processService = yield* $(ProcessService)
-    const { exec } = processService
-    return (scriptName: string, args: ReadonlyArray<string>) =>
-      gen(function* ($) {
-        const projectDir = yield* $(ensureProjectDir(processService, projectDirRef))
-        return yield* $(exec(`${command} ${scriptName} ${args.join(' ')}`.trim(), projectDir))
-      })
+    return effectfulRun(processService, command, projectDirRef)
+  })
+
+/**
+ * Returns a function that executes the proper build command in the project directory.
+ */
+export const makeScopedBuild = (command: string, projectDirRef: Ref.Ref<string>) =>
+  gen(function* ($) {
+    const processService = yield* $(ProcessService)
+    const fileSystemService = yield* $(FileSystemService)
+    const scriptExists = yield* $(checkScriptExists(processService, fileSystemService, 'compile'))
+    if (scriptExists) {
+      return effectfulRun(processService, command, projectDirRef).bind(null, 'compile')
+    }
+    return effectfulRun(processService, command, projectDirRef).bind(null, 'build')
   })
 
 export const makePackageManager = (packageManagerCommand: string) =>
@@ -36,12 +71,18 @@ export const makePackageManager = (packageManagerCommand: string) =>
 
     // Create a function to run a script in the project directory
     const run = yield* $(makeScopedRun(packageManagerCommand, projectDirRef))
+    const runBuild = yield* $(makeScopedBuild(packageManagerCommand, projectDirRef))
 
     const service: PackageManagerService = {
       setProjectRoot: (projectDir: string) => Ref.set_(projectDirRef, projectDir),
       runScript: (scriptName: string, args: ReadonlyArray<string>) =>
         pipe(
           run('run', [scriptName, ...args]),
+          mapError((error) => new RunScriptError(error.error))
+        ),
+      build: (args: ReadonlyArray<string>) =>
+        pipe(
+          runBuild(args),
           mapError((error) => new RunScriptError(error.error))
         ),
       installProductionDependencies: () =>

--- a/packages/cli/src/services/package-manager/index.ts
+++ b/packages/cli/src/services/package-manager/index.ts
@@ -17,6 +17,7 @@ export interface PackageManagerService {
   readonly installProductionDependencies: () => Effect<unknown, InstallDependenciesError, void>
   readonly installAllDependencies: () => Effect<unknown, InstallDependenciesError, void>
   readonly runScript: (scriptName: string, args: ReadonlyArray<string>) => Effect<unknown, RunScriptError, string>
+  readonly build: (args: ReadonlyArray<string>) => Effect<unknown, RunScriptError, string>
 }
 
 export const PackageManagerService = tag<PackageManagerService>()

--- a/packages/cli/src/services/package-manager/rush.impl.ts
+++ b/packages/cli/src/services/package-manager/rush.impl.ts
@@ -17,7 +17,12 @@ export const makeRushPackageManager = gen(function* ($) {
     ...commonService,
     runScript: (scriptName: string, args: ReadonlyArray<string>) =>
       pipe(
-        runRushX(scriptName, args),
+        runRushX(scriptName, null, args),
+        mapError((error) => new RunScriptError(error.error))
+      ),
+    build: (args: ReadonlyArray<string>) =>
+      pipe(
+        runRush('build', null, args),
         mapError((error) => new RunScriptError(error.error))
       ),
     installProductionDependencies: () =>
@@ -28,7 +33,7 @@ export const makeRushPackageManager = gen(function* ($) {
       ),
     installAllDependencies: () =>
       pipe(
-        runRush('update', []),
+        runRush('update', null, []),
         mapError((error) => new InstallDependenciesError(error.error))
       ),
   }

--- a/packages/cli/test/services/config-service.test.ts
+++ b/packages/cli/test/services/config-service.test.ts
@@ -22,7 +22,7 @@ describe('configService', () => {
       replace(PackageManager, 'LivePackageManager', TestPackageManager.layer)
       await configService.compileProject(userProjectPath)
       expect(TestPackageManager.fakes.runScript).to.have.calledWith('clean')
-      expect(TestPackageManager.fakes.runScript).to.have.calledWith('build')
+      expect(TestPackageManager.fakes.build).to.have.been.called
     })
   })
 

--- a/packages/cli/test/services/file-system/test.impl.ts
+++ b/packages/cli/test/services/file-system/test.impl.ts
@@ -5,5 +5,6 @@ import { FakeOverrides, fakeService } from '@boostercloud/application-tester/src
 export const makeTestFileSystem = (overrides?: FakeOverrides<FileSystemService>) =>
   fakeService(FileSystemService, {
     readDirectoryContents: fake.returns([]),
+    readFileContents: fake.returns('{}'),
     ...overrides,
   })

--- a/packages/cli/test/services/package-manager/npm.test.ts
+++ b/packages/cli/test/services/package-manager/npm.test.ts
@@ -70,7 +70,7 @@ describe('PackageManager - npm Implementation', () => {
         layer: Layer.using(testLayer)(NpmPackageManager),
         onError: guardError('An error ocurred'),
       })
-      expect(TestProcess.fakes.exec).to.have.been.calledWith('npm build')
+      expect(TestProcess.fakes.exec).to.have.been.calledWith('npm run build')
     })
   })
 

--- a/packages/cli/test/services/package-manager/npm.test.ts
+++ b/packages/cli/test/services/package-manager/npm.test.ts
@@ -36,6 +36,44 @@ describe('PackageManager - npm Implementation', () => {
     expect(TestProcess.fakes.exec).to.have.been.calledWith(`npm run ${script} ${args.join(' ')}`)
   })
 
+  describe('when the `compile` script exists', () => {
+    const TestFileSystemWithCompileScript = makeTestFileSystem({
+      readFileContents: fake.returns('{"scripts": {"compile": "tsc"}}'),
+    })
+
+    it('run the `compile` script', async () => {
+      const compileLayer = Layer.all(TestFileSystemWithCompileScript.layer, TestProcess.layer)
+
+      const effect = gen(function* ($) {
+        const { build } = yield* $(PackageManagerService)
+        return yield* $(build([]))
+      })
+
+      await unsafeRunEffect(mapEffError(effect), {
+        layer: Layer.using(compileLayer)(NpmPackageManager),
+        onError: guardError('An error ocurred'),
+      })
+      expect(TestProcess.fakes.exec).to.have.been.calledWith('npm run compile')
+    })
+  })
+
+  describe('when the `compile` script does not exist', () => {
+    it('run the `build` script', async () => {
+      const testLayer = Layer.all(TestFileSystem.layer, TestProcess.layer)
+
+      const effect = gen(function* ($) {
+        const { build } = yield* $(PackageManagerService)
+        return yield* $(build([]))
+      })
+
+      await unsafeRunEffect(mapEffError(effect), {
+        layer: Layer.using(testLayer)(NpmPackageManager),
+        onError: guardError('An error ocurred'),
+      })
+      expect(TestProcess.fakes.exec).to.have.been.calledWith('npm build')
+    })
+  })
+
   it('can set the project root properly', async () => {
     const projectRoot = 'projectRoot'
 

--- a/packages/cli/test/services/package-manager/pnpm.test.ts
+++ b/packages/cli/test/services/package-manager/pnpm.test.ts
@@ -68,7 +68,7 @@ describe('PackageManager - Pnpm Implementation', () => {
         layer: Layer.using(testLayer)(PnpmPackageManager),
         onError: guardError('An error ocurred'),
       })
-      expect(TestProcess.fakes.exec).to.have.been.calledWith('pnpm build')
+      expect(TestProcess.fakes.exec).to.have.been.calledWith('pnpm run build')
     })
   })
 

--- a/packages/cli/test/services/package-manager/rush.test.ts
+++ b/packages/cli/test/services/package-manager/rush.test.ts
@@ -39,6 +39,21 @@ describe('PackageManager - Rush Implementation', () => {
     expect(TestProcess.fakes.exec).to.have.been.calledWith(`rushx ${script} ${args.join(' ')}`)
   })
 
+  it('runs the `build` script', async () => {
+    const testLayer = Layer.all(TestFileSystem.layer, TestProcess.layer)
+
+    const effect = gen(function* ($) {
+      const { build } = yield* $(PackageManagerService)
+      return yield* $(build([]))
+    })
+
+    await unsafeRunEffect(mapEffError(effect), {
+      layer: Layer.using(testLayer)(RushPackageManager),
+      onError: guardError('An error ocurred'),
+    })
+    expect(TestProcess.fakes.exec).to.have.been.calledWith('rush build')
+  })
+
   it('can set the project root properly', async () => {
     const projectRoot = 'projectRoot'
 

--- a/packages/cli/test/services/package-manager/test.impl.ts
+++ b/packages/cli/test/services/package-manager/test.impl.ts
@@ -6,6 +6,7 @@ export const makeTestPackageManager = (overrides?: FakeOverrides<PackageManagerS
   fakeService(PackageManagerService, {
     setProjectRoot: fake(),
     runScript: fake.returns(''),
+    build: fake.returns(''),
     installAllDependencies: fake(),
     installProductionDependencies: fake(),
     ...overrides,

--- a/packages/cli/test/services/package-manager/yarn.test.ts
+++ b/packages/cli/test/services/package-manager/yarn.test.ts
@@ -36,6 +36,44 @@ describe('PackageManager - Yarn Implementation', () => {
     expect(TestProcess.fakes.exec).to.have.been.calledWith(`yarn run ${script} ${args.join(' ')}`)
   })
 
+  describe('when the `compile` script exists', () => {
+    const TestFileSystemWithCompileScript = makeTestFileSystem({
+      readFileContents: fake.returns('{"scripts": {"compile": "tsc"}}'),
+    })
+
+    it('run the `compile` script', async () => {
+      const testLayer = Layer.all(TestFileSystemWithCompileScript.layer, TestProcess.layer)
+
+      const effect = gen(function* ($) {
+        const { build } = yield* $(PackageManagerService)
+        return yield* $(build([]))
+      })
+
+      await unsafeRunEffect(mapEffError(effect), {
+        layer: Layer.using(testLayer)(YarnPackageManager),
+        onError: guardError('An error ocurred'),
+      })
+      expect(TestProcess.fakes.exec).to.have.been.calledWith('yarn run compile')
+    })
+  })
+
+  describe('when the `compile` script does not exist', () => {
+    it('run the `build` script', async () => {
+      const testLayer = Layer.all(TestFileSystem.layer, TestProcess.layer)
+
+      const effect = gen(function* ($) {
+        const { build } = yield* $(PackageManagerService)
+        return yield* $(build([]))
+      })
+
+      await unsafeRunEffect(mapEffError(effect), {
+        layer: Layer.using(testLayer)(YarnPackageManager),
+        onError: guardError('An error ocurred'),
+      })
+      expect(TestProcess.fakes.exec).to.have.been.calledWith('yarn build')
+    })
+  })
+
   it('can set the project root properly', async () => {
     const projectRoot = 'projectRoot'
 

--- a/packages/cli/test/services/package-manager/yarn.test.ts
+++ b/packages/cli/test/services/package-manager/yarn.test.ts
@@ -70,7 +70,7 @@ describe('PackageManager - Yarn Implementation', () => {
         layer: Layer.using(testLayer)(YarnPackageManager),
         onError: guardError('An error ocurred'),
       })
-      expect(TestProcess.fakes.exec).to.have.been.calledWith('yarn build')
+      expect(TestProcess.fakes.exec).to.have.been.calledWith('yarn run build')
     })
   })
 

--- a/packages/framework-integration-tests/integration/provider-unaware/cli/cli.build.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/cli/cli.build.integration.ts
@@ -5,6 +5,7 @@ import { exec } from 'child-process-promise'
 // Imported from another package to avoid duplication
 // It is OK-ish, since integration tests are always run in the context of the whole monorepo
 import { createSandboxProject } from '../../../../cli/src/common/sandbox'
+import * as fs from 'fs'
 
 describe('Build', () => {
   let buildSandboxDir: string
@@ -34,6 +35,36 @@ describe('Build', () => {
       expect(fileExists(path.join(buildSandboxDir, 'dist', 'roles.d.ts'))).to.be.true
       expect(fileExists(path.join(buildSandboxDir, 'dist', 'config', 'config.js'))).to.be.true
       expect(fileExists(path.join(buildSandboxDir, 'dist', 'config', 'config.d.ts'))).to.be.true
+    })
+  })
+})
+
+describe('Compile fallback', () => {
+  let compileSandboxDir: string
+
+  before(async () => {
+    compileSandboxDir = createSandboxProject(sandboxPathFor('compile'))
+
+    // Add a 'compile' script to the package.json
+    const packageJsonPath = path.join(compileSandboxDir, 'package.json')
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    packageJson.scripts.compile = 'echo "eureka"'
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+  })
+
+  after(() => {
+    removeFolders([compileSandboxDir])
+  })
+
+  const cliPath = path.join('..', '..', 'cli', 'bin', 'run')
+
+  context('when a compile script is present', () => {
+    it('should call the compile script instead', async () => {
+      const expectedOutputRegex = new RegExp('eureka')
+
+      const { stdout } = await exec(`${cliPath} build`, { cwd: compileSandboxDir })
+
+      expect(stdout).to.match(expectedOutputRegex)
     })
   })
 })

--- a/packages/framework-integration-tests/integration/provider-unaware/cli/cli.build.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/cli/cli.build.integration.ts
@@ -48,7 +48,7 @@ describe('Compile fallback', () => {
     // Add a 'compile' script to the package.json
     const packageJsonPath = path.join(compileSandboxDir, 'package.json')
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
-    packageJson.scripts.compile = 'echo "eureka"'
+    packageJson.scripts.compile = 'echo "eureka" > eureka'
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
   })
 
@@ -60,11 +60,14 @@ describe('Compile fallback', () => {
 
   context('when a compile script is present', () => {
     it('should call the compile script instead', async () => {
-      const expectedOutputRegex = new RegExp('eureka')
+      const expectedOutputRegex = new RegExp(
+        ['boost build', 'Checking project structure', 'Building project', 'Build complete'].join('(.|\n)*')
+      )
 
       const { stdout } = await exec(`${cliPath} build`, { cwd: compileSandboxDir })
 
       expect(stdout).to.match(expectedOutputRegex)
+      expect(fileExists(path.join(compileSandboxDir, 'eureka'))).to.be.true
     })
   })
 })


### PR DESCRIPTION
## Description

Now When Booster CLI commands need to build the user project, Booster will check if there's a "compile" script defined in the user's package.json file. If it exists, it will run it instead of the default "build" script.

This is a fallback to provide backwards compatibility with projects created with previous versions of Booster that used this "compile" script by default instead.

This PR closes #1307

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~Updated documentation accordingly~