### PR TITLE
Update re_test-integration-prepare.yml

### DIFF
--- a/.github/workflows/re_test-integration-prepare.yml
+++ b/.github/workflows/re_test-integration-prepare.yml
@@ -58,6 +58,7 @@ jobs:
           name: integration-test-dependencies-${{ inputs.command_sha }}
           path: packages/framework-integration-tests/.booster
           retention-days: 1
+          include-hidden-files: true
 
       - name: Upload integration test dependencies
         uses: actions/upload-artifact@v4
@@ -67,3 +68,4 @@ jobs:
           name: integration-test-dependencies-${{ github.sha }}
           path: packages/framework-integration-tests/.booster
           retention-days: 1
+          include-hidden-files: true


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#github-flow
- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#publishing-your-pull-request

- Make sure you followed our Code style https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#code-style-guidelines

- Make sure everything works https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#getting-the-code

- Run tests 🐛 https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#running-unit-tests

-->

## Description

As announced in the [GitHub blog](https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/), starting September 2nd, the upload-artifact action ignores hidden files and directories by default. Since our integration tests publish our artifacts to a hidden directory (`packages/framework-integration-tests/.booster`), this change breaks them, so the `include-hidden-files` option needs to be added to the workflow.

## Changes

<!-- 

Describe changes you have made:

- Added tests
- Described "amazingMethodName" purpose in the docs
- New method `amazingMethodName`

-->

* Add `include-hidden-files: true` option to the upload-artifact action.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
