### PR TITLE
AWS unit tests now pass after changing expected input

### DIFF
--- a/packages/framework-provider-aws/test/library/read-models-searcher-adapter.test.ts
+++ b/packages/framework-provider-aws/test/library/read-models-searcher-adapter.test.ts
@@ -190,7 +190,7 @@ describe('Read models searcher adapter', () => {
       const expectedInput = {
         ...expectedParams,
         FilterExpression:
-          '(attribute_exists(#days) and attribute_not_exists(#mainItem) and attribute_exists(#mainItem.#sku) and attribute_exists(#mainItem.#sku.#price))',
+          '(attribute_exists(#days) and attribute_not_exists(#mainItem) and attribute_exists(#mainItem.#sku) and attribute_exists(#mainItem.#price))',
         ExpressionAttributeNames: {
           '#days': 'days',
           '#mainItem': 'mainItem',


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#github-flow
- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#publishing-your-pull-request

- Make sure you followed our Code style https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#code-style-guidelines

- Make sure everything works https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#getting-the-code

- Run tests 🐛 https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#running-unit-tests

-->

## Description
<Describe the purpose of this pull request>

## Changes

- Changed expected input for for the 1 failing test in `@boostercloud/framework-provider-aws`, there was a change in the upgrade PR but the expected input wasn't changed, making the test fail

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
