### PR TITLE
Azure no longer described as experimental

### DIFF
--- a/common/changes/@boostercloud/framework-core/azure-is-no-longer-experimental_2023-02-18-23-11.json
+++ b/common/changes/@boostercloud/framework-core/azure-is-no-longer-experimental_2023-02-18-23-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/common/changes/@boostercloud/framework-core/azure-is-no-longer-experimental_2023-02-22-20-01.json
+++ b/common/changes/@boostercloud/framework-core/azure-is-no-longer-experimental_2023-02-22-20-01.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@boostercloud/framework-core",
-      "comment": "",
-      "type": "none"
+      "comment": "Removed the experimental tag from Azure provider mentions in the documentation and CLI",
+      "type": "patch"
     }
   ],
   "packageName": "@boostercloud/framework-core"

--- a/packages/cli/src/common/provider.ts
+++ b/packages/cli/src/common/provider.ts
@@ -1,6 +1,6 @@
 export const enum Provider {
   AWS = '@boostercloud/framework-provider-aws (AWS)',
-  AZURE = '@boostercloud/framework-provider-azure (Azure) [Experimental]',
+  AZURE = '@boostercloud/framework-provider-azure (Azure)',
   KUBERNETES = '@boostercloud/framework-provider-kubernetes (Kubernetes) [Experimental]',
   OTHER = 'Other',
 }

--- a/packages/cli/test/common/provider.test.ts
+++ b/packages/cli/test/common/provider.test.ts
@@ -6,7 +6,7 @@ describe('selectedProvider', (): void => {
     expect(Provider.AWS).to.be.equal('@boostercloud/framework-provider-aws (AWS)')
   })
   it('get selected provider: Azure', async () => {
-    expect(Provider.AZURE).to.be.equal('@boostercloud/framework-provider-azure (Azure) [Experimental]')
+    expect(Provider.AZURE).to.be.equal('@boostercloud/framework-provider-azure (Azure)')
   })
   it('get selected provider: Kubernetes', async () => {
     expect(Provider.KUBERNETES).to.be.equal('@boostercloud/framework-provider-kubernetes (Kubernetes) [Experimental]')

--- a/website/docs/10_going-deeper/infrastructure-providers.mdx
+++ b/website/docs/10_going-deeper/infrastructure-providers.mdx
@@ -4,12 +4,12 @@ import TerminalWindow from '@site/src/components/TerminalWindow/TerminalWindow'
 
 The providers are different implementations of the Booster runtime to allow Booster applications run on different cloud providers or services. They all implement the same interface, and the main idea behind the providers is that no matter what the developer chooses as backend, they won't need to know anything about the underlying infrastructure.
 
-Currently, the Booster framework provides a fully working provider package:
+Currently, the Booster framework provides two fully working provider packages:
 
 - **framework-provider-aws-\***
 - **framework-provider-azure-\***
 
-Other providers packages are currently under experimental support. Some of the features might be missing:
+It also exists an experimental implementation for Kubernetes. Feel free to try it, but some features will be missing and the resources used are not designed for production:
 
 - **framework-provider-kubernetes-\***
 
@@ -206,7 +206,7 @@ Now just let the magic happen, Booster will create everything for you and give y
 
 ### Azure synth command
 
-Azure provider implement the experimental **Booster** `synth` command. This command will generate [Terrafom](https://www.terraform.io/) templates from your code. It will also generate needed files to deploy your Booster application using [cdktf](https://learn.hashicorp.com/tutorials/terraform/cdktf).
+Azure provider implements the experimental **Booster** `synth` command. This command will generate [Terrafom](https://www.terraform.io/) templates from your code. It will also generate needed files to deploy your Booster application using [cdktf](https://learn.hashicorp.com/tutorials/terraform/cdktf).
 
 Running `synth` command, for example `boost synth -e production` will generate following files:
 

--- a/website/docs/10_going-deeper/rockets.mdx
+++ b/website/docs/10_going-deeper/rockets.mdx
@@ -4,7 +4,7 @@ import DocCardList from '@theme/DocCardList'
 
 You can extend Booster by creating rockets. A rocket is just a node package that implements the public Booster rocket interfaces. You can use them for many things:
 
-1. Extend your infrastructure (Currently supported in AWS, and under experimental support in Azure and Local): You can write a rocket that adds provider resources to your application stack.
+1. Extend your infrastructure: You can write a rocket that adds provider resources to your application stack.
 2. Runtime extensions (Not yet implemented): Add new annotations and interfaces, which combined with infrastructure extensions, could implement new abstractions on top of highly requested use cases.
 3. Deploy and init hooks (Not yet implemented): Run custom scripts before or after deployment, or before a Booster application is loaded.
 
@@ -14,11 +14,6 @@ This extension mechanism is very new, but we're planning to port most of the fun
 - Easier to manage feature sets in different providers: It would be really hard for the core team and contributors to implement and test every new feature in every supported provider, so by providing functionality like rockets, you'll have access to the most advanced features for your provider faster, and the rockets library can be built on-demand for each provider.
 
 ### Create your own Rocket
-
-:::note
-Currently Rockets work in AWS.
-In Azure and Local, Rockets are under experimental support. We are working on porting them to other providers.
-:::
 
 A rocket is nothing more than an npm package that extends your current Booster architecture. The structure is simple, and it mainly has 2 methods: `mountStack` and `unmountStack`. We'll explain what they are shortly.
 


### PR DESCRIPTION
## Description

It's been a while since many people are using the Azure implementation with no issues, so this PR puts it in the place it deserved, as a fully supported provider.

## Changes

Removed all the misleading notes claiming that Azure support is experimental