### PR TITLE
Fix event api for events and notifications not found

### DIFF
--- a/common/changes/@boostercloud/framework-core/fix_event_api_events_notifications_not_found_2023-10-02-13-14.json
+++ b/common/changes/@boostercloud/framework-core/fix_event_api_events_notifications_not_found_2023-10-02-13-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "Fix event api for events and notifications not found",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1543,7 +1543,7 @@ packages:
       '@aws-cdk/aws-logs': 1.199.0_tqi77pcvvujtgay5663ykqn7wy
       '@aws-cdk/aws-s3': 1.199.0_wim6pvar6pmwiq3fs3ksmix5ru
       '@aws-cdk/aws-s3-assets': 1.199.0_tqi77pcvvujtgay5663ykqn7wy
-      '@aws-cdk/aws-secretsmanager': 1.199.0_uxypjio4ejtfqgxognd5fibs2q
+      '@aws-cdk/aws-secretsmanager': 1.199.0_maqnqwhn36fygp3z4rdnivbxii
       '@aws-cdk/core': 1.199.0_kscyon7amn7dglog7cugnqvkwm
       '@aws-cdk/region-info': 1.199.0
       constructs: 3.4.293
@@ -1765,7 +1765,7 @@ packages:
       '@aws-cdk/aws-route53-targets': 1.199.0_6qn3q4quwxpkjgl3z2r2rmaqqi
       '@aws-cdk/aws-s3': 1.199.0_wim6pvar6pmwiq3fs3ksmix5ru
       '@aws-cdk/aws-s3-assets': 1.199.0_tqi77pcvvujtgay5663ykqn7wy
-      '@aws-cdk/aws-secretsmanager': 1.199.0_uxypjio4ejtfqgxognd5fibs2q
+      '@aws-cdk/aws-secretsmanager': 1.199.0_maqnqwhn36fygp3z4rdnivbxii
       '@aws-cdk/aws-servicediscovery': 1.199.0_4axszbdsnc7kzhsa3r5g56z4bu
       '@aws-cdk/aws-sns': 1.199.0_wim6pvar6pmwiq3fs3ksmix5ru
       '@aws-cdk/aws-sqs': 1.199.0_iumdymv27iwprkm3rzoqxlpuia
@@ -2011,7 +2011,7 @@ packages:
       '@aws-cdk/aws-lambda': 1.199.0_5pbncl2no5vqinyo3n2ekkob5q
       '@aws-cdk/aws-s3': 1.199.0_wim6pvar6pmwiq3fs3ksmix5ru
       '@aws-cdk/aws-s3-notifications': 1.199.0_fufarp47blk4okwshjegj2wjg4
-      '@aws-cdk/aws-secretsmanager': 1.199.0_uxypjio4ejtfqgxognd5fibs2q
+      '@aws-cdk/aws-secretsmanager': 1.199.0_maqnqwhn36fygp3z4rdnivbxii
       '@aws-cdk/aws-sns': 1.199.0_wim6pvar6pmwiq3fs3ksmix5ru
       '@aws-cdk/aws-sns-subscriptions': 1.199.0_x7skkdpav5hf4ncc76dwztyszi
       '@aws-cdk/aws-sqs': 1.199.0_iumdymv27iwprkm3rzoqxlpuia
@@ -2236,7 +2236,7 @@ packages:
       constructs: 3.4.293
     dev: false
 
-  /@aws-cdk/aws-secretsmanager/1.199.0_uxypjio4ejtfqgxognd5fibs2q:
+  /@aws-cdk/aws-secretsmanager/1.199.0_maqnqwhn36fygp3z4rdnivbxii:
     resolution: {integrity: sha512-Dj0+q7I9xRwg1hHowrHb9rxmicDGZVmQixFaFuBdsS5zNfBNdC6WJGWhDddJDZIPclip06fXBm/by4+l4XUpNw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -2246,12 +2246,18 @@ packages:
       '@aws-cdk/cx-api': 1.199.0
       constructs: ^3.3.69
     dependencies:
+      '@aws-cdk/aws-ec2': 1.199.0_ylylsu27pdmlfxyxktlluxtkr4
       '@aws-cdk/aws-iam': 1.199.0_xwfh4icwyvj4zfjhzlqde6qllu
+      '@aws-cdk/aws-kms': 1.199.0_iumdymv27iwprkm3rzoqxlpuia
       '@aws-cdk/aws-lambda': 1.199.0_5pbncl2no5vqinyo3n2ekkob5q
       '@aws-cdk/aws-sam': 1.199.0_xwfh4icwyvj4zfjhzlqde6qllu
       '@aws-cdk/core': 1.199.0_kscyon7amn7dglog7cugnqvkwm
       '@aws-cdk/cx-api': 1.199.0
       constructs: 3.4.293
+    transitivePeerDependencies:
+      - '@aws-cdk/assets'
+      - '@aws-cdk/aws-logs'
+      - '@aws-cdk/aws-s3'
     dev: false
 
   /@aws-cdk/aws-servicediscovery/1.199.0_4axszbdsnc7kzhsa3r5g56z4bu:
@@ -3495,7 +3501,7 @@ packages:
     dev: true
 
   /@pkgjs/parseargs/0.11.0:
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==, tarball: https://repo1.uhc.com:443/artifactory/api/npm/npm-virtual/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
     engines: {node: '>=14'}
     requiresBuild: true
     dev: true
@@ -6488,7 +6494,7 @@ packages:
     dev: true
 
   /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, tarball: https://repo1.uhc.com:443/artifactory/api/npm/npm-virtual/fsevents/-/fsevents-2.3.2.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true

--- a/packages/framework-core/src/booster-event-search.ts
+++ b/packages/framework-core/src/booster-event-search.ts
@@ -1,0 +1,34 @@
+import {
+  BoosterConfig,
+  EventMetadata,
+  EventSearchParameters,
+  EventSearchResponse,
+  NotificationMetadata,
+} from '@boostercloud/framework-types'
+import { createInstance, getLogger } from '@boostercloud/framework-common-helpers'
+
+export async function eventSearch(
+  config: BoosterConfig,
+  request: EventSearchParameters
+): Promise<Array<EventSearchResponse>> {
+  const events: Array<EventSearchResponse> = await config.provider.events.search(config, request)
+  return events.map((event) => createEventValueInstance(config, event))
+}
+
+function createEventValueInstance(config: BoosterConfig, event: EventSearchResponse): EventSearchResponse {
+  const logger = getLogger(config, 'booster-event-search#createEventValueInstance')
+  const eventMetadata: EventMetadata = config.events[event.type]
+  if (eventMetadata) {
+    event.value = createInstance(eventMetadata.class, event.value)
+    logger.debug(`Found @Event for "${event.type}". Created value instance`)
+    return event
+  }
+  const notificationMetadata: NotificationMetadata = config.notifications[event.type]
+  if (notificationMetadata) {
+    event.value = createInstance(notificationMetadata.class, event.value)
+    logger.debug(`Found @Notification for "${event.type}"`)
+  } else {
+    logger.warn(`Could not find @Event or @Notification class for "${event.type}". Returned the event as it was`)
+  }
+  return event
+}

--- a/packages/framework-core/src/booster.ts
+++ b/packages/framework-core/src/booster.ts
@@ -30,6 +30,7 @@ import { JwksUriTokenVerifier, JWT_ENV_VARS } from './services/token-verifiers'
 import { BoosterAuthorizer } from './booster-authorizer'
 import { BoosterReadModelsReader } from './booster-read-models-reader'
 import { BoosterEntityTouched } from './core-concepts/touch-entity/events/booster-entity-touched'
+import { eventSearch } from './booster-event-search'
 
 /**
  * Main class to interact with Booster and configure it.
@@ -103,12 +104,7 @@ export class Booster {
   }
 
   public static async events(request: EventSearchParameters): Promise<Array<EventSearchResponse>> {
-    const events: Array<EventSearchResponse> = await this.config.provider.events.search(this.config, request)
-    return events.map((event) => {
-      const eventMetadata = this.config.events[event.type]
-      event.value = createInstance(eventMetadata.class, event.value)
-      return event
-    })
+    return eventSearch(this.config, request)
   }
 
   public static async entitiesIDs(

--- a/packages/framework-integration-tests/src/common/custom-logger.ts
+++ b/packages/framework-integration-tests/src/common/custom-logger.ts
@@ -1,0 +1,74 @@
+import { Level, Logger } from '@boostercloud/framework-types'
+import * as util from 'util'
+
+function formatMessage(message?: any, ...optionalParams: any[]): string {
+  return util
+    .format(message, ...optionalParams)
+    .replace(/\n|\\n/g, ' ')
+    .replace(/\s+/g, ' ')
+}
+
+function getLogLevelColor(logLevel: Level): string {
+  let errorColor = ''
+  switch (logLevel) {
+    case Level.error:
+      errorColor = '\x1B[31m'
+      break
+    case Level.warn:
+      errorColor = '\x1B[33m'
+      break
+    case Level.info:
+      errorColor = '\x1B[34m'
+      break
+    case Level.debug:
+      errorColor = '\x1B[32m'
+      break
+    default:
+      errorColor = ''
+  }
+  return errorColor
+}
+
+function getLogLevelMessage(logLevel: Level): string {
+  const logLevelMessage = Level[logLevel].toUpperCase()
+  if (process.env.BOOSTER_ENV === 'local') {
+    const color = getLogLevelColor(logLevel)
+    return `${color}[${logLevelMessage}]: `
+  }
+  return `[${logLevelMessage}]: `
+}
+
+function newLine() {
+  if (process.env.BOOSTER_ENV === 'local') {
+    process.stdout.write('\x1B[0m')
+  }
+  process.stdout.write('\n')
+}
+
+const log = (logLevel: Level, message?: any, ...optionalParams: any[]): void => {
+  if (process.env.BOOSTER_ENV === 'local') {
+    process.stdout.write(util.format(`${getLogLevelColor(logLevel)}${new Date().toISOString()} - `))
+  }
+  const logLevelMessage = getLogLevelMessage(logLevel)
+  process.stdout.write(util.format(logLevelMessage))
+  process.stdout.write(formatMessage(message, optionalParams))
+  newLine()
+}
+
+export class CustomLogger implements Logger {
+  debug(message?: any, ...optionalParams: any[]): void {
+    log(Level.debug, message, ...optionalParams)
+  }
+
+  info(message?: any, ...optionalParams: any[]): void {
+    log(Level.info, message, ...optionalParams)
+  }
+
+  warn(message?: any, ...optionalParams: any[]): void {
+    log(Level.warn, message, ...optionalParams)
+  }
+
+  error(message?: any, ...optionalParams: any[]): void {
+    log(Level.error, message, ...optionalParams)
+  }
+}

--- a/packages/framework-integration-tests/src/common/custom-tracer.ts
+++ b/packages/framework-integration-tests/src/common/custom-tracer.ts
@@ -1,14 +1,14 @@
 import { TraceInfo, BoosterConfig, TraceTypes } from '@boostercloud/framework-types'
+import { getLogger } from '@boostercloud/framework-common-helpers'
 
 export class CustomTracer {
   static async onStart(config: BoosterConfig, actionType: string, traceInfo: TraceInfo): Promise<void> {
-    console.log(`${TraceTypes[TraceTypes.START]}: ${actionType}`, traceInfo)
+    const logger = getLogger(config, 'CustomTracer#onStart')
+    logger.debug(`${TraceTypes[TraceTypes.START]}: ${actionType}`, traceInfo)
   }
 
   static async onEnd(config: BoosterConfig, actionType: string, traceInfo: TraceInfo): Promise<void> {
-    console.log(
-      `${TraceTypes[TraceTypes.END]}: ${actionType} (${traceInfo.elapsedInvocationMillis} ms)\n`,
-      traceInfo
-    )
+    const logger = getLogger(config, 'CustomTracer#onEnd')
+    logger.debug(`${TraceTypes[TraceTypes.END]}: ${actionType} (${traceInfo.elapsedInvocationMillis} ms)\n`, traceInfo)
   }
 }

--- a/packages/framework-integration-tests/src/config/config.ts
+++ b/packages/framework-integration-tests/src/config/config.ts
@@ -3,12 +3,17 @@ import { BoosterConfig, DecodedToken, TraceActionTypes } from '@boostercloud/fra
 import * as fs from 'fs'
 import * as path from 'path'
 import { CustomTracer } from '../common/custom-tracer'
+import { CustomLogger } from '../common/custom-logger'
 
 class CustomPublicKeyTokenVerifier extends PublicKeyTokenVerifier {
   public async verify(token: string): Promise<DecodedToken> {
     await super.verify(token)
     throw new Error('Unauthorized')
   }
+}
+
+function configureLogger(config: BoosterConfig): void {
+  config.logger = new CustomLogger()
 }
 
 function configureInvocationsHandler(config: BoosterConfig) {
@@ -38,6 +43,7 @@ Booster.configure('local', (config: BoosterConfig): void => {
     ),
   ]
   configureInvocationsHandler(config)
+  configureLogger(config)
 })
 
 Booster.configure('development', (config: BoosterConfig): void => {
@@ -103,4 +109,5 @@ Booster.configure('azure', (config: BoosterConfig): void => {
     ),
   ]
   configureInvocationsHandler(config)
+  configureLogger(config)
 })

--- a/packages/framework-types/src/envelope.ts
+++ b/packages/framework-types/src/envelope.ts
@@ -96,7 +96,7 @@ export interface EventSearchResponse {
   requestID: UUID
   user?: UserEnvelope
   createdAt: string
-  value: EventInterface
+  value: EventInterface | NotificationInterface
 }
 
 export interface ReadModelEnvelope {


### PR DESCRIPTION
When we use the event API to get events Booster try to creates instances from them. This could cause issues if the event class had been removed. If the event class doesn’t exist Booster should not create the instance and the content will be a plain object

Also, when we use the event API to get notifications events Booster is not able to find the event class. Also, if the class doesn’t exist Booster should not fail but keep the event as a plain object.