### PR TITLE
Fix: Change spelling from "Bosoter" to "Booster" in Booster docs

### DIFF
--- a/website/docs/03_architecture/02_command.mdx
+++ b/website/docs/03_architecture/02_command.mdx
@@ -2,11 +2,11 @@ import TerminalWindow from '@site/src/components/TerminalWindow/TerminalWindow'
 
 # Command
 
-Commands are any action a user performs on your application. For example, `RemoveItemFromCart`, `RatePhoto` or `AddCommentToPost`. They express the intention of an user, and they are the main interaction mechanism of your application. They are a similar to the concept of a  **request on a REST API**. Command issuers can also send data on a command as parameters. 
+Commands are any action a user performs on your application. For example, `RemoveItemFromCart`, `RatePhoto` or `AddCommentToPost`. They express the intention of an user, and they are the main interaction mechanism of your application. They are a similar to the concept of a **request on a REST API**. Command issuers can also send data on a command as parameters.
 
 ## Creating a command
 
-The Bosoter CLI will help you to create new commands. You just need to run the following command and the CLI will generate all the boilerplate for you:
+The Booster CLI will help you to create new commands. You just need to run the following command and the CLI will generate all the boilerplate for you:
 
 <TerminalWindow>
 
@@ -58,7 +58,7 @@ Each command class must have a method called `handle`. This function is the comm
 
 ### Registering events
 
-Within the command handler execution, it is possible to register domain events. The command handler function receives the `register` argument, so within the handler, it is possible to call `register.events(...)` with a list of events. 
+Within the command handler execution, it is possible to register domain events. The command handler function receives the `register` argument, so within the handler, it is possible to call `register.events(...)` with a list of events.
 
 ```typescript title="src/commands/create-product.ts"
 @Command()
@@ -76,7 +76,7 @@ For more details about events and the register parameter, see the [`Events`](/ar
 
 ### Returning a value
 
-The command handler function can return a value. This value will be the response of the GraphQL mutation. By default, the command handler function expects you to return a  `void` as a return type. Since GrahpQL does not have a `void` type, the command handler function returns `true` when called through the GraphQL. This is because the GraphQL specification requires a response, and `true` is the most appropriate value to represent a successful execution with no return value.
+The command handler function can return a value. This value will be the response of the GraphQL mutation. By default, the command handler function expects you to return a `void` as a return type. Since GrahpQL does not have a `void` type, the command handler function returns `true` when called through the GraphQL. This is because the GraphQL specification requires a response, and `true` is the most appropriate value to represent a successful execution with no return value.
 
 If you want to return a value, you can change the return type of the handler function. For example, if you want to return a `string`:
 
@@ -123,15 +123,13 @@ export class CreateProduct {
 ```
 
 You'll get something like this response:
-  
+
 ```json
 {
   "errors": [
     {
       "message": "price must be below 10, and it was 19.99",
-      "path": [
-        "CreateProduct"
-      ]
+      "path": ["CreateProduct"]
     }
   ]
 }
@@ -197,11 +195,9 @@ export class MoveStock {
 }
 ```
 
-
-
 ## Authorizing a command
 
-Commands are part of the public API of a Booster application, so you can define who is authorized to submit them. All commands are protected by default, which means that no one can submit them. In order to allow users to submit a command, you must explicitly authorize them. You can use the `authorize` field of the `@Command` decorator to specify the authorization rule. 
+Commands are part of the public API of a Booster application, so you can define who is authorized to submit them. All commands are protected by default, which means that no one can submit them. In order to allow users to submit a command, you must explicitly authorize them. You can use the `authorize` field of the `@Command` decorator to specify the authorization rule.
 
 ```typescript title="src/commands/create-product.ts"
 @Command({

--- a/website/docs/03_architecture/03_event.mdx
+++ b/website/docs/03_architecture/03_event.mdx
@@ -1,13 +1,12 @@
 import TerminalWindow from '@site/src/components/TerminalWindow/TerminalWindow'
 
-
 # Event
 
 An event is a fact of something that has happened in your application. Every action that takes place on your application should be stored as an event. They are stored in a single collection, forming a set of **immutable records of facts** that contain the whole story of your application. This collection of events is commonly known as the **Event Store**.
 
 ## Creating an event
 
-The Bosoter CLI will help you to create new events. You just need to run the following command and the CLI will generate all the boilerplate for you:
+The Booster CLI will help you to create new events. You just need to run the following command and the CLI will generate all the boilerplate for you:
 
 <TerminalWindow>
 
@@ -52,7 +51,7 @@ export class CartPaid {
 ```
 
 :::tip
-If your domain requires a ***Singleton*** entity, where there's only one instance of that entity in your whole application, you can return a constant value.
+If your domain requires a **_Singleton_** entity, where there's only one instance of that entity in your whole application, you can return a constant value.
 :::
 
 :::caution

--- a/website/docs/03_architecture/04_event-handler.mdx
+++ b/website/docs/03_architecture/04_event-handler.mdx
@@ -1,17 +1,16 @@
 ---
-description: Learn how to react to events and trigger side effects in Booster by defining event handlers. 
+description: Learn how to react to events and trigger side effects in Booster by defining event handlers.
 ---
 
 import TerminalWindow from '@site/src/components/TerminalWindow/TerminalWindow'
 
-
 # Event handler
 
-An event handler is a class that reacts to events. They are commonly used to trigger side effects in case of a new event. For instance, if a new event is registered in the system, an event handler could send an email to the user. 
+An event handler is a class that reacts to events. They are commonly used to trigger side effects in case of a new event. For instance, if a new event is registered in the system, an event handler could send an email to the user.
 
 ## Creating an event handler
 
-The Bosoter CLI will help you to create new event handlers. You just need to run the following command and the CLI will generate all the boilerplate for you:
+The Booster CLI will help you to create new event handlers. You just need to run the following command and the CLI will generate all the boilerplate for you:
 
 <TerminalWindow>
 
@@ -31,7 +30,6 @@ In Booster, event handlers are classes decorated with the `@EventHandler` decora
 // highlight-next-line
 @EventHandler(StockMoved)
 export class HandleAvailability {
-
   // highlight-start
   public static async handle(event: StockMoved): Promise<void> {
     // Do something here
@@ -49,6 +47,7 @@ Event handlers can be easily created using the Booster CLI command `boost new:ev
 ```typescript
 boost new:event-handler HandleAvailability --event StockMoved
 ```
+
 </TerminalWindow>
 
 Once the creation is completed, there will be a new file in the event handlers directory `<project-root>/src/event-handlers/handle-availability.ts`.
@@ -67,7 +66,7 @@ Once the creation is completed, there will be a new file in the event handlers d
 
 ## Registering events from an event handler
 
-Event handlers can also register new events. This is useful when you want to trigger a new event after a certain condition is met. For example, if you want to send an email to the user when a product is out of stock. 
+Event handlers can also register new events. This is useful when you want to trigger a new event after a certain condition is met. For example, if you want to send an email to the user when a product is out of stock.
 
 In order to register new events, Booster injects the `register` instance in the `handle` method as a second parameter. This `register` instance has a `events(...)` method that allows you to store any side effect events, you can specify as many as you need separated by commas as arguments of the function.
 

--- a/website/docs/03_architecture/05_entity.mdx
+++ b/website/docs/03_architecture/05_entity.mdx
@@ -1,6 +1,5 @@
 import TerminalWindow from '@site/src/components/TerminalWindow/TerminalWindow'
 
-
 # Entity
 
 If events are the _source of truth_ of your application, entities are the _current state_ of your application. For example, if you have an application that allows users to create bank accounts, the events would be something like `AccountCreated`, `MoneyDeposited`, `MoneyWithdrawn`, etc. But the entities would be the `BankAccount` themselves, with the current balance, owner, etc.
@@ -13,7 +12,7 @@ Under the hood, Booster stores snapshots of the entities in order to reduce the 
 
 ## Creating entities
 
-The Bosoter CLI will help you to create new entities. You just need to run the following command and the CLI will generate all the boilerplate for you:
+The Booster CLI will help you to create new entities. You just need to run the following command and the CLI will generate all the boilerplate for you:
 
 <TerminalWindow>
 
@@ -27,7 +26,7 @@ This will generate a new file called `product.ts` in the `src/entities` director
 
 ## Declaring an entity
 
-To declare an entity in Booster, you must define a class decorated with the `@Entity` decorator. Inside of the class, you must define a constructor with all the fields you want to have in your entity. 
+To declare an entity in Booster, you must define a class decorated with the `@Entity` decorator. Inside of the class, you must define a constructor with all the fields you want to have in your entity.
 
 ```typescript title="src/entities/entity-name.ts"
 @Entity
@@ -38,7 +37,7 @@ export class EntityName {
 
 ## The reduce function
 
-In order to tell Booster how to reduce the events, you must define a static method decorated with the `@Reduces` decorator. This method will be called by the framework every time an event of the specified type is emitted. The reducer method must return a new entity instance with the current state of the entity. 
+In order to tell Booster how to reduce the events, you must define a static method decorated with the `@Reduces` decorator. This method will be called by the framework every time an event of the specified type is emitted. The reducer method must return a new entity instance with the current state of the entity.
 
 ```typescript title="src/entities/entity-name.ts"
 @Entity
@@ -61,7 +60,7 @@ The reducer method receives two parameters:
 
 ### Reducing multiple events
 
-You can define as many reducer methods as you want, each one for a different event type. For example, if you have a `Cart` entity, you could define a reducer for `ProductAdded` events and another one for `ProductRemoved` events. 
+You can define as many reducer methods as you want, each one for a different event type. For example, if you have a `Cart` entity, you could define a reducer for `ProductAdded` events and another one for `ProductRemoved` events.
 
 ```typescript title="src/entities/cart.ts"
 @Entity
@@ -86,7 +85,6 @@ export class Cart {
 It's highly recommended to **keep your reducer functions pure**, which means that you should be able to produce the new entity version by just looking at the event and the current entity state. You should avoid calling third party services, reading or writing to a database, or changing any external state.
 :::
 
-
 There could be a lot of events being reduced concurrently among many entities, but, **for a specific entity instance, the events order is preserved**. This means that while one event is being reduced, all other events of any kind _that belong to the same entity instance_ will be waiting in a queue until the previous reducer has finished. This is how Booster guarantees that the entity state is consistent.
 
 ![reducer process gif](/img/reducer.gif)
@@ -99,8 +97,7 @@ This property is called [Eventual Consistency](https://en.wikipedia.org/wiki/Eve
 
 ## Entity ID
 
-In order to identify each entity instance, you must define an `id` field on each entity. This field will be used by the framework to identify the entity instance. If the value of the `id` field matches the value returned by the [`entityID()` method](event#events-and-entities) of an Event, the framework will consider that the event belongs to that entity instance. 
-
+In order to identify each entity instance, you must define an `id` field on each entity. This field will be used by the framework to identify the entity instance. If the value of the `id` field matches the value returned by the [`entityID()` method](event#events-and-entities) of an Event, the framework will consider that the event belongs to that entity instance.
 
 ```typescript title="src/entities/entity-name.ts"
 @Entity
@@ -122,7 +119,6 @@ export class EntityName {
 :::tip
 We recommend you to use the `UUID` type for the `id` field. You can generate a new `UUID` value by calling the `UUID.generate()` method already provided by the framework.
 :::
-
 
 ## Entities naming convention
 
@@ -149,5 +145,3 @@ Entities live within the entities directory of the project source: `<project-roo
 │   ├── index.ts
 │   └── read-models
 ```
-
-

--- a/website/docs/03_architecture/06_read-model.mdx
+++ b/website/docs/03_architecture/06_read-model.mdx
@@ -6,14 +6,13 @@ In other words, Read Models are cached data optimized for read operations. They'
 
 ## Creating a read model
 
-The Bosoter CLI will help you to create new read models. You just need to run the following command and the CLI will generate all the boilerplate for you:
+The Booster CLI will help you to create new read models. You just need to run the following command and the CLI will generate all the boilerplate for you:
 
 ```shell
 boost new:read-model CartReadModel --fields id:UUID cartItems:"Array<CartItem>" paid:boolean --projects Cart
 ```
 
 This will generate a new file called `cart-read-model.ts` in the `src/read-models` directory. You can also create the file manually, but you will need to create the class and decorate it, so we recommend using the CLI.
-
 
 ## Declaring a read model
 
@@ -30,7 +29,6 @@ export class ReadModelName {
 The `ReadModelName` class name will be used as the read model name in the GraphQL schema. Also, the types on the constructor will be used to generate the GraphQL schema. For example, if you have a property of type `Array<CartItem>` the GraphQL schema will know that is an array of `CartItem` objects.
 :::
 
-
 ## The projection function
 
 The projection function is a static method decorated with the `@Projects` decorator. It is used to define how the read model is updated when an entity is modified. he projection function must return a new instance of the read model, it receives two arguments:
@@ -38,16 +36,12 @@ The projection function is a static method decorated with the `@Projects` decora
 - `entity`: The entity that has been modified
 - `current?`: The current read model instance. If it's the first time the read model is created, this argument will be `undefined`
 
-You must provide the `@Projects` decorator with an entity class and the ***join key***. The join key is the name of the field in the entity that is used to match it with the read model's `id` field. In the example below, we are using the `id` field of the `Cart` entity to match it with the `CartReadModel` read model.
-  
+You must provide the `@Projects` decorator with an entity class and the **_join key_**. The join key is the name of the field in the entity that is used to match it with the read model's `id` field. In the example below, we are using the `id` field of the `Cart` entity to match it with the `CartReadModel` read model.
+
 ```typescript
 @ReadModel
 export class CartReadModel {
-  public constructor(
-    readonly id: UUID,
-    readonly cartItems: Array<CartItem>,
-    readonly paid: boolean
-  ) {}
+  public constructor(readonly id: UUID, readonly cartItems: Array<CartItem>, readonly paid: boolean) {}
 
   // highlight-start
   @Projects(Cart, 'id')
@@ -83,11 +77,11 @@ export class UserReadModel {
 
 ### Advanced join keys
 
-There might be cases where you need to project an entity into a read model using a more complex join key. For that reason, Booster supports other types of join keys. 
+There might be cases where you need to project an entity into a read model using a more complex join key. For that reason, Booster supports other types of join keys.
 
 #### Array of entities
 
-You can use an array of entities as a join key.  For example, if you have a `Group` entity with an array of users in that group (`users: Array<UUID>`), you can have the following to update each `UserReadModel` accordingly:
+You can use an array of entities as a join key. For example, if you have a `Group` entity with an array of users in that group (`users: Array<UUID>`), you can have the following to update each `UserReadModel` accordingly:
 
 ```typescript
   @Projects(Group, 'users')
@@ -132,7 +126,6 @@ export class UserReadModel {
 :::info
 Deleting a read model is a very expensive operation. It will trigger a write operation in the read model store. If you can, try to avoid deleting read models.
 :::
-
 
 #### Keeping read models untouched
 
@@ -239,19 +232,14 @@ Notice that getters are not cached in the read models database, so the getters w
 
 ## Authorizing a read model
 
-Read models are part of the public API of a Booster application, so you can define who is authorized to submit them. All read models are protected by default, which means that no one can query them. In order to allow users to query a read model, you must explicitly authorize them. You can use the `authorize` field of the `@ReadModel` decorator to specify the authorization rule. 
+Read models are part of the public API of a Booster application, so you can define who is authorized to submit them. All read models are protected by default, which means that no one can query them. In order to allow users to query a read model, you must explicitly authorize them. You can use the `authorize` field of the `@ReadModel` decorator to specify the authorization rule.
 
 ```typescript title="src/read-model/product-read-model.ts"
 @ReadModel({
-  authorize: 'all'
+  authorize: 'all',
 })
 export class ProductReadModel {
-  public constructor(
-    public id: UUID,
-    readonly name: string,
-    readonly description: string,
-    readonly price: number
-  ) {}
+  public constructor(public id: UUID, readonly name: string, readonly description: string, readonly price: number) {}
 
   @Projects(Product, 'id')
   public static projectProduct(entity: Product, current?: ProductReadModel): ProjectionResult<ProductReadModel> {
@@ -261,7 +249,6 @@ export class ProductReadModel {
 ```
 
 You can read more about this on the [Authorization section](/security/authorization).
-
 
 ## Querying a read model
 
@@ -300,7 +287,6 @@ Booster GraphQL API provides support for filtering Read Models on `queries` and 
 ## Subscribing to a read model
 
 Booster GraphQL API also provides support for real-time updates using subscriptions and a web-socket. To get more information about it go to the [GraphQL API](/graphql#subscribing-to-read-models) section.
-
 
 ## Sorting Read Models
 


### PR DESCRIPTION
## Changes

- Change spelling from "Bosoter" to "Booster" on several documentation pages.

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly