### PR TITLE
Return readModel instance when querying by id

### DIFF
--- a/common/changes/@boostercloud/framework-core/fix-findbyid-readmodel-instance_2023-05-24-11-08.json
+++ b/common/changes/@boostercloud/framework-core/fix-findbyid-readmodel-instance_2023-05-24-11-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "Return ReadModel instance when querying by id",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/packages/framework-core/src/booster-read-models-reader.ts
+++ b/packages/framework-core/src/booster-read-models-reader.ts
@@ -13,7 +13,7 @@ import {
   SortFor,
   SubscriptionEnvelope,
 } from '@boostercloud/framework-types'
-import { createInstances, getLogger } from '@boostercloud/framework-common-helpers'
+import { createInstance, createInstances, getLogger } from '@boostercloud/framework-common-helpers'
 import { Booster } from './booster'
 import { applyReadModelRequestBeforeFunctions } from './services/filter-helpers'
 import { ReadModelSchemaMigrator } from './read-model-schema-migrator'
@@ -39,12 +39,13 @@ export class BoosterReadModelsReader {
     }
     const currentReadModel = await Booster.readModel(readModelMetadata.class).findById(key.id, key.sequenceKey)
     if (currentReadModel) {
+      const readModelInstance = createInstance(readModelMetadata.class, currentReadModel)
       const readModelName = readModelMetadata.class.name
       const readModelSchemaMigrator = new ReadModelSchemaMigrator(this.config)
-      if (Array.isArray(currentReadModel)) {
-        return [await readModelSchemaMigrator.migrate(<ReadModelInterface>currentReadModel[0], readModelName)]
+      if (Array.isArray(readModelInstance)) {
+        return [await readModelSchemaMigrator.migrate(<ReadModelInterface>readModelInstance[0], readModelName)]
       }
-      return readModelSchemaMigrator.migrate(<ReadModelInterface>currentReadModel, readModelName)
+      return readModelSchemaMigrator.migrate(<ReadModelInterface>readModelInstance, readModelName)
     }
     return currentReadModel
   }


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#github-flow
- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#publishing-your-pull-request

- Make sure you followed our Code style https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#code-style-guidelines

- Make sure everything works https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#getting-the-code

- Run tests 🐛 https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#running-unit-tests

-->

## Description
When querying a ReadModel list, the ReadModels are returned as instances. When a ReadModel is queried by id, this is not the case. As a consequence, getters do not work when querying by id. 

## Changes
When querying a ReadModel by id, an instance is not returned so the getters work.
<!-- 

Describe changes you have made:

- Added tests
- Described "amazingMethodName" purpose in the docs
- New method `amazingMethodName`

-->

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
