### PR TITLE
fix(framework-provider-aws): ensure storeSnapshot is idempotent

### DIFF
--- a/common/changes/@boostercloud/framework-core/feature-fix_aws_idempotency_2023-06-26-10-49.json
+++ b/common/changes/@boostercloud/framework-core/feature-fix_aws_idempotency_2023-06-26-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "ensure aws storeSnapshot is idempotent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/packages/framework-provider-aws/src/library/events-adapter.ts
+++ b/packages/framework-provider-aws/src/library/events-adapter.ts
@@ -134,11 +134,6 @@ export async function storeSnapshot(
     await dynamoDB
       .put({
         TableName: config.resourceNames.eventsStore,
-        ConditionExpression: `${eventsStoreAttributes.partitionKey} <> :partitionKey AND ${eventsStoreAttributes.sortKey} <> :sortKey`,
-        ExpressionAttributeValues: {
-          ':partitionKey': partitionKey,
-          ':sortKey': sortKey,
-        },
         Item: {
           ...persistableSnapshot,
           [eventsStoreAttributes.partitionKey]: partitionKey,

--- a/packages/framework-provider-aws/src/library/events-adapter.ts
+++ b/packages/framework-provider-aws/src/library/events-adapter.ts
@@ -114,45 +114,37 @@ export async function storeSnapshot(
   snapshotEnvelope: NonPersistedEntitySnapshotEnvelope,
   config: BoosterConfig
 ): Promise<EntitySnapshotEnvelope> {
-  try {
-    const logger = getLogger(config, 'EventsAdapter#storeSnapshot')
-    logger.debug('Storing the following snapshot:', snapshotEnvelope)
+  const logger = getLogger(config, 'EventsAdapter#storeSnapshot')
+  logger.debug('Storing the following snapshot:', snapshotEnvelope)
 
-    const partitionKey = partitionKeyForEntitySnapshot(snapshotEnvelope.entityTypeName, snapshotEnvelope.entityID)
-    /**
-     * The sort key of the snapshot matches the sort key of the last event that generated it.
-     * Entity snapshots can be potentially created by competing processes, and this way
-     * of storing the data makes snapshot creation an idempotent operation, allowing us to
-     * aggressively cache snapshots. If the snapshot already exists, it will be silently overwritten.
-     */
-    const sortKey = snapshotEnvelope.snapshottedEventCreatedAt
-    const persistableSnapshot = {
-      ...snapshotEnvelope,
-      createdAt: snapshotEnvelope.snapshottedEventCreatedAt,
-      persistedAt: new Date().toISOString(),
-    }
-    await dynamoDB
-      .put({
-        TableName: config.resourceNames.eventsStore,
-        Item: {
-          ...persistableSnapshot,
-          [eventsStoreAttributes.partitionKey]: partitionKey,
-          [eventsStoreAttributes.sortKey]: sortKey,
-          [eventsStoreAttributes.indexByEntity.partitionKey]: partitionKeyForIndexByEntity(
-            snapshotEnvelope.entityTypeName,
-            snapshotEnvelope.kind
-          ),
-        },
-      })
-      .promise()
-    return persistableSnapshot
-  } catch (e) {
-    const error = e as Error
-    if (error.name == 'ConditionalCheckFailedException') {
-      throw new OptimisticConcurrencyUnexpectedVersionError(error.message)
-    }
-    throw e
+  const partitionKey = partitionKeyForEntitySnapshot(snapshotEnvelope.entityTypeName, snapshotEnvelope.entityID)
+  /**
+   * The sort key of the snapshot matches the sort key of the last event that generated it.
+   * Entity snapshots can be potentially created by competing processes, and this way
+   * of storing the data makes snapshot creation an idempotent operation, allowing us to
+   * aggressively cache snapshots. If the snapshot already exists, it will be silently overwritten.
+   */
+  const sortKey = snapshotEnvelope.snapshottedEventCreatedAt
+  const persistableSnapshot = {
+    ...snapshotEnvelope,
+    createdAt: snapshotEnvelope.snapshottedEventCreatedAt,
+    persistedAt: new Date().toISOString(),
   }
+  await dynamoDB
+    .put({
+      TableName: config.resourceNames.eventsStore,
+      Item: {
+        ...persistableSnapshot,
+        [eventsStoreAttributes.partitionKey]: partitionKey,
+        [eventsStoreAttributes.sortKey]: sortKey,
+        [eventsStoreAttributes.indexByEntity.partitionKey]: partitionKeyForIndexByEntity(
+          snapshotEnvelope.entityTypeName,
+          snapshotEnvelope.kind
+        ),
+      },
+    })
+    .promise()
+  return persistableSnapshot
 }
 
 async function persistEvent(


### PR DESCRIPTION
## Description
Fix DynamoDB call in `storeSnapshot` by ensuring it is idempotent
This fixes errors when eventHandlers are accessing entities via `Booster.entity` and also attempting to cache snapshots

## Changes

- Removed ConditionExpression from dyanmoDB call to ensure idempotency

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly
