### PR TITLE
Separated event from snapshot storage and started using the value `snapshottedEventCreatedAt` in snapshots to initialize the database sort key.

### DIFF
--- a/packages/framework-core/src/booster-data-migrations.ts
+++ b/packages/framework-core/src/booster-data-migrations.ts
@@ -34,7 +34,7 @@ export class BoosterDataMigrations {
         BoosterDataMigrationEntity.name,
         configuredMigration.class.name
       )
-      if (migrationEntityForConfiguredMigration === null) {
+      if (migrationEntityForConfiguredMigration === undefined) {
         logger.debug('Not found running or finished migrations for the DataMigration', configuredMigration)
         migrating = true
         await BoosterDataMigrations.migrate(configuredMigration)

--- a/packages/framework-core/src/booster-event-dispatcher.ts
+++ b/packages/framework-core/src/booster-event-dispatcher.ts
@@ -38,9 +38,16 @@ export class BoosterEventDispatcher {
 
   private static eventProcessor(eventStore: EventStore, readModelStore: ReadModelStore): EventsStreamingCallback {
     return async (entityName, entityID, eventEnvelopes, config) => {
-      // TODO: Separate the snapshot creation/read-model generation from the event handling into two independent processes.
-      await BoosterEventDispatcher.snapshotAndUpdateReadModels(config, entityName, entityID, eventStore, readModelStore)
-      await BoosterEventDispatcher.dispatchEntityEventsToEventHandlers(eventEnvelopes, config)
+      await Promise.allSettled([
+        await BoosterEventDispatcher.snapshotAndUpdateReadModels(
+          config,
+          entityName,
+          entityID,
+          eventStore,
+          readModelStore
+        ),
+        await BoosterEventDispatcher.dispatchEntityEventsToEventHandlers(eventEnvelopes, config),
+      ])
     }
   }
 

--- a/packages/framework-core/src/booster-register-handler.ts
+++ b/packages/framework-core/src/booster-register-handler.ts
@@ -26,7 +26,7 @@ export class RegisterHandler {
       return
     }
 
-    return config.provider.events.store(
+    await config.provider.events.store(
       register.eventList.map((event) => RegisterHandler.wrapEvent(config, event, register)),
       config
     )
@@ -64,7 +64,6 @@ export class RegisterHandler {
       entityTypeName: entityTypeName,
       typeName: eventTypeName,
       value: event,
-      createdAt: new Date().toISOString(), // TODO: This could be overridden by the provider. We should not set it. Ensure all providers set it
     }
   }
 

--- a/packages/framework-core/src/booster-register-handler.ts
+++ b/packages/framework-core/src/booster-register-handler.ts
@@ -2,9 +2,9 @@ import {
   BOOSTER_SUPER_KIND,
   BoosterConfig,
   DOMAIN_SUPER_KIND,
-  EventEnvelope,
   EventInterface,
   Instance,
+  NonPersistedEventEnvelope,
   NotFoundError,
   Register,
   SuperKindType,
@@ -36,7 +36,11 @@ export class RegisterHandler {
     return RegisterHandler.handle(Booster.config, record)
   }
 
-  private static wrapEvent(config: BoosterConfig, event: Instance & EventInterface, register: Register): EventEnvelope {
+  private static wrapEvent(
+    config: BoosterConfig,
+    event: Instance & EventInterface,
+    register: Register
+  ): NonPersistedEventEnvelope {
     const eventTypeName = event.constructor.name
     const entityTypeName = RegisterHandler.getEntityTypeName(eventTypeName, event, config)
     if (!entityTypeName) {

--- a/packages/framework-core/src/schema-migrator.ts
+++ b/packages/framework-core/src/schema-migrator.ts
@@ -7,10 +7,11 @@ import {
   EntityInterface,
   EventInterface,
   InvalidVersionError,
+  EntitySnapshotEnvelope,
 } from '@boostercloud/framework-types'
 import { getLogger } from '@boostercloud/framework-common-helpers'
 
-type SchemaMigrableEnvelope = CommandEnvelope | EventEnvelope
+type SchemaMigrableEnvelope = CommandEnvelope | EventEnvelope | EntitySnapshotEnvelope
 type SchemaMigrableValue = CommandInterface | EventInterface | EntityInterface
 
 export class SchemaMigrator {

--- a/packages/framework-core/src/services/event-store.ts
+++ b/packages/framework-core/src/services/event-store.ts
@@ -152,12 +152,12 @@ export class EventStore {
     }
   }
 
-  private toBoosterEntityMigratedSnapshot(eventEnvelope: EventEnvelope): EntitySnapshotEnvelope {
+  private toBoosterEntityMigratedSnapshot(eventEnvelope: EventEnvelope): NonPersistedEntitySnapshotEnvelope {
     const logger = getLogger(this.config, 'EventStore#toBoosterEntityMigratedSnapshot')
     const value = eventEnvelope.value as BoosterEntityMigrated
     const entity = value.newEntity
     const className = value.newEntityName
-    const boosterMigratedSnapshot: EntitySnapshotEnvelope = {
+    const boosterMigratedSnapshot: NonPersistedEntitySnapshotEnvelope = {
       version: this.config.currentVersionFor(className),
       kind: 'snapshot',
       superKind: eventEnvelope.superKind,
@@ -166,7 +166,6 @@ export class EventStore {
       entityTypeName: className,
       typeName: className,
       value: entity,
-      createdAt: new Date().toISOString(),
       snapshottedEventCreatedAt: eventEnvelope.createdAt,
     }
     logger.debug('BoosterEntityMigrated result: ', boosterMigratedSnapshot)

--- a/packages/framework-core/src/services/raw-events-parser.ts
+++ b/packages/framework-core/src/services/raw-events-parser.ts
@@ -34,7 +34,7 @@ export class RawEventsParser {
       try {
         await callbackFn(entityTypeName, entityID, entityEnvelopes, config)
       } catch (e) {
-        logger.error('An error occurred while processing events', e)
+        logger.error(`An error occurred while processing events for entity ${entityTypeName} with ID ${entityID}`, e)
       }
     })
     // We use allSettled because we don't care if some of the processes fail

--- a/packages/framework-core/src/services/read-model-store.ts
+++ b/packages/framework-core/src/services/read-model-store.ts
@@ -2,7 +2,6 @@
 import {
   BoosterConfig,
   ReadModelInterface,
-  EventEnvelope,
   ProjectionMetadata,
   UUID,
   EntityInterface,
@@ -10,6 +9,7 @@ import {
   OptimisticConcurrencyUnexpectedVersionError,
   SequenceKey,
   ProjectionGlobalError,
+  EntitySnapshotEnvelope,
 } from '@boostercloud/framework-types'
 import { Promises, retryIfError, createInstance, getLogger } from '@boostercloud/framework-common-helpers'
 import { BoosterGlobalErrorDispatcher } from '../booster-global-error-dispatcher'
@@ -18,7 +18,7 @@ import { ReadModelSchemaMigrator } from '../read-model-schema-migrator'
 export class ReadModelStore {
   public constructor(readonly config: BoosterConfig) {}
 
-  public async project(entitySnapshotEnvelope: EventEnvelope): Promise<void> {
+  public async project(entitySnapshotEnvelope: EntitySnapshotEnvelope): Promise<void> {
     const logger = getLogger(this.config, 'ReadModelStore#project')
     const projections = this.config.projections[entitySnapshotEnvelope.entityTypeName]
     if (!projections) {

--- a/packages/framework-core/test/booster-event-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-event-dispatcher.test.ts
@@ -65,7 +65,8 @@ const someEntitySnapshot: EntitySnapshotEnvelope = {
   value: someEntity,
   requestID: '234',
   typeName: 'SomeEntity',
-  createdAt: 'a few nanoseconds later',
+  createdAt: 'an uncertain future',
+  persistedAt: 'a few nanoseconds later',
   snapshottedEventCreatedAt: 'an uncertain future',
 }
 

--- a/packages/framework-core/test/booster-event-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-event-dispatcher.test.ts
@@ -4,12 +4,13 @@ import { BoosterEventDispatcher } from '../src/booster-event-dispatcher'
 import { fake, replace, restore, createStubInstance } from 'sinon'
 import {
   BoosterConfig,
-  EventEnvelope,
+  EntitySnapshotEnvelope,
   UUID,
   EntityInterface,
   ProviderLibrary,
   Register,
   EventInterface,
+  NonPersistedEventEnvelope,
 } from '@boostercloud/framework-types'
 import { expect } from './expect'
 import { RawEventsParser } from '../src/services/raw-events-parser'
@@ -34,7 +35,7 @@ class AnEventHandler {
     event.getPrefixedId('prefix')
   }
 }
-const someEvent: EventEnvelope = {
+const someEvent: NonPersistedEventEnvelope = {
   version: 1,
   kind: 'event',
   superKind: 'domain',
@@ -55,7 +56,7 @@ const someEntity: EntityInterface = {
   id: '42',
 }
 
-const someEntitySnapshot: EventEnvelope = {
+const someEntitySnapshot: EntitySnapshotEnvelope = {
   version: 1,
   kind: 'snapshot',
   superKind: 'domain',
@@ -65,6 +66,8 @@ const someEntitySnapshot: EventEnvelope = {
   requestID: '234',
   typeName: 'SomeEntity',
   createdAt: 'a few nanoseconds later',
+  snapshottedEventCreatedAt: 'an uncertain future',
+  snapshottedEventPersistedAt: 'a certain future',
 }
 
 describe('BoosterEventDispatcher', () => {

--- a/packages/framework-core/test/booster-event-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-event-dispatcher.test.ts
@@ -31,6 +31,7 @@ class SomeEvent {
 }
 
 class AnEventHandler {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public static async handle(event: SomeEvent, register: Register): Promise<void> {
     event.getPrefixedId('prefix')
   }
@@ -49,7 +50,6 @@ const someEvent: NonPersistedEventEnvelope = {
   },
   requestID: '123',
   typeName: 'SomeEvent',
-  createdAt: 'an uncertain future',
 }
 
 const someEntity: EntityInterface = {
@@ -67,7 +67,6 @@ const someEntitySnapshot: EntitySnapshotEnvelope = {
   typeName: 'SomeEntity',
   createdAt: 'a few nanoseconds later',
   snapshottedEventCreatedAt: 'an uncertain future',
-  snapshottedEventPersistedAt: 'a certain future',
 }
 
 describe('BoosterEventDispatcher', () => {

--- a/packages/framework-core/test/booster-global-error-dispatcher.test.ts
+++ b/packages/framework-core/test/booster-global-error-dispatcher.test.ts
@@ -4,7 +4,7 @@ import {
   CommandEnvelope,
   CommandHandlerGlobalError,
   EntityInterface,
-  EventEnvelope,
+  EntitySnapshotEnvelope,
   EventHandlerGlobalError,
   EventInterface,
   GlobalErrorContainer,
@@ -179,12 +179,15 @@ describe('BoosterGlobalErrorDispatcher', () => {
   it('should dispatch SnapshotPersistHandlerGlobalError', async () => {
     @GlobalErrorHandler()
     class ErrorHandler {
-      public static async onSnapshotPersistError(error: Error, snapshot: EventEnvelope): Promise<Error | undefined> {
+      public static async onSnapshotPersistError(
+        error: Error,
+        snapshot: EntitySnapshotEnvelope
+      ): Promise<Error | undefined> {
         return new Error(`${error}.onSnapshotPersistError`)
       }
     }
-    const mockEvent = {} as EventEnvelope
-    const snapshotPersistHandlerGlobalError = new SnapshotPersistHandlerGlobalError(mockEvent, baseError)
+    const mockSnapshot = {} as EntitySnapshotEnvelope
+    const snapshotPersistHandlerGlobalError = new SnapshotPersistHandlerGlobalError(mockSnapshot, baseError)
     config.globalErrorsHandler = { class: ErrorHandler } as GlobalErrorHandlerMetadata
     const errorDispatcher = new BoosterGlobalErrorDispatcher(config)
     const result = await errorDispatcher.dispatch(snapshotPersistHandlerGlobalError)

--- a/packages/framework-core/test/booster-register-handler.test.ts
+++ b/packages/framework-core/test/booster-register-handler.test.ts
@@ -90,7 +90,6 @@ describe('the `RegisterHandler` class', () => {
     expect(config.provider.events.store).to.have.been.calledWithMatch(
       [
         {
-          createdAt: 'just the right time',
           currentUser: undefined,
           entityID: '42',
           entityTypeName: 'SomeEntity',
@@ -102,7 +101,6 @@ describe('the `RegisterHandler` class', () => {
           version: 1,
         },
         {
-          createdAt: 'just the right time',
           currentUser: undefined,
           entityID: '42',
           entityTypeName: 'SomeEntity',
@@ -131,7 +129,6 @@ describe('the `RegisterHandler` class', () => {
     }
     const register = new Register('1234', {} as any, RegisterHandler.flush, user)
     const event = new SomeEvent('a')
-    replace(Date.prototype, 'toISOString', fake.returns('right here, right now!'))
 
     const registerHandler = RegisterHandler as any
     expect(registerHandler.wrapEvent(config, event, register)).to.deep.equal({
@@ -142,7 +139,6 @@ describe('the `RegisterHandler` class', () => {
       requestID: '1234',
       entityTypeName: 'SomeEntity',
       value: event,
-      createdAt: 'right here, right now!',
       currentUser: user,
       typeName: 'SomeEvent',
     })
@@ -162,7 +158,6 @@ describe('the `RegisterHandler` class', () => {
     const register = new Register('1234', {}, RegisterHandler.flush, user)
     const someEntity = new SomeEntity('42')
     const event = new BoosterEntityMigrated('oldEntity', 'oldEntityId', 'newEntityName', someEntity)
-    replace(Date.prototype, 'toISOString', fake.returns('right here, right now!'))
 
     const registerHandler = RegisterHandler as any
     expect(registerHandler.wrapEvent(config, event, register)).to.deep.equal({
@@ -173,7 +168,6 @@ describe('the `RegisterHandler` class', () => {
       entityID: 'oldEntityId',
       requestID: '1234',
       value: event,
-      createdAt: 'right here, right now!',
       currentUser: user,
       typeName: 'BoosterEntityMigrated',
     })

--- a/packages/framework-core/test/services/event-store.test.ts
+++ b/packages/framework-core/test/services/event-store.test.ts
@@ -880,7 +880,6 @@ describe('EventStore', () => {
             }
 
             const newSnapshot = await eventStore.entityReducer(eventEnvelope, snapshot)
-            delete newSnapshot.createdAt
 
             expect(newSnapshot).to.be.deep.equal({
               version: 1,

--- a/packages/framework-core/test/services/raw-events-parser.test.ts
+++ b/packages/framework-core/test/services/raw-events-parser.test.ts
@@ -172,7 +172,8 @@ function createEntitySnapshotEnvelope(entityTypeName: string, entityID: string):
     value: { id: random.uuid() },
     requestID: random.uuid(),
     typeName: 'Snapshot' + random.alpha(),
-    createdAt: random.alpha(),
+    createdAt: snapshottedEventCreatedAt,
+    persistedAt: random.alpha(),
     snapshottedEventCreatedAt,
   }
 }

--- a/packages/framework-core/test/services/raw-events-parser.test.ts
+++ b/packages/framework-core/test/services/raw-events-parser.test.ts
@@ -158,7 +158,6 @@ function createPersistedEventEnvelope(entityTypeName: string, entityID: string):
     requestID: random.uuid(),
     typeName: 'Event' + random.alpha(),
     createdAt,
-    persistedAt: createdAt + '1',
   }
 }
 
@@ -175,6 +174,5 @@ function createEntitySnapshotEnvelope(entityTypeName: string, entityID: string):
     typeName: 'Snapshot' + random.alpha(),
     createdAt: random.alpha(),
     snapshottedEventCreatedAt,
-    snapshottedEventPersistedAt: snapshottedEventCreatedAt + '1',
   }
 }

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -170,7 +170,8 @@ describe('ReadModelStore', () => {
       } as any,
       requestID: 'whatever',
       typeName: entityName,
-      createdAt: new Date().toISOString(),
+      createdAt: snapshottedEventCreatedAt,
+      persistedAt: new Date().toISOString(),
       snapshottedEventCreatedAt,
     }
   }
@@ -188,6 +189,7 @@ describe('ReadModelStore', () => {
           requestID: 'whatever',
           typeName: AnImportantEntity.name,
           createdAt: new Date().toISOString(),
+          persistedAt: new Date().toISOString(),
           snapshottedEventCreatedAt: new Date().toISOString(),
         }
 

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -6,7 +6,6 @@ import { createInstance } from '@boostercloud/framework-common-helpers'
 import {
   Level,
   BoosterConfig,
-  EventEnvelope,
   UUID,
   ProviderLibrary,
   ReadModelAction,
@@ -14,6 +13,7 @@ import {
   ProjectionResult,
   ReadModelInterface,
   ProjectionMetadata,
+  EntitySnapshotEnvelope,
 } from '@boostercloud/framework-types'
 import { expect } from '../expect'
 import { BoosterAuthorizer } from '../../src/booster-authorizer'
@@ -150,11 +150,14 @@ describe('ReadModelStore', () => {
     } as ProjectionMetadata<any>,
   ]
 
-  function eventEnvelopeFor(entityName: string): EventEnvelope {
+  function entitySnapshotEnvelopeFor(entityName: string): EntitySnapshotEnvelope {
     let someKeyValue: any = 'joinColumnID'
     if (AnImportantEntityWithArray.name == entityName) {
       someKeyValue = ['joinColumnID', 'anotherJoinColumnID']
     }
+    const snapshottedEventCreatedAtDate = new Date()
+    const snapshottedEventCreatedAt = snapshottedEventCreatedAtDate.toISOString()
+    const snapshottedEventPersistedAt = new Date(snapshottedEventCreatedAtDate.getTime() + 1000).toISOString()
     return {
       version: 1,
       kind: 'snapshot',
@@ -169,13 +172,15 @@ describe('ReadModelStore', () => {
       requestID: 'whatever',
       typeName: entityName,
       createdAt: new Date().toISOString(),
+      snapshottedEventCreatedAt,
+      snapshottedEventPersistedAt,
     }
   }
 
   describe('the `project` method', () => {
     context('when the entity class has no projections', () => {
       it('returns without errors and without performing any actions', async () => {
-        const entitySnapshotWithNoProjections: EventEnvelope = {
+        const entitySnapshotWithNoProjections: EntitySnapshotEnvelope = {
           version: 1,
           kind: 'snapshot',
           superKind: 'domain',
@@ -185,6 +190,8 @@ describe('ReadModelStore', () => {
           requestID: 'whatever',
           typeName: AnImportantEntity.name,
           createdAt: new Date().toISOString(),
+          snapshottedEventCreatedAt: new Date().toISOString(),
+          snapshottedEventPersistedAt: new Date().toISOString(),
         }
 
         replace(config.provider.readModels, 'store', fake())
@@ -209,7 +216,7 @@ describe('ReadModelStore', () => {
         )
         const readModelStore = new ReadModelStore(config)
 
-        await readModelStore.project(eventEnvelopeFor(AnImportantEntity.name))
+        await readModelStore.project(entitySnapshotEnvelopeFor(AnImportantEntity.name))
         expect(config.provider.readModels.store).not.to.have.been.called
         expect(config.provider.readModels.delete).to.have.been.calledThrice
       })
@@ -226,7 +233,7 @@ describe('ReadModelStore', () => {
         )
         const readModelStore = new ReadModelStore(config)
 
-        await readModelStore.project(eventEnvelopeFor(AnImportantEntity.name))
+        await readModelStore.project(entitySnapshotEnvelopeFor(AnImportantEntity.name))
         expect(config.provider.readModels.store).not.to.have.been.called
         expect(config.provider.readModels.delete).not.to.have.been.called
       })
@@ -239,10 +246,10 @@ describe('ReadModelStore', () => {
         replace(readModelStore, 'fetchReadModel', fake.returns(null))
         spy(SomeReadModel, 'someObserver')
         spy(AnotherReadModel, 'anotherObserver')
-        const entityValue: any = eventEnvelopeFor(AnImportantEntity.name).value
+        const entityValue: any = entitySnapshotEnvelopeFor(AnImportantEntity.name).value
         const anEntityInstance = new AnImportantEntity(entityValue.id, entityValue.someKey, entityValue.count)
 
-        await readModelStore.project(eventEnvelopeFor(AnImportantEntity.name))
+        await readModelStore.project(entitySnapshotEnvelopeFor(AnImportantEntity.name))
 
         expect(readModelStore.fetchReadModel).to.have.been.calledThrice
         expect(readModelStore.fetchReadModel).to.have.been.calledWith(SomeReadModel.name, 'joinColumnID')
@@ -311,7 +318,7 @@ describe('ReadModelStore', () => {
         )
         spy(SomeReadModel, 'someObserver')
         spy(AnotherReadModel, 'anotherObserver')
-        const anEntitySnapshot = eventEnvelopeFor(AnImportantEntity.name)
+        const anEntitySnapshot = entitySnapshotEnvelopeFor(AnImportantEntity.name)
         const entityValue: any = anEntitySnapshot.value
         const anEntityInstance = new AnImportantEntity(entityValue.id, entityValue.someKey, entityValue.count)
         await readModelStore.project(anEntitySnapshot)
@@ -374,7 +381,7 @@ describe('ReadModelStore', () => {
         const readModelStore = new ReadModelStore(config)
         const getPrefixedKeyFake = fake()
         replace(AnImportantEntity.prototype, 'getPrefixedKey', getPrefixedKeyFake)
-        await readModelStore.project(eventEnvelopeFor(AnImportantEntity.name))
+        await readModelStore.project(entitySnapshotEnvelopeFor(AnImportantEntity.name))
         expect(getPrefixedKeyFake).to.have.been.called
       })
     })
@@ -385,7 +392,7 @@ describe('ReadModelStore', () => {
         replace(config.provider.readModels, 'fetch', fake.returns([{ id: 'joinColumnID', count: 31415 }]))
         const getIdFake = fake()
         replace(SomeReadModel.prototype, 'getId', getIdFake)
-        await readModelStore.project(eventEnvelopeFor(AnEntity.name))
+        await readModelStore.project(entitySnapshotEnvelopeFor(AnEntity.name))
         expect(getIdFake).to.have.been.called
       })
     })
@@ -403,7 +410,7 @@ describe('ReadModelStore', () => {
         })
         replace(config.provider.readModels, 'store', fakeStore)
         const readModelStore = new ReadModelStore(config)
-        await readModelStore.project(eventEnvelopeFor(AnImportantEntity.name))
+        await readModelStore.project(entitySnapshotEnvelopeFor(AnImportantEntity.name))
 
         const someReadModelStoreCalls = fakeStore.getCalls().filter((call) => call.args[1] === SomeReadModel.name)
         expect(someReadModelStoreCalls).to.be.have.length(expectedTries)
@@ -444,7 +451,7 @@ describe('ReadModelStore', () => {
         )
         spy(SomeReadModel, 'someObserver')
         spy(SomeReadModel, 'someObserverArray')
-        const anEntitySnapshot = eventEnvelopeFor(AnImportantEntityWithArray.name)
+        const anEntitySnapshot = entitySnapshotEnvelopeFor(AnImportantEntityWithArray.name)
         const entityValue: any = anEntitySnapshot.value
         const anEntityInstance = new AnImportantEntityWithArray(entityValue.id, entityValue.someKey, entityValue.count)
         await readModelStore.project(anEntitySnapshot)
@@ -521,7 +528,7 @@ describe('ReadModelStore', () => {
         replace(config.provider.readModels, 'store', fakeStore)
 
         const readModelStore = new ReadModelStore(config)
-        await readModelStore.project(eventEnvelopeFor(AnImportantEntityWithArray.name))
+        await readModelStore.project(entitySnapshotEnvelopeFor(AnImportantEntityWithArray.name))
 
         const someReadModelStoreCalls = fakeStore.getCalls().filter((call) => call.args[1] === SomeReadModel.name)
         expect(someReadModelStoreCalls).to.be.have.length(expectedJoinColumnIDTries + expectedAnotherJoinColumnIDTries)
@@ -568,7 +575,7 @@ describe('ReadModelStore', () => {
       })
 
       it('applies the projections with the right sequenceMetadata', async () => {
-        const anEntitySnapshot = eventEnvelopeFor(AnImportantEntity.name)
+        const anEntitySnapshot = entitySnapshotEnvelopeFor(AnImportantEntity.name)
         const anEntityInstance = createInstance(AnImportantEntity, anEntitySnapshot.value) as any
         const readModelStore = new ReadModelStore(config)
         const fakeApplyProjectionToReadModel = fake()
@@ -662,7 +669,7 @@ describe('ReadModelStore', () => {
   describe('the `joinKeyForProjection` private method', () => {
     context('when the joinKey exists', () => {
       it('returns the joinKey value', () => {
-        const anEntitySnapshot = eventEnvelopeFor(AnImportantEntity.name)
+        const anEntitySnapshot = entitySnapshotEnvelopeFor(AnImportantEntity.name)
         const anEntityInstance = createInstance(AnImportantEntity, anEntitySnapshot.value) as any
         const readModelStore = new ReadModelStore(config) as any
 
@@ -674,7 +681,7 @@ describe('ReadModelStore', () => {
 
     context('when the joinkey does not exist', () => {
       it('should not throw and error an skip', () => {
-        const anEntitySnapshot = eventEnvelopeFor(AnImportantEntity.name)
+        const anEntitySnapshot = entitySnapshotEnvelopeFor(AnImportantEntity.name)
         const anEntityInstance = createInstance(AnImportantEntity, anEntitySnapshot.value) as any
         const readModelStore = new ReadModelStore(config) as any
         expect(readModelStore.joinKeyForProjection(anEntityInstance, { joinKey: 'whatever' })).to.be.undefined
@@ -685,7 +692,7 @@ describe('ReadModelStore', () => {
   describe('the `sequenceKeyForProjection` private method', () => {
     context('when there is no sequence key for the read model in the config', () => {
       it('returns undefined', () => {
-        const anEntitySnapshot = eventEnvelopeFor(AnImportantEntity.name)
+        const anEntitySnapshot = entitySnapshotEnvelopeFor(AnImportantEntity.name)
         const anEntityInstance = createInstance(AnImportantEntity, anEntitySnapshot.value) as any
         const readModelStore = new ReadModelStore(config) as any
 
@@ -703,7 +710,7 @@ describe('ReadModelStore', () => {
       })
 
       it('returns a `SequenceMetadata`object with the right sequenceKeyName and sequenceValue values', () => {
-        const anEntitySnapshot = eventEnvelopeFor(AnImportantEntity.name)
+        const anEntitySnapshot = entitySnapshotEnvelopeFor(AnImportantEntity.name)
         const anEntityInstance = createInstance(AnImportantEntity, anEntitySnapshot.value) as any
         const readModelStore = new ReadModelStore(config) as any
 

--- a/packages/framework-core/test/services/read-model-store.test.ts
+++ b/packages/framework-core/test/services/read-model-store.test.ts
@@ -157,7 +157,6 @@ describe('ReadModelStore', () => {
     }
     const snapshottedEventCreatedAtDate = new Date()
     const snapshottedEventCreatedAt = snapshottedEventCreatedAtDate.toISOString()
-    const snapshottedEventPersistedAt = new Date(snapshottedEventCreatedAtDate.getTime() + 1000).toISOString()
     return {
       version: 1,
       kind: 'snapshot',
@@ -173,7 +172,6 @@ describe('ReadModelStore', () => {
       typeName: entityName,
       createdAt: new Date().toISOString(),
       snapshottedEventCreatedAt,
-      snapshottedEventPersistedAt,
     }
   }
 
@@ -191,7 +189,6 @@ describe('ReadModelStore', () => {
           typeName: AnImportantEntity.name,
           createdAt: new Date().toISOString(),
           snapshottedEventCreatedAt: new Date().toISOString(),
-          snapshottedEventPersistedAt: new Date().toISOString(),
         }
 
         replace(config.provider.readModels, 'store', fake())

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -18,7 +18,7 @@ export const Provider = (rockets?: RocketDescriptor[]): ProviderLibrary => {
     const { Provider } = require('./setup')
     return Provider(rockets)
   } catch (e) {
-    // This only happens when running the project locally, where the dependency is not needed
+    // This only happens when running the project from an environment where the dependency is not needed
     return {} as ProviderLibrary
   }
 }

--- a/packages/framework-provider-aws/src/index.ts
+++ b/packages/framework-provider-aws/src/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ProviderInfrastructure, ProviderLibrary, RocketDescriptor } from '@boostercloud/framework-types'
-import { requestFailed, requestSucceeded } from './library/api-gateway-io'
+import { ProviderLibrary, RocketDescriptor } from '@boostercloud/framework-types'
 
 /**
  * `Provider` is a function that accepts a list of rocket names and returns an
@@ -10,56 +9,17 @@ import { requestFailed, requestSucceeded } from './library/api-gateway-io'
  */
 export const Provider = (rockets?: RocketDescriptor[]): ProviderLibrary => {
   try {
+    /**
+     * We try to load the AWS SDK dynamically here because it is not included in the
+     * production dependencies. Notice that this package is always present in AWS Lambda
+     * environments and is not needed in any other environment.
+     */
     require('aws-sdk')
     const { Provider } = require('./setup')
     return Provider(rockets)
   } catch (e) {
-    return {
-      // ProviderEventsLibrary
-      events: {
-        rawToEnvelopes: undefined as any,
-        forEntitySince: undefined as any,
-        latestEntitySnapshot: undefined as any,
-        store: undefined as any,
-        search: undefined as any,
-        searchEntitiesIDs: undefined as any,
-      },
-      // ProviderReadModelsLibrary
-      readModels: {
-        rawToEnvelopes: undefined as any,
-        fetch: undefined as any,
-        search: undefined as any,
-        store: undefined as any,
-        delete: undefined as any,
-        subscribe: undefined as any,
-        fetchSubscriptions: undefined as any,
-        deleteSubscription: undefined as any,
-        deleteAllSubscriptions: undefined as any,
-      },
-      // ProviderGraphQLLibrary
-      graphQL: {
-        rawToEnvelope: undefined as any,
-        handleResult: undefined as any,
-      },
-      // ProviderAPIHandling
-      api: {
-        requestSucceeded,
-        requestFailed,
-      },
-      connections: {
-        storeData: undefined as any,
-        fetchData: undefined as any,
-        deleteData: undefined as any,
-        sendMessage: undefined as any,
-      },
-      // ScheduledCommandsLibrary
-      scheduled: {
-        rawToEnvelope: undefined as any,
-      },
-      // ProviderInfrastructureGetter
-      infrastructure: () =>
-        require(require('../package.json').name + '-infrastructure').Infrastructure as ProviderInfrastructure,
-    }
+    // This only happens when running the project locally, where the dependency is not needed
+    return {} as ProviderLibrary
   }
 }
 

--- a/packages/framework-provider-aws/src/library/events-adapter.ts
+++ b/packages/framework-provider-aws/src/library/events-adapter.ts
@@ -129,6 +129,7 @@ export async function storeSnapshot(
     const persistableSnapshot = {
       ...snapshotEnvelope,
       createdAt: snapshotEnvelope.snapshottedEventCreatedAt,
+      persistedAt: new Date().toISOString(),
     }
     await dynamoDB
       .put({

--- a/packages/framework-provider-aws/src/library/events-adapter.ts
+++ b/packages/framework-provider-aws/src/library/events-adapter.ts
@@ -91,7 +91,7 @@ export async function readEntityLatestSnapshot(
 
 export async function storeEvents(
   dynamoDB: DynamoDB.DocumentClient,
-  eventEnvelopes: Array<EventEnvelope>,
+  eventEnvelopes: Array<NonPersistedEventEnvelope>,
   config: BoosterConfig
 ): Promise<void> {
   const logger = getLogger(config, 'EventsAdapter#storeEvents')

--- a/packages/framework-provider-aws/src/library/keys-helper.ts
+++ b/packages/framework-provider-aws/src/library/keys-helper.ts
@@ -1,14 +1,17 @@
-import { EventEnvelope, UUID } from '@boostercloud/framework-types'
+import { EntitySnapshotEnvelope, EventEnvelope, UUID } from '@boostercloud/framework-types'
 
-export function partitionKeyForEvent(
-  entityTypeName: string,
-  entityID: UUID,
-  kind: EventEnvelope['kind'] = 'event'
-): string {
-  return `${entityTypeName}-${entityID}-${kind}`
+export function partitionKeyForEvent(entityTypeName: string, entityID: UUID): string {
+  return `${entityTypeName}-${entityID}-event`
 }
 
-export function partitionKeyForIndexByEntity(entityTypeName: string, kind: EventEnvelope['kind']): string {
+export function partitionKeyForEntitySnapshot(entityTypeName: string, entityID: UUID): string {
+  return `${entityTypeName}-${entityID}-snapshot`
+}
+
+export function partitionKeyForIndexByEntity(
+  entityTypeName: string,
+  kind: EventEnvelope['kind'] | EntitySnapshotEnvelope['kind']
+): string {
   return `${entityTypeName}-${kind}`
 }
 

--- a/packages/framework-provider-aws/src/setup.ts
+++ b/packages/framework-provider-aws/src/setup.ts
@@ -13,6 +13,7 @@ import {
   readEntityEventsSince,
   readEntityLatestSnapshot,
   storeEvents,
+  storeSnapshot,
 } from './library/events-adapter'
 import { searchEntitiesIds, searchEvents } from './library/events-searcher-adapter'
 import { rawGraphQLRequestToEnvelope } from './library/graphql-adapter'
@@ -61,8 +62,9 @@ export const Provider = (rockets?: RocketDescriptor[]): ProviderLibrary => {
       forEntitySince: readEntityEventsSince.bind(null, dynamoDB),
       latestEntitySnapshot: readEntityLatestSnapshot.bind(null, dynamoDB),
       search: searchEvents.bind(null, dynamoDB),
-      store: storeEvents.bind(null, dynamoDB),
       searchEntitiesIDs: searchEntitiesIds.bind(null, dynamoDB),
+      store: storeEvents.bind(null, dynamoDB),
+      storeSnapshot: storeSnapshot.bind(null, dynamoDB),
     },
     // ProviderReadModelsLibrary
     readModels: {

--- a/packages/framework-provider-aws/test/index.test.ts
+++ b/packages/framework-provider-aws/test/index.test.ts
@@ -17,35 +17,16 @@ describe('the `framework-provider-aws` package', (): void => {
     afterEach(() => {
       restore()
     })
+
     context('with no rockets', () => {
-      it('returns a `ProviderLibrary` undefined when DynamoDB is undefined', () => {
+      it('returns an empty `ProviderLibrary` when DynamoDB is undefined', () => {
         stub(awsSdk, 'DynamoDB').returns(undefined)
         const providerLibrary: ProviderLibrary = providerPackage.Provider()
-        expect(providerLibrary.events.rawToEnvelopes).to.be.undefined
-        expect(providerLibrary.events.forEntitySince).to.be.undefined
-        expect(providerLibrary.events.latestEntitySnapshot).to.be.undefined
-        expect(providerLibrary.events.store).to.be.undefined
-        expect(providerLibrary.events.search).to.be.undefined
-      })
-      it('returns a `ProviderLibrary` object', () => {
-        const providerLibrary: ProviderLibrary = providerPackage.Provider()
         expect(providerLibrary).to.be.an('object')
-        expect(providerLibrary.api).to.be.an('object')
-        expect(providerLibrary.connections).to.be.an('object')
-        expect(providerLibrary.events).to.be.an('object')
-        expect(providerLibrary.graphQL).to.be.an('object')
-        expect(providerLibrary.infrastructure).to.be.a('function')
-        expect(providerLibrary.readModels).to.be.an('object')
-        expect(providerLibrary.events.search).to.be.not.undefined
-      })
-      describe('infrastructure', () => {
-        it('is loaded with no parameters', () => {
-          const providerLibrary: ProviderLibrary = providerPackageSetup.Provider()
-          providerLibrary.infrastructure()
-          expect(fakeInfrastructure).to.have.been.calledWith()
-        })
+        expect(providerLibrary).to.deep.equal({})
       })
     })
+
     context('with a list of rockets', () => {
       const rockets = [
         {

--- a/packages/framework-provider-aws/test/library/events-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/events-adapter.test.ts
@@ -117,7 +117,6 @@ describe('the events-adapter', () => {
           value: {
             entityID: e.entityID,
           },
-          createdAt: new Date().toISOString(),
         }
       })
 
@@ -161,7 +160,6 @@ function buildEventEnvelopes(): Array<NonPersistedEventEnvelope> {
       typeName: 'EventName',
       entityTypeName: 'EntityName',
       requestID: 'requestID',
-      createdAt: 'once',
     },
     {
       version: 1,
@@ -174,7 +172,6 @@ function buildEventEnvelopes(): Array<NonPersistedEventEnvelope> {
       typeName: 'EventName2',
       entityTypeName: 'EntityName2',
       requestID: 'requestID2',
-      createdAt: 'once upon a time',
     },
   ]
 }

--- a/packages/framework-provider-aws/test/library/events-search-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/events-search-adapter.test.ts
@@ -3,11 +3,11 @@ import { expect } from '../expect'
 import { createStubInstance, restore, SinonStubbedInstance, fake, replace } from 'sinon'
 import {
   BoosterConfig,
-  EventEnvelope,
   EventParametersFilterByEntity,
   EventParametersFilterByType,
   EventSearchParameters,
   EventSearchResponse,
+  NonPersistedEventEnvelope,
 } from '@boostercloud/framework-types'
 import { random, date } from 'faker'
 import { DynamoDB } from 'aws-sdk'
@@ -15,7 +15,8 @@ import { searchEvents } from '../../src/library/events-searcher-adapter'
 import { eventsStoreAttributes } from '../../src'
 import { partitionKeyForEvent, partitionKeyForIndexByEntity } from '../../src/library/keys-helper'
 import { DocumentClient } from 'aws-sdk/clients/dynamodb'
-import rewire = require('rewire')
+
+const rewire = require('rewire')
 
 describe('Events searcher adapter', () => {
   const config: BoosterConfig = new BoosterConfig('test')
@@ -259,7 +260,7 @@ describe('Events searcher adapter', () => {
       const occurredThirdDate = date.recent(),
         occurredSecondDate = date.recent(10, occurredThirdDate),
         occurredFirstDate = date.recent(10, occurredSecondDate)
-      const unsortedResult: Array<EventEnvelope> = [
+      const unsortedResult: Array<NonPersistedEventEnvelope> = [
         buildEventEnvelope(occurredThirdID, occurredThirdDate.toISOString()),
         buildEventEnvelope(occurredFirstID, occurredFirstDate.toISOString()),
         buildEventEnvelope(occurredSecondID, occurredSecondDate.toISOString()),
@@ -296,7 +297,7 @@ describe('Events searcher adapter', () => {
   }
 })
 
-function buildEventEnvelope(id: string, createdAt: string): EventEnvelope {
+function buildEventEnvelope(id: string, createdAt: string): NonPersistedEventEnvelope {
   return {
     entityID: id,
     createdAt,

--- a/packages/framework-provider-aws/test/library/events-search-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/events-search-adapter.test.ts
@@ -3,6 +3,7 @@ import { expect } from '../expect'
 import { createStubInstance, restore, SinonStubbedInstance, fake, replace } from 'sinon'
 import {
   BoosterConfig,
+  EventEnvelope,
   EventParametersFilterByEntity,
   EventParametersFilterByType,
   EventSearchParameters,
@@ -297,7 +298,7 @@ describe('Events searcher adapter', () => {
   }
 })
 
-function buildEventEnvelope(id: string, createdAt: string): NonPersistedEventEnvelope {
+function buildEventEnvelope(id: string, createdAt: string): EventEnvelope {
   return {
     entityID: id,
     createdAt,

--- a/packages/framework-provider-aws/test/library/partition-keys.test.ts
+++ b/packages/framework-provider-aws/test/library/partition-keys.test.ts
@@ -1,17 +1,31 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from '../expect'
-import { partitionKeyForEvent, sortKeyForSubscription } from '../../src/library/keys-helper'
-import { EventEnvelope } from '@boostercloud/framework-types'
+import {
+  partitionKeyForEvent,
+  partitionKeyForEntitySnapshot,
+  sortKeyForSubscription,
+} from '../../src/library/keys-helper'
 import { lorem, random } from 'faker'
 
 describe('"partitionKeyForEvent" function', () => {
   it('returns a correctly formatted partition key', () => {
     const entityName = lorem.word()
     const entityID = random.uuid()
-    const kind: EventEnvelope['kind'] = 'snapshot'
 
-    const expected = `${entityName}-${entityID}-${kind}`
-    const got = partitionKeyForEvent(entityName, entityID, kind)
+    const expected = `${entityName}-${entityID}-event`
+    const got = partitionKeyForEvent(entityName, entityID)
+
+    expect(got).to.equal(expected)
+  })
+})
+
+describe('"partitionKeyForEntitySnapshot" function', () => {
+  it('returns a correctly formatted partition key', () => {
+    const entityName = lorem.word()
+    const entityID = random.uuid()
+
+    const expected = `${entityName}-${entityID}-snapshot`
+    const got = partitionKeyForEntitySnapshot(entityName, entityID)
 
     expect(got).to.equal(expected)
   })

--- a/packages/framework-provider-azure/src/index.ts
+++ b/packages/framework-provider-azure/src/index.ts
@@ -7,6 +7,7 @@ import {
   storeEvents,
   readEntityEventsSince,
   readEntityLatestSnapshot,
+  storeSnapshot,
 } from './library/events-adapter'
 import { CosmosClient } from '@azure/cosmos'
 import { environmentVarNames } from './constants'
@@ -35,6 +36,7 @@ export const Provider = (rockets?: RocketDescriptor[]): ProviderLibrary => ({
   events: {
     rawToEnvelopes: rawEventsToEnvelopes,
     store: storeEvents.bind(null, cosmosClient),
+    storeSnapshot: storeSnapshot.bind(null, cosmosClient),
     forEntitySince: readEntityEventsSince.bind(null, cosmosClient),
     latestEntitySnapshot: readEntityLatestSnapshot.bind(null, cosmosClient),
     search: searchEvents.bind(null, cosmosClient),

--- a/packages/framework-provider-azure/src/library/events-adapter.ts
+++ b/packages/framework-provider-azure/src/library/events-adapter.ts
@@ -177,6 +177,6 @@ export async function storeSnapshot(
     [eventsStoreAttributes.partitionKey]: partitionKey,
     [eventsStoreAttributes.sortKey]: sortKey,
   })
-  logger.debug('[EventsAdapter#storeSnapshot] Snapshot stored')
+  logger.debug('Snapshot stored', snapshotEnvelope)
   return persistableEntitySnapshot
 }

--- a/packages/framework-provider-azure/src/library/partition-keys.ts
+++ b/packages/framework-provider-azure/src/library/partition-keys.ts
@@ -1,11 +1,11 @@
 import { EventEnvelope, UUID } from '@boostercloud/framework-types'
 
-export function partitionKeyForEvent(
-  entityTypeName: string,
-  entityID: UUID,
-  kind: EventEnvelope['kind'] = 'event'
-): string {
-  return `${entityTypeName}-${entityID}-${kind}`
+export function partitionKeyForEvent(entityTypeName: string, entityID: UUID): string {
+  return `${entityTypeName}-${entityID}-'event`
+}
+
+export function partitionKeyForSnapshot(entityTypeName: string, entityID: UUID): string {
+  return `${entityTypeName}-${entityID}-'snapshot`
 }
 
 export function partitionKeyForIndexByEntity(entityTypeName: string, kind: EventEnvelope['kind']): string {

--- a/packages/framework-provider-azure/test/library/events-adapter.test.ts
+++ b/packages/framework-provider-azure/test/library/events-adapter.test.ts
@@ -5,7 +5,7 @@ import { createStubInstance, fake, restore, match, stub, SinonStubbedInstance } 
 import { BoosterConfig, EventEnvelope, UUID } from '@boostercloud/framework-types'
 import { CosmosClient } from '@azure/cosmos'
 import { eventsStoreAttributes } from '../../src/constants'
-import { partitionKeyForEvent } from '../../src/library/partition-keys'
+import { partitionKeyForEvent, partitionKeyForSnapshot } from '../../src/library/partition-keys'
 import { Context } from '@azure/functions'
 import { random } from 'faker'
 import {
@@ -109,7 +109,7 @@ describe('Events adapter', () => {
           parameters: [
             {
               name: '@partitionKey',
-              value: partitionKeyForEvent(mockEntityName, mockEntityId, 'snapshot'),
+              value: partitionKeyForSnapshot(mockEntityName, mockEntityId),
             },
           ],
         })
@@ -134,8 +134,7 @@ describe('Events adapter', () => {
           ...mockEvents[0],
           [eventsStoreAttributes.partitionKey]: partitionKeyForEvent(
             mockEvents[0].entityTypeName,
-            mockEvents[0].entityID,
-            mockEvents[0].kind
+            mockEvents[0].entityID
           ),
           [eventsStoreAttributes.sortKey]: match.defined,
         })

--- a/packages/framework-provider-kubernetes/src/index.ts
+++ b/packages/framework-provider-kubernetes/src/index.ts
@@ -32,6 +32,7 @@ export const Provider = (): ProviderLibrary => ({
   events: {
     rawToEnvelopes: EventsAdapter.rawToEnvelopes,
     store: EventsAdapter.store.bind(null, eventRegistry, userApp),
+    storeSnapshot: EventsAdapter.storeSnapshot.bind(null, eventRegistry),
     forEntitySince: EventsAdapter.forEntitySince.bind(null, eventRegistry),
     latestEntitySnapshot: EventsAdapter.latestEntitySnapshot.bind(null, eventRegistry),
     search: EventsAdapter.search.bind(null, eventRegistry),

--- a/packages/framework-provider-kubernetes/src/services/event-registry.ts
+++ b/packages/framework-provider-kubernetes/src/services/event-registry.ts
@@ -29,7 +29,7 @@ export class EventRegistry {
     logger.debug('About to post', event)
     const persistableEvent: EventEnvelope = {
       ...event,
-      persistedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
     }
     const data = [{ key: this.eventKey(persistableEvent), value: persistableEvent }]
     const response = await fetch(stateUrl, {
@@ -103,7 +103,7 @@ export class EventRegistry {
       event.entityID, // entityId
       event.kind, // 'event' | 'snapshot'
       event.typeName, // 'PostCreated' event name
-      event.persistedAt, // timespan
+      event.createdAt, // timespan
       UUID.generate(), // hash to make key unique
     ]
     return keyParts.join(RedisAdapter.keySeparator)
@@ -116,7 +116,7 @@ export class EventRegistry {
       snapshot.entityID, // entityId
       snapshot.kind, // 'event' | 'snapshot'
       snapshot.version, // snapshot version
-      snapshot.snapshottedEventPersistedAt, // timespan
+      snapshot.snapshottedEventCreatedAt, // timespan
       UUID.generate(), // hash to make key unique
     ]
     return keyParts.join(RedisAdapter.keySeparator)

--- a/packages/framework-provider-local/.vscode/launch.json
+++ b/packages/framework-provider-local/.vscode/launch.json
@@ -4,6 +4,7 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+  
     {
       "command": "rushx test",
       "name": "Unit Tests",

--- a/packages/framework-provider-local/src/index.ts
+++ b/packages/framework-provider-local/src/index.ts
@@ -4,6 +4,7 @@ import {
   readEntityEventsSince,
   readEntityLatestSnapshot,
   storeEvents,
+  storeSnapshot,
 } from './library/events-adapter'
 import { requestSucceeded, requestFailed } from './library/api-adapter'
 import { EventRegistry, ReadModelRegistry } from './services'
@@ -43,6 +44,7 @@ export const Provider = (rocketDescriptors?: RocketDescriptor[]): ProviderLibrar
     forEntitySince: readEntityEventsSince.bind(null, eventRegistry),
     latestEntitySnapshot: readEntityLatestSnapshot.bind(null, eventRegistry),
     store: storeEvents.bind(null, userApp, eventRegistry),
+    storeSnapshot: storeSnapshot.bind(null, eventRegistry),
     search: searchEvents.bind(null, eventRegistry),
     searchEntitiesIDs: searchEntitiesIds.bind(null, eventRegistry),
   },

--- a/packages/framework-provider-local/src/library/events-adapter.ts
+++ b/packages/framework-provider-local/src/library/events-adapter.ts
@@ -102,6 +102,7 @@ export async function storeSnapshot(
   const persistableEntitySnapshot = {
     ...snapshotEnvelope,
     createdAt: snapshotEnvelope.snapshottedEventCreatedAt,
+    persistedAt: new Date().toISOString(),
   }
   await retryIfError(() => eventRegistry.store(persistableEntitySnapshot), OptimisticConcurrencyUnexpectedVersionError)
   logger.debug('Snapshot stored')

--- a/packages/framework-provider-local/src/services/event-registry.ts
+++ b/packages/framework-provider-local/src/services/event-registry.ts
@@ -37,7 +37,7 @@ export class EventRegistry {
     const results = await new Promise<EventStoreEntryEnvelope[]>((resolve, reject) =>
       this.events
         .find({ ...query, kind: 'snapshot' })
-        .sort({ snapshottedEventPersistedAt: -1 }) // Sort in descending order (newer timestamps first)
+        .sort({ snapshottedEventCreatedAt: -1 }) // Sort in descending order (newer timestamps first)
         .exec((err, docs) => {
           if (err) reject(err)
           else resolve(docs)

--- a/packages/framework-provider-local/test/helpers/event-helper.ts
+++ b/packages/framework-provider-local/test/helpers/event-helper.ts
@@ -1,11 +1,14 @@
-import { EventEnvelope } from '@boostercloud/framework-types'
+import { EntitySnapshotEnvelope, EventEnvelope, NonPersistedEventEnvelope } from '@boostercloud/framework-types'
 import { random, date } from 'faker'
 
-export function createMockEventEnvelop(): EventEnvelope {
-  return createMockEventEnvelopForEntity(random.word(), random.uuid())
+export function createMockNonPersistedEventEnvelop(): NonPersistedEventEnvelope {
+  return createMockNonPersistedEventEnvelopeForEntity(random.word(), random.uuid())
 }
 
-export function createMockEventEnvelopForEntity(entityTypeName: string, entityID: string): EventEnvelope {
+export function createMockNonPersistedEventEnvelopeForEntity(
+  entityTypeName: string,
+  entityID: string
+): NonPersistedEventEnvelope {
   return {
     kind: 'event',
     superKind: 'domain',
@@ -21,12 +24,16 @@ export function createMockEventEnvelopForEntity(entityTypeName: string, entityID
   }
 }
 
-export function createMockSnapshot(): EventEnvelope {
+export function createMockEventEnvelope(): EventEnvelope {
+  return createMockEventEnvelopeForEntity(random.word(), random.uuid())
+}
+
+export function createMockEventEnvelopeForEntity(entityTypeName: string, entityID: string): EventEnvelope {
   return {
-    kind: 'snapshot',
+    kind: 'event',
     superKind: 'domain',
-    entityID: random.uuid(),
-    entityTypeName: random.word(),
+    entityID: entityID,
+    entityTypeName: entityTypeName,
     value: {
       id: random.uuid(),
     },
@@ -34,5 +41,27 @@ export function createMockSnapshot(): EventEnvelope {
     requestID: random.uuid(),
     typeName: random.word(),
     version: random.number(),
+    persistedAt: date.past().toISOString(),
+  }
+}
+
+export function createMockEntitySnapshotEnvelope(entityTypeName?: string, entityId?: string): EntitySnapshotEnvelope {
+  const creationDate = date.past()
+  const snapshottedEventCreatedAt = creationDate.toISOString()
+  const snapshottedEventPersistedAt = new Date(creationDate.getDate() + 1000).toISOString() // 1 second after creation date
+  return {
+    kind: 'snapshot',
+    superKind: 'domain',
+    entityID: entityId ?? random.uuid(),
+    entityTypeName: entityTypeName ?? random.word(),
+    value: {
+      id: random.uuid(),
+    },
+    createdAt: date.past().toISOString(),
+    requestID: random.uuid(),
+    typeName: random.word(),
+    version: random.number(),
+    snapshottedEventCreatedAt,
+    snapshottedEventPersistedAt,
   }
 }

--- a/packages/framework-provider-local/test/helpers/event-helper.ts
+++ b/packages/framework-provider-local/test/helpers/event-helper.ts
@@ -17,7 +17,6 @@ export function createMockNonPersistedEventEnvelopeForEntity(
     value: {
       id: random.uuid(),
     },
-    createdAt: date.past().toISOString(),
     requestID: random.uuid(),
     typeName: random.word(),
     version: random.number(),
@@ -41,14 +40,12 @@ export function createMockEventEnvelopeForEntity(entityTypeName: string, entityI
     requestID: random.uuid(),
     typeName: random.word(),
     version: random.number(),
-    persistedAt: date.past().toISOString(),
   }
 }
 
 export function createMockEntitySnapshotEnvelope(entityTypeName?: string, entityId?: string): EntitySnapshotEnvelope {
   const creationDate = date.past()
   const snapshottedEventCreatedAt = creationDate.toISOString()
-  const snapshottedEventPersistedAt = new Date(creationDate.getDate() + 1000).toISOString() // 1 second after creation date
   return {
     kind: 'snapshot',
     superKind: 'domain',
@@ -62,6 +59,5 @@ export function createMockEntitySnapshotEnvelope(entityTypeName?: string, entity
     typeName: random.word(),
     version: random.number(),
     snapshottedEventCreatedAt,
-    snapshottedEventPersistedAt,
   }
 }

--- a/packages/framework-provider-local/test/helpers/event-helper.ts
+++ b/packages/framework-provider-local/test/helpers/event-helper.ts
@@ -54,7 +54,8 @@ export function createMockEntitySnapshotEnvelope(entityTypeName?: string, entity
     value: {
       id: random.uuid(),
     },
-    createdAt: date.past().toISOString(),
+    createdAt: snapshottedEventCreatedAt,
+    persistedAt: new Date(creationDate.getTime() + 1000).toISOString(),
     requestID: random.uuid(),
     typeName: random.word(),
     version: random.number(),

--- a/packages/framework-provider-local/test/library/events-adapter.test.ts
+++ b/packages/framework-provider-local/test/library/events-adapter.test.ts
@@ -246,26 +246,26 @@ describe('events-adapter', () => {
     context('with event envelopes', () => {
       it('should call event registry store', async () => {
         const mockEventEnvelop = createMockNonPersistedEventEnvelop()
-        // The `persistedAt` will be set in the `persistEvent` method
+        // The `createdAt` will be set in the `persistEvent` method
         replace(Date.prototype, 'toISOString', () => 'a magical time')
 
         await storeEvents(mockUserApp, mockEventRegistry, [mockEventEnvelop], mockConfig)
 
         expect(storeStub).to.have.been.calledWithExactly({
           ...mockEventEnvelop,
-          persistedAt: 'a magical time',
+          createdAt: 'a magical time',
         })
       })
 
       it('should call userApp boosterEventDispatcher', async () => {
         const mockEventEnvelop = createMockNonPersistedEventEnvelop()
-        // The `persistedAt` will be set in the `persistEvent` method
+        // The `createdAt` will be set in the `persistEvent` method
         replace(Date.prototype, 'toISOString', () => 'a magical time')
 
         await storeEvents(mockUserApp, mockEventRegistry, [mockEventEnvelop], mockConfig)
 
         expect(boosterEventDispatcherStub).to.have.been.calledOnceWithExactly([
-          { ...mockEventEnvelop, persistedAt: 'a magical time' },
+          { ...mockEventEnvelop, createdAt: 'a magical time' },
         ])
       })
     })

--- a/packages/framework-provider-local/test/services/event-registry.test.ts
+++ b/packages/framework-provider-local/test/services/event-registry.test.ts
@@ -1,13 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { EventEnvelope } from '@boostercloud/framework-types'
+import { EventEnvelope, EntitySnapshotEnvelope } from '@boostercloud/framework-types'
 import { expect } from '../expect'
 import * as faker from 'faker'
 import { stub, restore } from 'sinon'
 import { EventRegistry } from '../../src/services'
-import { createMockEventEnvelope, createMockEventEnvelopeForEntity } from '../helpers/event-helper'
+import {
+  createMockEventEnvelope,
+  createMockEventEnvelopeForEntity,
+  createMockEntitySnapshotEnvelope,
+} from '../helpers/event-helper'
 import { date, random } from 'faker'
-import { createMockEntitySnapshotEnvelope } from '../helpers/event-helper';
-import { EntitySnapshotEnvelope } from '@boostercloud/framework-types';
 
 describe('the event registry', () => {
   let initialEventsCount: number
@@ -108,7 +110,7 @@ describe('the event registry', () => {
       newerMockDate = date.recent().toISOString()
       copyOfMockTargetSnapshot = {
         ...mockTargetSnapshot,
-        snapshottedEventPersistedAt: newerMockDate,
+        snapshottedEventCreatedAt: newerMockDate,
       }
       await eventRegistry.store(copyOfMockTargetSnapshot)
     })
@@ -172,7 +174,6 @@ describe('the event registry', () => {
         requestID: faker.random.uuid(),
         typeName: faker.random.word(),
         version: faker.random.number(),
-        persistedAt: faker.date.past().toISOString(),
       }
 
       const error = new Error(faker.random.words())

--- a/packages/framework-types/src/concepts/global-error-handler-metadata.ts
+++ b/packages/framework-types/src/concepts/global-error-handler-metadata.ts
@@ -1,5 +1,5 @@
 import { AnyClass } from '../typelevel'
-import { CommandEnvelope, EventEnvelope } from '../envelope'
+import { CommandEnvelope, EntitySnapshotEnvelope } from '../envelope'
 import { EventInterface } from './event'
 import { ReadModelInterface } from './read-model'
 import { EntityInterface } from './entity'
@@ -18,7 +18,7 @@ export interface GlobalErrorHandlerInterface extends AnyClass {
     entity: EntityInterface,
     readModel: ReadModelInterface | undefined
   ): Promise<Error | undefined>
-  onSnapshotPersistError?(error: Error, snapshot: EventEnvelope): Promise<Error | undefined>
+  onSnapshotPersistError?(error: Error, snapshot: EntitySnapshotEnvelope): Promise<Error | undefined>
   onError?(error: Error | undefined): Promise<Error | undefined>
 }
 

--- a/packages/framework-types/src/concepts/global-error-handler-metadata.ts
+++ b/packages/framework-types/src/concepts/global-error-handler-metadata.ts
@@ -1,5 +1,5 @@
 import { AnyClass } from '../typelevel'
-import { CommandEnvelope, EntitySnapshotEnvelope } from '../envelope'
+import { CommandEnvelope, NonPersistedEntitySnapshotEnvelope } from '../envelope'
 import { EventInterface } from './event'
 import { ReadModelInterface } from './read-model'
 import { EntityInterface } from './entity'
@@ -18,7 +18,7 @@ export interface GlobalErrorHandlerInterface extends AnyClass {
     entity: EntityInterface,
     readModel: ReadModelInterface | undefined
   ): Promise<Error | undefined>
-  onSnapshotPersistError?(error: Error, snapshot: EntitySnapshotEnvelope): Promise<Error | undefined>
+  onSnapshotPersistError?(error: Error, snapshot: NonPersistedEntitySnapshotEnvelope): Promise<Error | undefined>
   onError?(error: Error | undefined): Promise<Error | undefined>
 }
 

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -33,20 +33,22 @@ export interface EventStoreEntryEnvelope extends Envelope {
   entityID: UUID
   entityTypeName: string
   value: EventInterface | EntityInterface
-  createdAt: string
 }
 
 export interface NonPersistedEventEnvelope extends EventStoreEntryEnvelope {
   kind: 'event'
 }
 export interface EventEnvelope extends NonPersistedEventEnvelope {
-  persistedAt: string
+  createdAt: string
 }
 
-export interface EntitySnapshotEnvelope extends EventStoreEntryEnvelope {
+export interface NonPersistedEntitySnapshotEnvelope extends EventStoreEntryEnvelope {
   kind: 'snapshot'
   snapshottedEventCreatedAt: string
-  snapshottedEventPersistedAt: string
+}
+
+export interface EntitySnapshotEnvelope extends NonPersistedEntitySnapshotEnvelope {
+  createdAt: string
 }
 export interface EventSearchRequest extends Envelope {
   parameters: EventSearchParameters

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -26,18 +26,28 @@ export interface ScheduledCommandEnvelope extends Envelope {
 
 export type SuperKindType = 'domain' | 'notification' | 'booster'
 
-export interface EventEnvelope extends Envelope {
+interface EventStoreEntryEnvelope extends Envelope {
   typeName: string
   version: number
-  kind: 'event' | 'snapshot'
   superKind: SuperKindType
   entityID: UUID
   entityTypeName: string
   value: EventInterface | EntityInterface
   createdAt: string
-  snapshottedEventCreatedAt?: string
 }
 
+export interface NonPersistedEventEnvelope extends EventStoreEntryEnvelope {
+  kind: 'event'
+}
+export interface EventEnvelope extends NonPersistedEventEnvelope {
+  persistedAt: string
+}
+
+export interface EntitySnapshotEnvelope extends EventStoreEntryEnvelope {
+  kind: 'snapshot'
+  snapshottedEventCreatedAt: string
+  snapshottedEventPersistedAt: string
+}
 export interface EventSearchRequest extends Envelope {
   parameters: EventSearchParameters
 }

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -48,7 +48,10 @@ export interface NonPersistedEntitySnapshotEnvelope extends EventStoreEntryEnvel
 }
 
 export interface EntitySnapshotEnvelope extends NonPersistedEntitySnapshotEnvelope {
+  /** Logic creation date of the snapshot, it always matches the creation date of the latest event included in it. */
   createdAt: string
+  /** Time when this snapshot was actually persisted in the database. */
+  persistedAt: string
 }
 export interface EventSearchRequest extends Envelope {
   parameters: EventSearchParameters

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -26,7 +26,7 @@ export interface ScheduledCommandEnvelope extends Envelope {
 
 export type SuperKindType = 'domain' | 'notification' | 'booster'
 
-interface EventStoreEntryEnvelope extends Envelope {
+export interface EventStoreEntryEnvelope extends Envelope {
   typeName: string
   version: number
   superKind: SuperKindType

--- a/packages/framework-types/src/errors/snapshot-persist-handler-global-error.ts
+++ b/packages/framework-types/src/errors/snapshot-persist-handler-global-error.ts
@@ -1,5 +1,5 @@
 import { GlobalErrorContainer } from './global-error-container'
-import { EventEnvelope } from '../envelope'
+import { EntitySnapshotEnvelope } from '../envelope'
 
 /**
  * @deprecated Errors when persisting snapshots can be safely ignored because
@@ -12,7 +12,7 @@ import { EventEnvelope } from '../envelope'
  * This class is kept for backwards compatibility.
  */
 export class SnapshotPersistHandlerGlobalError extends GlobalErrorContainer {
-  constructor(readonly snapshot: EventEnvelope, originalError: Error) {
+  constructor(readonly snapshot: EntitySnapshotEnvelope, originalError: Error) {
     super(originalError)
   }
 }

--- a/packages/framework-types/src/errors/snapshot-persist-handler-global-error.ts
+++ b/packages/framework-types/src/errors/snapshot-persist-handler-global-error.ts
@@ -1,5 +1,5 @@
 import { GlobalErrorContainer } from './global-error-container'
-import { EntitySnapshotEnvelope } from '../envelope'
+import { NonPersistedEntitySnapshotEnvelope } from '../envelope'
 
 /**
  * @deprecated Errors when persisting snapshots can be safely ignored because
@@ -12,7 +12,7 @@ import { EntitySnapshotEnvelope } from '../envelope'
  * This class is kept for backwards compatibility.
  */
 export class SnapshotPersistHandlerGlobalError extends GlobalErrorContainer {
-  constructor(readonly snapshot: EntitySnapshotEnvelope, originalError: Error) {
+  constructor(readonly snapshot: NonPersistedEntitySnapshotEnvelope, originalError: Error) {
     super(originalError)
   }
 }

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -2,11 +2,13 @@ import { ReadModelInterface, SequenceKey, UUID } from './concepts'
 import { BoosterConfig } from './config'
 import {
   ConnectionDataEnvelope,
+  EntitySnapshotEnvelope,
   EventEnvelope,
   EventSearchParameters,
   EventSearchResponse,
   GraphQLRequestEnvelope,
   GraphQLRequestEnvelopeError,
+  NonPersistedEventEnvelope,
   PaginatedEntitiesIdsResult,
   ReadModelEnvelope,
   ReadModelListResult,
@@ -35,7 +37,11 @@ export interface ProviderEventsLibrary {
     entityID: UUID,
     since?: string
   ): Promise<Array<EventEnvelope>>
-  latestEntitySnapshot(config: BoosterConfig, entityTypeName: string, entityID: UUID): Promise<EventEnvelope | null>
+  latestEntitySnapshot(
+    config: BoosterConfig,
+    entityTypeName: string,
+    entityID: UUID
+  ): Promise<EntitySnapshotEnvelope | undefined>
   search(config: BoosterConfig, parameters: EventSearchParameters): Promise<Array<EventSearchResponse>>
   searchEntitiesIDs(
     config: BoosterConfig,
@@ -43,8 +49,10 @@ export interface ProviderEventsLibrary {
     afterCursor: Record<string, string> | undefined,
     entityTypeName: string
   ): Promise<PaginatedEntitiesIdsResult>
-  /** Streams an event to the corresponding event handler */
-  store(eventEnvelopes: Array<EventEnvelope>, config: BoosterConfig): Promise<void>
+  /** Stores a list of events in the events store */
+  store(eventEnvelopes: Array<NonPersistedEventEnvelope>, config: BoosterConfig): Promise<void>
+  /** Stores an entity snapshot in the event store */
+  storeSnapshot(snapshotEnvelope: EntitySnapshotEnvelope, config: BoosterConfig): Promise<void>
 }
 export interface ProviderReadModelsLibrary {
   rawToEnvelopes(config: BoosterConfig, rawEvents: unknown): Promise<Array<ReadModelEnvelope>>
@@ -73,7 +81,7 @@ export interface ProviderReadModelsLibrary {
     readModel: ReadModelInterface,
     expectedCurrentVersion?: number
   ): Promise<unknown>
-  delete(config: BoosterConfig, readModelName: string, readModel: ReadModelInterface | undefined): Promise<any>
+  delete(config: BoosterConfig, readModelName: string, readModel: ReadModelInterface | undefined): Promise<unknown>
   subscribe(config: BoosterConfig, subscriptionEnvelope: SubscriptionEnvelope): Promise<void>
   fetchSubscriptions(config: BoosterConfig, subscriptionName: string): Promise<Array<SubscriptionEnvelope>>
   deleteSubscription(config: BoosterConfig, connectionID: string, subscriptionID: string): Promise<void>

--- a/packages/framework-types/src/provider.ts
+++ b/packages/framework-types/src/provider.ts
@@ -3,12 +3,13 @@ import { BoosterConfig } from './config'
 import {
   ConnectionDataEnvelope,
   EntitySnapshotEnvelope,
+  NonPersistedEntitySnapshotEnvelope,
   EventEnvelope,
+  NonPersistedEventEnvelope,
   EventSearchParameters,
   EventSearchResponse,
   GraphQLRequestEnvelope,
   GraphQLRequestEnvelopeError,
-  NonPersistedEventEnvelope,
   PaginatedEntitiesIdsResult,
   ReadModelEnvelope,
   ReadModelListResult,
@@ -50,9 +51,12 @@ export interface ProviderEventsLibrary {
     entityTypeName: string
   ): Promise<PaginatedEntitiesIdsResult>
   /** Stores a list of events in the events store */
-  store(eventEnvelopes: Array<NonPersistedEventEnvelope>, config: BoosterConfig): Promise<void>
+  store(eventEnvelopes: Array<NonPersistedEventEnvelope>, config: BoosterConfig): Promise<Array<EventEnvelope>>
   /** Stores an entity snapshot in the event store */
-  storeSnapshot(snapshotEnvelope: EntitySnapshotEnvelope, config: BoosterConfig): Promise<void>
+  storeSnapshot(
+    snapshotEnvelope: NonPersistedEntitySnapshotEnvelope,
+    config: BoosterConfig
+  ): Promise<EntitySnapshotEnvelope>
 }
 export interface ProviderReadModelsLibrary {
   rawToEnvelopes(config: BoosterConfig, rawEvents: unknown): Promise<Array<ReadModelEnvelope>>


### PR DESCRIPTION
## Description

TL;DR. This change makes it possible to build the correct state of an entity starting from an arbitrary snapshot in the database, making the process of snapshot generation idempotent, and allowing snapshot writes from competing threads without inducing risks of missing events.

In the current codebase, events and entity snapshots are ordered in the database by a timestamp calculated at the time of persisting them. This makes Booster apps especially sensible to insertion order, making it harder to properly cache snapshots at read time, and forcing us to limit snapshot creation to the events dispatcher. While this approach has shown great resiliency, it comes at the cost of performance. When a certain number of commands and event handlers need to access the most recent version of an entity to validate further actions, and there's no recent snapshot, all of them have to recalculate the last state from the event source, making the event dispatcher process slower.

This behavior has been changed in #1116, where @gonzalogarciajaubert pointed out about a potential issue caused by the way we were setting up the snapshots sort keys. This PR fixes that potential issue with a rework on how events and snapshots are stored and ordered in the database.

> Notice that this change has been worked on top of the changes in #1116, so they're related and must be merged in order.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
~- [ ] Updated documentation accordingly~

## Additional checklist (Scenarios to add to the automated tests)

- [x] An exception while reducing events from a specific entity does no longer affect the reduction of other entities (#1254)
- [x] Event handlers are processed in parallel with read model updates
- [x] An error reducing an entity halts any future reduction for the failing entity (until someone fixes it)
- [x] An error thrown in an event handler does not stop other event handlers
- [x] When a snapshot already exists in the database, trying to rewrite it fails silently (writing it again is not needed)
- [x] Once a failing entity is fixed, the process restarts where it was left no matter how much time passed
- [x] Event handlers no longer wait for snapshots and read models to be calculated, they are processed in parallel, and a failure in one of the threads does not affect the other
- [ ] This change increases performance enough to augment the current load test limits
