### PR TITLE
Fix: Upgrade AWS Lambda node version to Node 16

### DIFF
--- a/packages/framework-provider-aws-infrastructure/src/infrastructure/params.ts
+++ b/packages/framework-provider-aws-infrastructure/src/infrastructure/params.ts
@@ -18,7 +18,7 @@ export function lambda(
   apis: APIs
 ): Pick<FunctionProps, 'runtime' | 'timeout' | 'memorySize' | 'environment'> {
   return {
-    runtime: Runtime.NODEJS_14_X,
+    runtime: Runtime.NODEJS_16_X,
     timeout: Duration.minutes(15),
     memorySize: 1024,
     environment: {


### PR DESCRIPTION
## Description

This PR upgrades the AWS lambda version to solve some reported issues in the AWS environment.
