### PR TITLE
Support UUID contains filters

### DIFF
--- a/.github/actions/test-integration-run-one/action.yml
+++ b/.github/actions/test-integration-run-one/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
     type: string
   azure-region:
-    default: 'Central US'
+    default: 'East US'
     required: false
     type: string
   azure-publisher-email:

--- a/.github/actions/test-integration-run-one/action.yml
+++ b/.github/actions/test-integration-run-one/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
     type: string
   azure-region:
-    default: 'East US'
+    default: 'Central US'
     required: false
     type: string
   azure-publisher-email:

--- a/common/changes/@boostercloud/framework-core/support_uuid_contains_filters_2023-03-16-10-39.json
+++ b/common/changes/@boostercloud/framework-core/support_uuid_contains_filters_2023-03-16-10-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "Support UUID contains and beginsWith filters",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/packages/framework-core/src/services/graphql/query-helpers/graphql-query-filter-arguments-builder.ts
+++ b/packages/framework-core/src/services/graphql/query-helpers/graphql-query-filter-arguments-builder.ts
@@ -148,6 +148,8 @@ export class GraphqlQueryFilterArgumentsBuilder {
         eq: { type: GraphQLID },
         ne: { type: GraphQLID },
         in: { type: GraphQLList(GraphQLID) },
+        beginsWith: { type: GraphQLString },
+        contains: { type: GraphQLString },
         isDefined: { type: GraphQLBoolean },
       }
     // use `name`, `typeGroup` === 'Interface'

--- a/packages/framework-integration-tests/integration/provider-unaware/end-to-end/read-models.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/end-to-end/read-models.integration.ts
@@ -795,6 +795,54 @@ describe('Read models end-to-end tests', () => {
         expect(cartData[0].payment.id).to.be.eq(mockPaymentId)
       })
 
+      it('should retrieve ´a list of carts when filter by contains with UUID fields', async () => {
+        const partialMockCartId = mockCartId.slice(1, -1)
+        const filter = {
+          and: [
+            {
+              id: { eq: mockCartId },
+            },
+            {
+              id: {
+                contains: partialMockCartId,
+              },
+            },
+          ],
+        }
+
+        const queryResult = await waitForIt(
+          () => {
+            return client.query({
+              variables: {
+                filter: filter,
+              },
+              query: gql`
+                query ListCartReadModels($filter: ListCartReadModelFilter) {
+                  ListCartReadModels(filter: $filter) {
+                    items {
+                      id
+                      shippingAddress {
+                        firstName
+                      }
+                    }
+                  }
+                }
+              `,
+            })
+          },
+          (result) => {
+            const carts = result?.data?.ListCartReadModels?.items
+            return carts?.length >= 1 && carts[0].id === mockCartId
+          }
+        )
+
+        const cartData = queryResult.data.ListCartReadModels.items
+
+        expect(cartData).to.be.an('array')
+        expect(cartData.length).to.equal(1)
+        expect(cartData[0].id).to.equal(mockCartId)
+      })
+
       it('should retrieve a list of carts when filter by null', async () => {
         const mockPaymentId: string = random.uuid()
         await client.mutate({


### PR DESCRIPTION
## Description
Add `contains` and `beginsWith` filters to UUID fields

## Changes
Update graphQL to support `contains` and `beginsWith` filters to UUID fields

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly
