### PR TITLE
Upgrade for Node 18 Task - Fix CLI unit tests

### DIFF
--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -12,6 +12,7 @@ import * as packageManagerImpl from '../../src/services/package-manager/live.imp
 import * as configService from '../../src/services/config-service'
 import * as projectChecker from '../../src/services/project-checker'
 import { makeTestPackageManager } from '../services/package-manager/test.impl'
+import { root } from '../configRoot'
 
 // With this trick we can test non exported symbols
 const rewire = require('rewire')
@@ -90,6 +91,7 @@ describe('deploy', () => {
   describe('run', () => {
     context('when no environment provided', async () => {
       test
+        .loadConfig({ root })
         .stdout()
         .command(['deploy'])
         .it('shows no environment provided error', (ctx) => {

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -12,7 +12,6 @@ import * as packageManagerImpl from '../../src/services/package-manager/live.imp
 import * as configService from '../../src/services/config-service'
 import * as projectChecker from '../../src/services/project-checker'
 import { makeTestPackageManager } from '../services/package-manager/test.impl'
-import { root } from '../configRoot'
 
 // With this trick we can test non exported symbols
 const rewire = require('rewire')
@@ -91,7 +90,7 @@ describe('deploy', () => {
   describe('run', () => {
     context('when no environment provided', async () => {
       test
-        .loadConfig({ root })
+        .loadConfig({ root: __dirname })
         .stdout()
         .command(['deploy'])
         .it('shows no environment provided error', (ctx) => {

--- a/packages/cli/test/commands/nuke.test.ts
+++ b/packages/cli/test/commands/nuke.test.ts
@@ -11,7 +11,7 @@ import { test } from '@oclif/test'
 import * as environment from '../../src/services/environment'
 import * as configService from '../../src/services/config-service'
 import * as projectChecker from '../../src/services/project-checker'
-
+import { root } from '../configRoot'
 const rewire = require('rewire')
 const nuke = rewire('../../src/commands/nuke')
 const runTasks = nuke.__get__('runTasks')
@@ -118,6 +118,7 @@ describe('nuke', () => {
   describe('run', () => {
     context('when no environment provided', async () => {
       test
+        .loadConfig({ root })
         .stdout()
         .command(['nuke'])
         .it('shows no environment provided error', (ctx) => {

--- a/packages/cli/test/commands/nuke.test.ts
+++ b/packages/cli/test/commands/nuke.test.ts
@@ -11,7 +11,6 @@ import { test } from '@oclif/test'
 import * as environment from '../../src/services/environment'
 import * as configService from '../../src/services/config-service'
 import * as projectChecker from '../../src/services/project-checker'
-import { root } from '../configRoot'
 const rewire = require('rewire')
 const nuke = rewire('../../src/commands/nuke')
 const runTasks = nuke.__get__('runTasks')
@@ -118,7 +117,7 @@ describe('nuke', () => {
   describe('run', () => {
     context('when no environment provided', async () => {
       test
-        .loadConfig({ root })
+        .loadConfig({ root: __dirname })
         .stdout()
         .command(['nuke'])
         .it('shows no environment provided error', (ctx) => {

--- a/packages/cli/test/commands/start.test.ts
+++ b/packages/cli/test/commands/start.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '../expect'
 import { restore, fake, replace } from 'sinon'
-import rewire = require('rewire')
 import { ProviderLibrary, BoosterConfig } from '@boostercloud/framework-types'
 import * as Start from '../../src/commands/start'
 import * as providerService from '../../src/services/provider-service'
@@ -10,7 +9,9 @@ import { test } from '@oclif/test'
 import * as environment from '../../src/services/environment'
 import * as configService from '../../src/services/config-service'
 import * as projectChecker from '../../src/services/project-checker'
+import { root } from '../configRoot'
 
+import rewire = require('rewire')
 const start = rewire('../../src/commands/start')
 const runTasks = start.__get__('runTasks')
 
@@ -44,6 +45,7 @@ describe('start', () => {
   describe('run', () => {
     context('when no environment provided', async () => {
       test
+        .loadConfig({ root })
         .stdout()
         .command(['start'])
         .it('shows no environment provided error', (ctx) => {

--- a/packages/cli/test/commands/start.test.ts
+++ b/packages/cli/test/commands/start.test.ts
@@ -9,7 +9,6 @@ import { test } from '@oclif/test'
 import * as environment from '../../src/services/environment'
 import * as configService from '../../src/services/config-service'
 import * as projectChecker from '../../src/services/project-checker'
-import { root } from '../configRoot'
 
 import rewire = require('rewire')
 const start = rewire('../../src/commands/start')
@@ -45,7 +44,7 @@ describe('start', () => {
   describe('run', () => {
     context('when no environment provided', async () => {
       test
-        .loadConfig({ root })
+        .loadConfig({ root: __dirname })
         .stdout()
         .command(['start'])
         .it('shows no environment provided error', (ctx) => {

--- a/packages/cli/test/commands/stub/publish.test.ts
+++ b/packages/cli/test/commands/stub/publish.test.ts
@@ -18,6 +18,7 @@ describe('stub', async () => {
     const directoryFileMocks: fs.Dirent[] = [
       {
         name: 'fake-command.stub',
+        path: '/someDir',
         isFile: () => true,
         isDirectory: () => false,
         isBlockDevice: () => false,
@@ -28,6 +29,7 @@ describe('stub', async () => {
       },
       {
         name: 'fake-event.stub',
+        path: '/someDir',
         isFile: () => true,
         isDirectory: () => false,
         isBlockDevice: () => false,
@@ -38,6 +40,7 @@ describe('stub', async () => {
       },
       {
         name: 'fake-directory',
+        path: '/someDir',
         isFile: () => false,
         isDirectory: () => true,
         isBlockDevice: () => false,

--- a/packages/cli/test/configRoot.ts
+++ b/packages/cli/test/configRoot.ts
@@ -1,0 +1,3 @@
+import * as path from 'path'
+
+export const root = path.join(__dirname, '..')

--- a/packages/cli/test/configRoot.ts
+++ b/packages/cli/test/configRoot.ts
@@ -1,3 +1,0 @@
-import * as path from 'path'
-
-export const root = path.join(__dirname, '..')

--- a/packages/cli/test/services/environment.test.ts
+++ b/packages/cli/test/services/environment.test.ts
@@ -1,6 +1,6 @@
 import { initializeEnvironment, currentEnvironment } from '../../src/services/environment'
 import { logger } from '../../src/services/logger'
-import { restore, replace, fake, stub } from 'sinon'
+import { restore, replace, fake } from 'sinon'
 import { expect } from '../expect'
 
 describe('environment service', (): void => {
@@ -21,7 +21,6 @@ describe('environment service', (): void => {
   describe('currentEnvironment', (): void => {
     it('get current environment: testing', async () => {
       process.env.BOOSTER_ENV = 'testing'
-      stub(process.env, 'BOOSTER_ENV').value('testing')
       expect(currentEnvironment()).to.be.equal('testing')
     })
 
@@ -39,11 +38,9 @@ describe('environment service', (): void => {
     describe('process.env.BOOSTER_ENV set', (): void => {
       beforeEach(() => {
         process.env.BOOSTER_ENV = 'testing'
-        stub(process.env, 'BOOSTER_ENV').value('testing')
       })
 
       it('set environment in param: no log message', async () => {
-        stub(process.env, 'BOOSTER_ENV').value('testing')
         initializeEnvironment(logger, 'production')
         expect(logger.error).to.not.have.been.calledWithMatch(logMessage)
         expect(process.env.BOOSTER_ENV).to.be.equal('production')

--- a/packages/cli/test/services/environment.test.ts
+++ b/packages/cli/test/services/environment.test.ts
@@ -37,7 +37,12 @@ describe('environment service', (): void => {
 
     describe('process.env.BOOSTER_ENV set', (): void => {
       beforeEach(() => {
-        process.env.BOOSTER_ENV = 'testing'
+        process.env.BOOSTER_ENV = ''
+        replace(process.env, 'BOOSTER_ENV', 'testing')
+      })
+
+      afterEach(() => {
+        restore()
       })
 
       it('set environment in param: no log message', async () => {

--- a/packages/cli/test/services/stub-publisher.test.ts
+++ b/packages/cli/test/services/stub-publisher.test.ts
@@ -18,6 +18,7 @@ describe('stub publisher', () => {
   const directoryFileMocks: fs.Dirent[] = [
     {
       name: 'fake-command.stub',
+      path: '/someDir',
       isFile: () => true,
       isDirectory: () => false,
       isBlockDevice: () => false,
@@ -28,6 +29,7 @@ describe('stub publisher', () => {
     },
     {
       name: 'fake-event.stub',
+      path: '/someDir',
       isFile: () => true,
       isDirectory: () => false,
       isBlockDevice: () => false,
@@ -38,6 +40,7 @@ describe('stub publisher', () => {
     },
     {
       name: 'fake-stub.ts',
+      path: '/someDir',
       isFile: () => true,
       isDirectory: () => false,
       isBlockDevice: () => false,
@@ -48,6 +51,7 @@ describe('stub publisher', () => {
     },
     {
       name: 'fake-directory-1',
+      path: '/someDir',
       isFile: () => false,
       isDirectory: () => true,
       isBlockDevice: () => false,
@@ -58,6 +62,7 @@ describe('stub publisher', () => {
     },
     {
       name: 'fake-directory-2',
+      path: '/someDir',
       isFile: () => false,
       isDirectory: () => true,
       isBlockDevice: () => false,
@@ -154,6 +159,7 @@ describe('stub publisher', () => {
         const filteredFiles = createTemplateFileMap([
           {
             name: 'fake-file-1.stub',
+            path: '/someDir',
             isFile: () => true,
             isDirectory: () => false,
             isBlockDevice: () => false,
@@ -164,6 +170,7 @@ describe('stub publisher', () => {
           },
           {
             name: 'fake-file-2.stub',
+            path: '/someDir',
             isFile: () => true,
             isDirectory: () => false,
             isBlockDevice: () => false,
@@ -187,6 +194,7 @@ describe('stub publisher', () => {
         const filteredFiles = createTemplateFileMap([
           {
             name: 'fake-directory',
+            path: '/someDir',
             isFile: () => false,
             isDirectory: () => true,
             isBlockDevice: () => false,
@@ -204,6 +212,7 @@ describe('stub publisher', () => {
         const filteredFiles = createTemplateFileMap([
           {
             name: 'fake-stub.ts',
+            path: '/someDir',
             isFile: () => true,
             isDirectory: () => false,
             isBlockDevice: () => false,


### PR DESCRIPTION
Branch with the necessary changes to fix the CLI unit testing

## Change list 

### Add rootConfig helper
- `packages/cli/test/configRoot.ts`

### Add LoadConfig before @oclif/command testing
- `packages/cli/test/commands/deploy.test.ts`
- `packages/cli/test/commands/nuke.test.ts`
- `packages/cli/test/commands/start.test.ts`

### Remove unnecessary environments stubs
- `packages/cli/test/services/environment.test.ts`
-
### Add path to fs.Dirent object
- `packages/cli/test/services/stub-publisher.test.ts`
- `packages/cli/test/services/stub-publisher.test.ts`

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- N/A Updated documentation accordingly