### PR TITLE
fix: ws dependency vulnerability

### DIFF
--- a/common/changes/@boostercloud/framework-core/ws_version_bump_2024-07-25-19-50.json
+++ b/common/changes/@boostercloud/framework-core/ws_version_bump_2024-07-25-19-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "Bump ws version (fixes CVE-2024-37890)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
   ../../packages/application-tester:
     specifiers:
       '@apollo/client': 3.7.13
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@types/jsonwebtoken': 9.0.1
       '@types/node': ^18.18.2
@@ -35,7 +35,7 @@ importers:
       subscriptions-transport-ws: 0.11.0
       tslib: ^2.4.0
       typescript: 5.1.6
-      ws: 8.12.0
+      ws: 8.17.1
     dependencies:
       '@apollo/client': 3.7.13_pvbge6vplei5rx3k4pxg27es3y
       '@boostercloud/framework-types': link:../framework-types
@@ -47,7 +47,7 @@ importers:
       sinon: 9.2.3
       subscriptions-transport-ws: 0.11.0_graphql@16.9.0
       tslib: 2.6.3
-      ws: 8.12.0
+      ws: 8.17.1
     devDependencies:
       '@boostercloud/eslint-config': link:../../tools/eslint-config
       '@types/jsonwebtoken': 9.0.1
@@ -70,10 +70,10 @@ importers:
 
   ../../packages/cli:
     specifiers:
-      '@boostercloud/application-tester': workspace:^2.12.1
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-core': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
+      '@boostercloud/application-tester': workspace:^2.13.0
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-core': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@oclif/core': 3.15.0
       '@oclif/plugin-help': ^5
@@ -183,8 +183,8 @@ importers:
 
   ../../packages/framework-common-helpers:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -258,10 +258,10 @@ importers:
 
   ../../packages/framework-core:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-common-helpers': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
-      '@boostercloud/metadata-booster': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-common-helpers': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
+      '@boostercloud/metadata-booster': workspace:^2.13.0
       '@effect/cli': 0.35.26
       '@effect/platform': 0.48.24
       '@effect/platform-node': 0.45.26
@@ -314,12 +314,12 @@ importers:
       tslib: ^2.4.0
       typescript: 5.1.6
       validator: 13.7.0
-      ws: 8.12.0
+      ws: 8.17.1
     dependencies:
       '@boostercloud/framework-common-helpers': link:../framework-common-helpers
       '@boostercloud/framework-types': link:../framework-types
       '@effect/cli': 0.35.26_q3uix5ylsud7xnsn3vpzgrghwu
-      '@effect/platform': 0.48.24_dyvpp6bxxcuou3trhs4x4ygr5y
+      '@effect/platform': 0.48.24_aixcdyfeuz2zct7jthaihye4ri
       '@effect/platform-node': 0.45.26_cahjalgelcnk6vcj6x2oc46m3a
       '@effect/printer': 0.32.2_67ibgamlfqfgywvgecp7hwrxja
       '@effect/printer-ansi': 0.32.26_67ibgamlfqfgywvgecp7hwrxja
@@ -337,7 +337,7 @@ importers:
       reflect-metadata: 0.1.13
       tslib: 2.6.3
       validator: 13.7.0
-      ws: 8.12.0
+      ws: 8.17.1
     devDependencies:
       '@boostercloud/eslint-config': link:../../tools/eslint-config
       '@boostercloud/metadata-booster': link:../metadata-booster
@@ -378,19 +378,19 @@ importers:
   ../../packages/framework-integration-tests:
     specifiers:
       '@apollo/client': 3.7.13
-      '@boostercloud/application-tester': workspace:^2.12.1
-      '@boostercloud/cli': workspace:^2.12.1
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-common-helpers': workspace:^2.12.1
-      '@boostercloud/framework-core': workspace:^2.12.1
-      '@boostercloud/framework-provider-aws': workspace:^2.12.1
-      '@boostercloud/framework-provider-aws-infrastructure': workspace:^2.12.1
-      '@boostercloud/framework-provider-azure': workspace:^2.12.1
-      '@boostercloud/framework-provider-azure-infrastructure': workspace:^2.12.1
-      '@boostercloud/framework-provider-local': workspace:^2.12.1
-      '@boostercloud/framework-provider-local-infrastructure': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
-      '@boostercloud/metadata-booster': workspace:^2.12.1
+      '@boostercloud/application-tester': workspace:^2.13.0
+      '@boostercloud/cli': workspace:^2.13.0
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-common-helpers': workspace:^2.13.0
+      '@boostercloud/framework-core': workspace:^2.13.0
+      '@boostercloud/framework-provider-aws': workspace:^2.13.0
+      '@boostercloud/framework-provider-aws-infrastructure': workspace:^2.13.0
+      '@boostercloud/framework-provider-azure': workspace:^2.13.0
+      '@boostercloud/framework-provider-azure-infrastructure': workspace:^2.13.0
+      '@boostercloud/framework-provider-local': workspace:^2.13.0
+      '@boostercloud/framework-provider-local-infrastructure': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
+      '@boostercloud/metadata-booster': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@effect/cli': 0.35.26
       '@effect/platform': 0.48.24
@@ -453,7 +453,7 @@ importers:
       ts-patch: 3.1.2
       tslib: ^2.4.0
       typescript: 5.1.6
-      ws: 8.12.0
+      ws: 8.17.1
     dependencies:
       '@boostercloud/framework-common-helpers': link:../framework-common-helpers
       '@boostercloud/framework-core': link:../framework-core
@@ -463,7 +463,7 @@ importers:
       '@boostercloud/framework-types': link:../framework-types
       '@effect-ts/core': 0.60.5
       '@effect/cli': 0.35.26_q3uix5ylsud7xnsn3vpzgrghwu
-      '@effect/platform': 0.48.24_dyvpp6bxxcuou3trhs4x4ygr5y
+      '@effect/platform': 0.48.24_aixcdyfeuz2zct7jthaihye4ri
       '@effect/platform-node': 0.45.26_cahjalgelcnk6vcj6x2oc46m3a
       '@effect/printer': 0.32.2_67ibgamlfqfgywvgecp7hwrxja
       '@effect/printer-ansi': 0.32.26_67ibgamlfqfgywvgecp7hwrxja
@@ -476,7 +476,7 @@ importers:
       fast-check: 3.19.0
       graphql: 16.9.0
       tslib: 2.6.3
-      ws: 8.12.0
+      ws: 8.17.1
     devDependencies:
       '@apollo/client': 3.7.13_jxorufveymi4xbrutgakjkp5wa
       '@boostercloud/application-tester': link:../application-tester
@@ -536,9 +536,9 @@ importers:
 
   ../../packages/framework-provider-aws:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-common-helpers': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-common-helpers': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@types/aws-lambda': 8.10.48
       '@types/chai': 4.2.18
@@ -632,10 +632,10 @@ importers:
       '@aws-cdk/core': ^1.170.0
       '@aws-cdk/custom-resources': ^1.170.0
       '@aws-cdk/cx-api': ^1.170.0
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-common-helpers': workspace:^2.12.1
-      '@boostercloud/framework-provider-aws': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-common-helpers': workspace:^2.13.0
+      '@boostercloud/framework-provider-aws': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@types/archiver': 5.1.0
       '@types/aws-lambda': 8.10.48
@@ -749,9 +749,9 @@ importers:
       '@azure/functions': ^1.2.2
       '@azure/identity': ~2.1.0
       '@azure/web-pubsub': ~1.1.0
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-common-helpers': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-common-helpers': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -823,11 +823,11 @@ importers:
       '@azure/arm-resources': ^5.0.1
       '@azure/cosmos': ^4.0.0
       '@azure/identity': ~2.1.0
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-common-helpers': workspace:^2.12.1
-      '@boostercloud/framework-core': workspace:^2.12.1
-      '@boostercloud/framework-provider-azure': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-common-helpers': workspace:^2.13.0
+      '@boostercloud/framework-core': workspace:^2.13.0
+      '@boostercloud/framework-provider-azure': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
       '@cdktf/provider-azurerm': 11.2.0
       '@cdktf/provider-time': 9.0.2
       '@effect-ts/core': ^0.60.4
@@ -934,9 +934,9 @@ importers:
 
   ../../packages/framework-provider-local:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-common-helpers': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-common-helpers': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@seald-io/nedb': 4.0.2
       '@types/chai': 4.2.18
@@ -970,14 +970,14 @@ importers:
       ts-node: ^10.9.1
       tslib: ^2.4.0
       typescript: 5.1.6
-      ws: 8.12.0
+      ws: 8.17.1
     dependencies:
       '@boostercloud/framework-common-helpers': link:../framework-common-helpers
       '@boostercloud/framework-types': link:../framework-types
       '@effect-ts/core': 0.60.5
       '@seald-io/nedb': 4.0.2
       tslib: 2.6.3
-      ws: 8.12.0
+      ws: 8.17.1
     devDependencies:
       '@boostercloud/eslint-config': link:../../tools/eslint-config
       '@types/chai': 4.2.18
@@ -1013,10 +1013,10 @@ importers:
 
   ../../packages/framework-provider-local-infrastructure:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/framework-common-helpers': workspace:^2.12.1
-      '@boostercloud/framework-provider-local': workspace:^2.12.1
-      '@boostercloud/framework-types': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/framework-common-helpers': workspace:^2.13.0
+      '@boostercloud/framework-provider-local': workspace:^2.13.0
+      '@boostercloud/framework-types': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -1096,8 +1096,8 @@ importers:
 
   ../../packages/framework-types:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.12.1
-      '@boostercloud/metadata-booster': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
+      '@boostercloud/metadata-booster': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@effect-ts/node': ~0.39.0
       '@effect/cli': 0.35.26
@@ -1135,12 +1135,12 @@ importers:
       typescript: 5.1.6
       uuid: 8.3.2
       web-streams-polyfill: ~3.3.2
-      ws: 8.12.0
+      ws: 8.17.1
     dependencies:
       '@effect-ts/core': 0.60.5
       '@effect-ts/node': 0.39.0_@effect-ts+core@0.60.5
       '@effect/cli': 0.35.26_q3uix5ylsud7xnsn3vpzgrghwu
-      '@effect/platform': 0.48.24_dyvpp6bxxcuou3trhs4x4ygr5y
+      '@effect/platform': 0.48.24_aixcdyfeuz2zct7jthaihye4ri
       '@effect/printer': 0.32.2_67ibgamlfqfgywvgecp7hwrxja
       '@effect/printer-ansi': 0.32.26_67ibgamlfqfgywvgecp7hwrxja
       '@effect/schema': 0.64.18_5wzfkogs2kowufbtxgyqyusxye
@@ -1149,7 +1149,7 @@ importers:
       tslib: 2.6.3
       uuid: 8.3.2
       web-streams-polyfill: 3.3.3
-      ws: 8.12.0
+      ws: 8.17.1
     devDependencies:
       '@boostercloud/eslint-config': link:../../tools/eslint-config
       '@boostercloud/metadata-booster': link:../metadata-booster
@@ -1181,7 +1181,7 @@ importers:
 
   ../../packages/metadata-booster:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.12.1
+      '@boostercloud/eslint-config': workspace:^2.13.0
       '@effect-ts/core': ^0.60.4
       '@types/node': ^18.18.2
       '@typescript-eslint/eslint-plugin': ^5.0.0
@@ -1668,10 +1668,11 @@ packages:
       '@aws-cdk/aws-logs': 1.204.0_l4ztnfmrjykhsbk6ow7yhidayu
       '@aws-cdk/aws-s3': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/aws-s3-assets': 1.204.0_l4ztnfmrjykhsbk6ow7yhidayu
-      '@aws-cdk/aws-secretsmanager': 1.204.0_2o53qceqenzlpxe4mjswmsqfiq
+      '@aws-cdk/aws-secretsmanager': 1.204.0_336juigttbrwz7tyvm6a6wfpy4
       '@aws-cdk/core': 1.204.0_hol6usdabdbzhugfw355k4ebam
       '@aws-cdk/region-info': 1.204.0
       constructs: 3.4.344
+      yaml: 1.10.2
     transitivePeerDependencies:
       - '@aws-cdk/aws-lambda'
       - '@aws-cdk/cx-api'
@@ -1787,6 +1788,7 @@ packages:
       '@aws-cdk/core': 1.204.0_hol6usdabdbzhugfw355k4ebam
       '@aws-cdk/custom-resources': 1.204.0_c23kgzmvfhgnr6qpzzlbsfzuc4
       constructs: 3.4.344
+      punycode: 2.3.1
     transitivePeerDependencies:
       - '@aws-cdk/aws-ec2'
       - '@aws-cdk/aws-logs'
@@ -1941,7 +1943,7 @@ packages:
       '@aws-cdk/aws-route53-targets': 1.204.0_2eviprr3zwoouaslbumtdekrhi
       '@aws-cdk/aws-s3': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/aws-s3-assets': 1.204.0_l4ztnfmrjykhsbk6ow7yhidayu
-      '@aws-cdk/aws-secretsmanager': 1.204.0_2o53qceqenzlpxe4mjswmsqfiq
+      '@aws-cdk/aws-secretsmanager': 1.204.0_336juigttbrwz7tyvm6a6wfpy4
       '@aws-cdk/aws-servicediscovery': 1.204.0_nu23nesxfni464wb5cy4ehgagi
       '@aws-cdk/aws-sns': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/aws-sqs': 1.204.0_cttdkzy7hngahjug7jmkfylr2y
@@ -2242,7 +2244,7 @@ packages:
       '@aws-cdk/aws-lambda': 1.204.0_afnjft5qr3fswieaeg3dwwhnvm
       '@aws-cdk/aws-s3': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/aws-s3-notifications': 1.204.0_xguspq3b5n56mo6dsez57f32qa
-      '@aws-cdk/aws-secretsmanager': 1.204.0_2o53qceqenzlpxe4mjswmsqfiq
+      '@aws-cdk/aws-secretsmanager': 1.204.0_336juigttbrwz7tyvm6a6wfpy4
       '@aws-cdk/aws-sns': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/aws-sns-subscriptions': 1.204.0_bpkznh2gsccwq6qpaogbkb4psu
       '@aws-cdk/aws-sqs': 1.204.0_cttdkzy7hngahjug7jmkfylr2y
@@ -2436,6 +2438,7 @@ packages:
       '@aws-cdk/aws-s3-assets': 1.204.0_l4ztnfmrjykhsbk6ow7yhidayu
       '@aws-cdk/core': 1.204.0_hol6usdabdbzhugfw355k4ebam
       '@aws-cdk/lambda-layer-awscli': 1.204.0_e7ybiu4yrrtvf3zlvzrvcjkvyy
+      case: 1.6.3
       constructs: 3.4.344
     transitivePeerDependencies:
       - '@aws-cdk/assets'
@@ -2511,7 +2514,7 @@ packages:
       constructs: 3.4.344
     dev: false
 
-  /@aws-cdk/aws-secretsmanager/1.204.0_2o53qceqenzlpxe4mjswmsqfiq:
+  /@aws-cdk/aws-secretsmanager/1.204.0_336juigttbrwz7tyvm6a6wfpy4:
     resolution: {integrity: sha512-ykpjYmP6qVOFbHtkaQBu3Xk7xp2UTR0ouzk7pb+zrEHKGmRvzGq+8J0IU+qXBJgQIVwFAPf2IgOSTzj6FJPdyA==}
     engines: {node: '>= 14.15.0'}
     deprecated: |-
@@ -2526,18 +2529,12 @@ packages:
       '@aws-cdk/cx-api': 1.204.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.204.0_r4d2a6r7lnkv26zjzkdsvuam2a
       '@aws-cdk/aws-iam': 1.204.0_add7c2jq5lcc6idtuigbkwnzeu
-      '@aws-cdk/aws-kms': 1.204.0_cttdkzy7hngahjug7jmkfylr2y
       '@aws-cdk/aws-lambda': 1.204.0_afnjft5qr3fswieaeg3dwwhnvm
       '@aws-cdk/aws-sam': 1.204.0_add7c2jq5lcc6idtuigbkwnzeu
       '@aws-cdk/core': 1.204.0_hol6usdabdbzhugfw355k4ebam
       '@aws-cdk/cx-api': 1.203.0
       constructs: 3.4.344
-    transitivePeerDependencies:
-      - '@aws-cdk/assets'
-      - '@aws-cdk/aws-logs'
-      - '@aws-cdk/aws-s3'
     dev: false
 
   /@aws-cdk/aws-servicediscovery/1.204.0_nu23nesxfni464wb5cy4ehgagi:
@@ -2715,6 +2712,9 @@ packages:
   /@aws-cdk/cloud-assembly-schema/1.203.0:
     resolution: {integrity: sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==}
     engines: {node: '>= 14.15.0'}
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.6.2
     dev: false
     bundledDependencies:
       - jsonschema
@@ -2728,6 +2728,9 @@ packages:
       This package is no longer being updated, and users should migrate to AWS CDK v2.
 
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.6.2
     dev: false
     bundledDependencies:
       - jsonschema
@@ -2736,6 +2739,9 @@ packages:
   /@aws-cdk/cloud-assembly-schema/2.39.1:
     resolution: {integrity: sha512-lSVaaedXWeK08uoq0IXDCspz9U/H4qIERemdsMQrMUDTiUe/JBby7vtmyMvOdEscE8GMAmiOzoPmAE0Uf+yw5A==}
     engines: {node: '>= 14.15.0'}
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.6.2
     dev: false
     bundledDependencies:
       - jsonschema
@@ -2769,7 +2775,11 @@ packages:
       '@aws-cdk/cloud-assembly-schema': 1.204.0
       '@aws-cdk/cx-api': 1.203.0
       '@aws-cdk/region-info': 1.204.0
+      '@balena/dockerignore': 1.0.2
       constructs: 3.4.344
+      fs-extra: 9.1.0
+      ignore: 5.3.1
+      minimatch: 3.1.2
     dev: false
     bundledDependencies:
       - fs-extra
@@ -2812,6 +2822,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 1.203.0
+      semver: 7.6.2
     dev: false
     bundledDependencies:
       - semver
@@ -2826,6 +2837,7 @@ packages:
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 1.204.0
+      semver: 7.6.2
     dev: false
     bundledDependencies:
       - semver
@@ -2835,6 +2847,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 2.39.1
+      semver: 7.6.2
     dev: false
     bundledDependencies:
       - semver
@@ -3322,6 +3335,10 @@ packages:
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
+  /@balena/dockerignore/1.0.2:
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+    dev: false
+
   /@cdktf/cli-core/0.19.2_react@17.0.2:
     resolution: {integrity: sha512-kjgEUhrHx3kUPfL7KsTo6GrurVUPT77FmOUf7wWXt7ajNE5zCPvx/HKGmQruzt0n6eLZp1aKT+r/D6YRfXcIGA==}
     dependencies:
@@ -3515,7 +3532,7 @@ packages:
       '@effect/schema': ^0.64.18
       effect: ^2.4.17
     dependencies:
-      '@effect/platform': 0.48.24_dyvpp6bxxcuou3trhs4x4ygr5y
+      '@effect/platform': 0.48.24_aixcdyfeuz2zct7jthaihye4ri
       '@effect/printer': 0.32.2_67ibgamlfqfgywvgecp7hwrxja
       '@effect/printer-ansi': 0.32.26_67ibgamlfqfgywvgecp7hwrxja
       '@effect/schema': 0.64.18_5wzfkogs2kowufbtxgyqyusxye
@@ -3531,7 +3548,7 @@ packages:
       '@effect/platform': ^0.48.29
       effect: ^2.4.19
     dependencies:
-      '@effect/platform': 0.48.24_dyvpp6bxxcuou3trhs4x4ygr5y
+      '@effect/platform': 0.48.24_aixcdyfeuz2zct7jthaihye4ri
       '@parcel/watcher': 2.4.1
       effect: 2.4.17
       multipasta: 0.2.2
@@ -3543,18 +3560,18 @@ packages:
       '@effect/platform': ^0.48.24
       effect: ^2.4.17
     dependencies:
-      '@effect/platform': 0.48.24_dyvpp6bxxcuou3trhs4x4ygr5y
+      '@effect/platform': 0.48.24_aixcdyfeuz2zct7jthaihye4ri
       '@effect/platform-node-shared': 0.3.29_cahjalgelcnk6vcj6x2oc46m3a
       effect: 2.4.17
       mime: 3.0.0
       undici: 6.19.2
-      ws: 8.18.0
+      ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /@effect/platform/0.48.24_dyvpp6bxxcuou3trhs4x4ygr5y:
+  /@effect/platform/0.48.24_aixcdyfeuz2zct7jthaihye4ri:
     resolution: {integrity: sha512-3XQSYTNnaWZfhomBbwYlSlb0iVVwArN5ZZzJYRkm3gTDKjzhnlVD3oWbfvjeCdZ5OYCY5AAjjG/OEK8/EY7UXg==}
     peerDependencies:
       '@effect/schema': ^0.64.18
@@ -3563,7 +3580,7 @@ packages:
       '@effect/schema': 0.64.18_5wzfkogs2kowufbtxgyqyusxye
       effect: 2.4.17
       find-my-way-ts: 0.1.4
-      isomorphic-ws: 5.0.0_ws@8.12.0
+      isomorphic-ws: 5.0.0_ws@8.17.1
       multipasta: 0.2.2
       path-browserify: 1.0.1
     transitivePeerDependencies:
@@ -5524,7 +5541,10 @@ packages:
     peerDependencies:
       constructs: ^10.0.25
     dependencies:
+      archiver: 5.3.2
       constructs: 10.3.0
+      json-stable-stringify: 1.1.1
+      semver: 7.6.2
     bundledDependencies:
       - archiver
       - json-stable-stringify
@@ -6417,7 +6437,7 @@ packages:
     dependencies:
       semver: 7.6.2
       shelljs: 0.8.5
-      typescript: 5.6.0-dev.20240705
+      typescript: 5.6.0-dev.20240725
 
   /duration/0.2.2:
     resolution: {integrity: sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==}
@@ -8325,12 +8345,12 @@ packages:
       ws: 7.5.10
     dev: true
 
-  /isomorphic-ws/5.0.0_ws@8.12.0:
+  /isomorphic-ws/5.0.0_ws@8.17.1:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
     peerDependencies:
       ws: '*'
     dependencies:
-      ws: 8.12.0
+      ws: 8.17.1
     dev: false
 
   /istanbul-lib-coverage/3.2.2:
@@ -8600,6 +8620,15 @@ packages:
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  /json-stable-stringify/1.1.1:
+    resolution: {integrity: sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+
   /json-stringify-safe/5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
     dev: true
@@ -8627,6 +8656,13 @@ packages:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  /jsonify/0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
+
+  /jsonschema/1.4.1:
+    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
+    dev: false
 
   /jsonwebtoken/8.5.1:
     resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
@@ -11561,8 +11597,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript/5.6.0-dev.20240705:
-    resolution: {integrity: sha512-Z1GBiSYZqdb2B4kkFvX6sDIFZzCGD7+RtHI2/ci9IIZA1CPS6qzbiB/D2RmPupSCXpQ8FRqax1RU0tlD/n70oA==}
+  /typescript/5.6.0-dev.20240725:
+    resolution: {integrity: sha512-kgUK4mJogTfm3+NjdYSb7LIerXpAG8lyYSdPHdfGPaJyBRhMJARPENf0TeUxhEOrGRuxHTrIPKdrSOQX5xTsuw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -11865,21 +11901,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  /ws/8.12.0:
-    resolution: {integrity: sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: false
-
-  /ws/8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+  /ws/8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1

--- a/packages/application-tester/package.json
+++ b/packages/application-tester/package.json
@@ -42,7 +42,7 @@
     "jsonwebtoken": "9.0.1",
     "subscriptions-transport-ws": "0.11.0",
     "tslib": "^2.4.0",
-    "ws": "8.12.0",
+    "ws": "8.17.1",
     "@types/sinon": "10.0.0",
     "sinon": "9.2.3",
     "@effect-ts/core": "^0.60.4"

--- a/packages/framework-core/package.json
+++ b/packages/framework-core/package.json
@@ -58,7 +58,7 @@
     "@effect/typeclass": "0.23.17",
     "@effect/printer-ansi": "0.32.26",
     "@effect/platform-node": "0.45.26",
-    "ws": "8.12.0"
+    "ws": "8.17.1"
   },
   "devDependencies": {
     "@boostercloud/metadata-booster": "workspace:^2.13.0",

--- a/packages/framework-integration-tests/package.json
+++ b/packages/framework-integration-tests/package.json
@@ -30,7 +30,7 @@
     "@effect/printer-ansi": "0.32.26",
     "@effect/platform-node": "0.45.26",
     "fast-check": "^3.13.2",
-    "ws": "8.12.0"
+    "ws": "8.17.1"
   },
   "devDependencies": {
     "@boostercloud/eslint-config": "workspace:^2.13.0",

--- a/packages/framework-provider-local/package.json
+++ b/packages/framework-provider-local/package.json
@@ -28,7 +28,7 @@
     "@seald-io/nedb": "4.0.2",
     "tslib": "^2.4.0",
     "@effect-ts/core": "^0.60.4",
-    "ws": "8.12.0"
+    "ws": "8.17.1"
   },
   "scripts": {
     "format": "prettier --write --ext '.js,.ts' **/*.ts **/*/*.ts",

--- a/packages/framework-types/package.json
+++ b/packages/framework-types/package.json
@@ -51,7 +51,7 @@
     "@effect/schema": "0.64.18",
     "@effect/typeclass": "0.23.17",
     "web-streams-polyfill": "~3.3.2",
-    "ws": "8.12.0"
+    "ws": "8.17.1"
   },
   "devDependencies": {
     "@boostercloud/eslint-config": "workspace:^2.13.0",


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#github-flow
- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#publishing-your-pull-request

- Make sure you followed our Code style https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#code-style-guidelines

- Make sure everything works https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#getting-the-code

- Run tests 🐛 https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#running-unit-tests

-->

## Description
 
This PR fixes vulnerability [CVE-2024-37890](https://nvd.nist.gov/vuln/detail/CVE-2024-37890) found in the [ws](https://github.com/websockets/ws) library which is listed as a dependency in several Booster packages.
 
## Changes

* Bump ws version from 8.12.0 to 8.17.1.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
