### PR TITLE
Fix CLI error handling issue

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -32,9 +32,7 @@ export default class Build extends BaseCommand {
       flags: { verbose },
     } = this.parse(Build)
 
-    if (verbose) {
-      console.error(fullError.message)
-    }
+    console.error(fullError.message)
 
     return super.catch(fullError)
   }


### PR DESCRIPTION
## Description
This pull request addresses the issue #1341, which involves fixing the behavior of the `catch` method in the `Build` class. Currently, when a compilation error occurs during the build process, the CLI fails silently, and errors are not displayed to the user. The purpose of this PR is to modify the code so that compilation errors are always displayed, regardless of the `verbose` flag.

## Changes
- Modified the `catch` method in the `Build` class to unconditionally log error messages to the console when a compilation error occurs.

Closes #1341
