### PR TITLE
Fix documentation typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ To start contributing to the project you would need to set up the project in you
 
 - Add your contribution
 
-- Make sure everything works by [executing the unit tests](#running-unit-tests): `rush rest`
+- Make sure everything works by [executing the unit tests](#running-unit-tests): `rush test`
 
 > **DISCLAIMER**: The integration test process changed, feel free to chime in into our Discord for more info
 


### PR DESCRIPTION
## Description
I have corrected a documentation typo in the `CONTRIBUTING.md` file. The original text mentioned "rust rest," which has been updated to the correct "rust test" to provide accurate and clear instructions.

Closes #1448