### PR TITLE
fixed incorrect return type of Searcher.searchOne

### DIFF
--- a/packages/framework-types/src/searcher.ts
+++ b/packages/framework-types/src/searcher.ts
@@ -85,13 +85,13 @@ export class Searcher<TObject> {
   }
 
   /**
-   * @deprecated [EOL v3] Use searchOnce instead
+   * @deprecated [EOL v3] Use searchOne instead
    */
   public async findById(id: UUID, sequenceKey?: SequenceKey): Promise<TObject | ReadOnlyNonEmptyArray<TObject>> {
     return this.finderByKeyFunction(this.objectClass, id, sequenceKey)
   }
 
-  public async searchOne(): Promise<TObject> {
+  public async searchOne(): Promise<TObject | undefined> {
     // TODO: If there is only an ID filter with one value, this should call to `findById`
     const searchResult = await this.searcherFunction(
       this.objectClass,


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#github-flow
- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#publishing-your-pull-request

- Make sure you followed our Code style https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#code-style-guidelines

- Make sure everything works https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#getting-the-code

- Run tests 🐛 https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#running-unit-tests

-->

## Description
<Describe the purpose of this pull request>

## Changes

Return type of Searcher.searchOne was incorrect, fixed. Also fixed deprecation notice for Searcher.findById pointing to nonexistant function.

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [X] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
