### PR TITLE
Fix read model queries when selecting deeply-nested arrays

### DIFF
--- a/common/changes/@boostercloud/framework-core/fix_nested_arrays_2024-09-24-21-22.json
+++ b/common/changes/@boostercloud/framework-core/fix_nested_arrays_2024-09-24-21-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "Correct handling of deeply-nested arrays and sub-array properties in Read Model queries",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -752,6 +752,7 @@ importers:
       '@boostercloud/eslint-config': workspace:^2.18.1
       '@boostercloud/framework-common-helpers': workspace:^2.18.1
       '@boostercloud/framework-types': workspace:^2.18.1
+      '@cdktf/provider-azurerm': 13.3.0
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -787,6 +788,7 @@ importers:
       '@azure/web-pubsub': 1.1.3
       '@boostercloud/framework-common-helpers': link:../framework-common-helpers
       '@boostercloud/framework-types': link:../framework-types
+      '@cdktf/provider-azurerm': 13.3.0
       '@effect-ts/core': 0.60.5
       tslib: 2.7.0
     devDependencies:
@@ -828,7 +830,7 @@ importers:
       '@boostercloud/framework-core': workspace:^2.18.1
       '@boostercloud/framework-provider-azure': workspace:^2.18.1
       '@boostercloud/framework-types': workspace:^2.18.1
-      '@cdktf/provider-azurerm': 11.2.0
+      '@cdktf/provider-azurerm': 13.3.0
       '@cdktf/provider-time': 9.0.2
       '@effect-ts/core': ^0.60.4
       '@types/archiver': 5.1.0
@@ -883,7 +885,7 @@ importers:
       '@boostercloud/framework-core': link:../framework-core
       '@boostercloud/framework-provider-azure': link:../framework-provider-azure
       '@boostercloud/framework-types': link:../framework-types
-      '@cdktf/provider-azurerm': 11.2.0_5k7lg6pu6lyti4sdnvep4rdzly
+      '@cdktf/provider-azurerm': 13.3.0_5k7lg6pu6lyti4sdnvep4rdzly
       '@cdktf/provider-time': 9.0.2_5k7lg6pu6lyti4sdnvep4rdzly
       '@effect-ts/core': 0.60.5
       '@types/archiver': 5.1.0
@@ -3416,11 +3418,19 @@ packages:
       nan: 2.20.0
       prebuild-install: 7.1.2
 
-  /@cdktf/provider-azurerm/11.2.0_5k7lg6pu6lyti4sdnvep4rdzly:
-    resolution: {integrity: sha512-1YpDrScd4YckEVKBPnXUI9yGeRmv7SiQdAj6Mq9eBXWgP1bemRk4mkQlqGm2pe9h5BECLEMZyAg5Cv/JGJX0Uw==}
+  /@cdktf/provider-azurerm/13.3.0:
+    resolution: {integrity: sha512-gXxAJYTpEMwxSteqJvZEQ8WpCot+E58sW5u/za0drc5zgkrYO3vTEsOByj8Vcxn7MWXrZFacnktgtU1UkPZs4w==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      cdktf: ^0.19.0
+      cdktf: ^0.20.0
+      constructs: ^10.3.0
+    dev: false
+
+  /@cdktf/provider-azurerm/13.3.0_5k7lg6pu6lyti4sdnvep4rdzly:
+    resolution: {integrity: sha512-gXxAJYTpEMwxSteqJvZEQ8WpCot+E58sW5u/za0drc5zgkrYO3vTEsOByj8Vcxn7MWXrZFacnktgtU1UkPZs4w==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      cdktf: ^0.20.0
       constructs: ^10.3.0
     dependencies:
       cdktf: 0.19.2_constructs@10.3.0
@@ -6409,7 +6419,7 @@ packages:
     dependencies:
       semver: 7.6.3
       shelljs: 0.8.5
-      typescript: 5.7.0-dev.20240924
+      typescript: 5.7.0-dev.20240925
 
   /duration/0.2.2:
     resolution: {integrity: sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==}
@@ -11556,8 +11566,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript/5.7.0-dev.20240924:
-    resolution: {integrity: sha512-Ij5R6dGDoRwlwMv0YAF0DSKOp2gGIv0SZNybFpAm05zZ/tktjetR7IrwuurvRlDEz7v91AC3ehs2lF7lJ8F/QA==}
+  /typescript/5.7.0-dev.20240925:
+    resolution: {integrity: sha512-k43Yzt0H2VwIvVJzSKaMUKSnAOWkAitSB+Zioc340LCsh4kSwCbyHCJSAJmAdFH0QuNIL3AuSybTfwOys8tqZw==}
     engines: {node: '>=14.17'}
     hasBin: true
 

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
   ../../packages/application-tester:
     specifiers:
       '@apollo/client': 3.7.13
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@types/jsonwebtoken': 9.0.1
       '@types/node': ^18.18.2
@@ -70,10 +70,10 @@ importers:
 
   ../../packages/cli:
     specifiers:
-      '@boostercloud/application-tester': workspace:^2.18.0
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-core': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
+      '@boostercloud/application-tester': workspace:^2.18.1
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-core': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@oclif/core': 3.15.0
       '@oclif/plugin-help': ^5
@@ -183,8 +183,8 @@ importers:
 
   ../../packages/framework-common-helpers:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -258,10 +258,10 @@ importers:
 
   ../../packages/framework-core:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-common-helpers': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
-      '@boostercloud/metadata-booster': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-common-helpers': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
+      '@boostercloud/metadata-booster': workspace:^2.18.1
       '@effect/cli': 0.35.26
       '@effect/platform': 0.48.24
       '@effect/platform-node': 0.45.26
@@ -378,19 +378,19 @@ importers:
   ../../packages/framework-integration-tests:
     specifiers:
       '@apollo/client': 3.7.13
-      '@boostercloud/application-tester': workspace:^2.18.0
-      '@boostercloud/cli': workspace:^2.18.0
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-common-helpers': workspace:^2.18.0
-      '@boostercloud/framework-core': workspace:^2.18.0
-      '@boostercloud/framework-provider-aws': workspace:^2.18.0
-      '@boostercloud/framework-provider-aws-infrastructure': workspace:^2.18.0
-      '@boostercloud/framework-provider-azure': workspace:^2.18.0
-      '@boostercloud/framework-provider-azure-infrastructure': workspace:^2.18.0
-      '@boostercloud/framework-provider-local': workspace:^2.18.0
-      '@boostercloud/framework-provider-local-infrastructure': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
-      '@boostercloud/metadata-booster': workspace:^2.18.0
+      '@boostercloud/application-tester': workspace:^2.18.1
+      '@boostercloud/cli': workspace:^2.18.1
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-common-helpers': workspace:^2.18.1
+      '@boostercloud/framework-core': workspace:^2.18.1
+      '@boostercloud/framework-provider-aws': workspace:^2.18.1
+      '@boostercloud/framework-provider-aws-infrastructure': workspace:^2.18.1
+      '@boostercloud/framework-provider-azure': workspace:^2.18.1
+      '@boostercloud/framework-provider-azure-infrastructure': workspace:^2.18.1
+      '@boostercloud/framework-provider-local': workspace:^2.18.1
+      '@boostercloud/framework-provider-local-infrastructure': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
+      '@boostercloud/metadata-booster': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@effect/cli': 0.35.26
       '@effect/platform': 0.48.24
@@ -536,9 +536,9 @@ importers:
 
   ../../packages/framework-provider-aws:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-common-helpers': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-common-helpers': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@types/aws-lambda': 8.10.48
       '@types/chai': 4.2.18
@@ -632,10 +632,10 @@ importers:
       '@aws-cdk/core': ^1.170.0
       '@aws-cdk/custom-resources': ^1.170.0
       '@aws-cdk/cx-api': ^1.170.0
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-common-helpers': workspace:^2.18.0
-      '@boostercloud/framework-provider-aws': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-common-helpers': workspace:^2.18.1
+      '@boostercloud/framework-provider-aws': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@types/archiver': 5.1.0
       '@types/aws-lambda': 8.10.48
@@ -749,9 +749,9 @@ importers:
       '@azure/functions': ^1.2.2
       '@azure/identity': ~2.1.0
       '@azure/web-pubsub': ~1.1.0
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-common-helpers': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-common-helpers': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -823,11 +823,11 @@ importers:
       '@azure/arm-resources': ^5.0.1
       '@azure/cosmos': ^4.0.0
       '@azure/identity': ~2.1.0
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-common-helpers': workspace:^2.18.0
-      '@boostercloud/framework-core': workspace:^2.18.0
-      '@boostercloud/framework-provider-azure': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-common-helpers': workspace:^2.18.1
+      '@boostercloud/framework-core': workspace:^2.18.1
+      '@boostercloud/framework-provider-azure': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
       '@cdktf/provider-azurerm': 11.2.0
       '@cdktf/provider-time': 9.0.2
       '@effect-ts/core': ^0.60.4
@@ -934,9 +934,9 @@ importers:
 
   ../../packages/framework-provider-local:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-common-helpers': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-common-helpers': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@seald-io/nedb': 4.0.2
       '@types/chai': 4.2.18
@@ -1013,10 +1013,10 @@ importers:
 
   ../../packages/framework-provider-local-infrastructure:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/framework-common-helpers': workspace:^2.18.0
-      '@boostercloud/framework-provider-local': workspace:^2.18.0
-      '@boostercloud/framework-types': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/framework-common-helpers': workspace:^2.18.1
+      '@boostercloud/framework-provider-local': workspace:^2.18.1
+      '@boostercloud/framework-types': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@types/chai': 4.2.18
       '@types/chai-as-promised': 7.1.4
@@ -1096,8 +1096,8 @@ importers:
 
   ../../packages/framework-types:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.18.0
-      '@boostercloud/metadata-booster': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
+      '@boostercloud/metadata-booster': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@effect-ts/node': ~0.39.0
       '@effect/cli': 0.35.26
@@ -1181,7 +1181,7 @@ importers:
 
   ../../packages/metadata-booster:
     specifiers:
-      '@boostercloud/eslint-config': workspace:^2.18.0
+      '@boostercloud/eslint-config': workspace:^2.18.1
       '@effect-ts/core': ^0.60.4
       '@types/node': ^18.18.2
       '@typescript-eslint/eslint-plugin': ^5.0.0
@@ -1660,7 +1660,7 @@ packages:
       '@aws-cdk/aws-codecommit': 1.204.0_scjupxxta56mdpzkdveav52ufq
       '@aws-cdk/aws-codestarnotifications': 1.204.0_add7c2jq5lcc6idtuigbkwnzeu
       '@aws-cdk/aws-ec2': 1.204.0_r4d2a6r7lnkv26zjzkdsvuam2a
-      '@aws-cdk/aws-ecr': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
+      '@aws-cdk/aws-ecr': 1.204.0_4bnk2gpayjo75fecjckge2dkni
       '@aws-cdk/aws-ecr-assets': 1.204.0_scjupxxta56mdpzkdveav52ufq
       '@aws-cdk/aws-events': 1.204.0_w2xl3dexbzdynnzeafah4cuzfm
       '@aws-cdk/aws-iam': 1.204.0_add7c2jq5lcc6idtuigbkwnzeu
@@ -1668,10 +1668,11 @@ packages:
       '@aws-cdk/aws-logs': 1.204.0_l4ztnfmrjykhsbk6ow7yhidayu
       '@aws-cdk/aws-s3': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/aws-s3-assets': 1.204.0_l4ztnfmrjykhsbk6ow7yhidayu
-      '@aws-cdk/aws-secretsmanager': 1.204.0_2o53qceqenzlpxe4mjswmsqfiq
+      '@aws-cdk/aws-secretsmanager': 1.204.0_336juigttbrwz7tyvm6a6wfpy4
       '@aws-cdk/core': 1.204.0_hol6usdabdbzhugfw355k4ebam
       '@aws-cdk/region-info': 1.204.0
       constructs: 3.4.344
+      yaml: 1.10.2
     transitivePeerDependencies:
       - '@aws-cdk/aws-lambda'
       - '@aws-cdk/cx-api'
@@ -1787,6 +1788,7 @@ packages:
       '@aws-cdk/core': 1.204.0_hol6usdabdbzhugfw355k4ebam
       '@aws-cdk/custom-resources': 1.204.0_c23kgzmvfhgnr6qpzzlbsfzuc4
       constructs: 3.4.344
+      punycode: 2.3.1
     transitivePeerDependencies:
       - '@aws-cdk/aws-ec2'
       - '@aws-cdk/aws-logs'
@@ -1873,7 +1875,7 @@ packages:
       constructs: ^3.3.69
     dependencies:
       '@aws-cdk/assets': 1.204.0_uszt2j4mor3yrbm3tre3az4zvy
-      '@aws-cdk/aws-ecr': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
+      '@aws-cdk/aws-ecr': 1.204.0_4bnk2gpayjo75fecjckge2dkni
       '@aws-cdk/aws-iam': 1.204.0_add7c2jq5lcc6idtuigbkwnzeu
       '@aws-cdk/aws-s3': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/core': 1.204.0_hol6usdabdbzhugfw355k4ebam
@@ -1883,7 +1885,7 @@ packages:
       - '@aws-cdk/aws-events'
     dev: false
 
-  /@aws-cdk/aws-ecr/1.204.0_bi2u42js5xhxqcsg5gqefde4xi:
+  /@aws-cdk/aws-ecr/1.204.0_4bnk2gpayjo75fecjckge2dkni:
     resolution: {integrity: sha512-oCts9e+ackWoFHeyn/3oKm3X1lSizleWNNXHp5WGM38lpNVrtCLMKSShu5iXJBhqRH2Mz1AcA4fDMWhe8DvJFA==}
     engines: {node: '>= 14.15.0'}
     deprecated: |-
@@ -1899,11 +1901,8 @@ packages:
     dependencies:
       '@aws-cdk/aws-events': 1.204.0_w2xl3dexbzdynnzeafah4cuzfm
       '@aws-cdk/aws-iam': 1.204.0_add7c2jq5lcc6idtuigbkwnzeu
-      '@aws-cdk/aws-kms': 1.204.0_cttdkzy7hngahjug7jmkfylr2y
       '@aws-cdk/core': 1.204.0_hol6usdabdbzhugfw355k4ebam
       constructs: 3.4.344
-    transitivePeerDependencies:
-      - '@aws-cdk/cx-api'
     dev: false
 
   /@aws-cdk/aws-ecs/1.204.0_iu2vquo67t63xu6vdymsg3ufny:
@@ -1929,7 +1928,7 @@ packages:
       '@aws-cdk/aws-certificatemanager': 1.204.0_xtqk4litqxecxsqs3sd6ajo2ja
       '@aws-cdk/aws-cloudwatch': 1.204.0_w2xl3dexbzdynnzeafah4cuzfm
       '@aws-cdk/aws-ec2': 1.204.0_r4d2a6r7lnkv26zjzkdsvuam2a
-      '@aws-cdk/aws-ecr': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
+      '@aws-cdk/aws-ecr': 1.204.0_4bnk2gpayjo75fecjckge2dkni
       '@aws-cdk/aws-ecr-assets': 1.204.0_scjupxxta56mdpzkdveav52ufq
       '@aws-cdk/aws-elasticloadbalancing': 1.204.0_s2iwowsvskkmujjbrmx4g5hlsi
       '@aws-cdk/aws-elasticloadbalancingv2': 1.204.0_xbmlyikxd4zabyotfrt4oo4gli
@@ -1941,7 +1940,7 @@ packages:
       '@aws-cdk/aws-route53-targets': 1.204.0_2eviprr3zwoouaslbumtdekrhi
       '@aws-cdk/aws-s3': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/aws-s3-assets': 1.204.0_l4ztnfmrjykhsbk6ow7yhidayu
-      '@aws-cdk/aws-secretsmanager': 1.204.0_2o53qceqenzlpxe4mjswmsqfiq
+      '@aws-cdk/aws-secretsmanager': 1.204.0_336juigttbrwz7tyvm6a6wfpy4
       '@aws-cdk/aws-servicediscovery': 1.204.0_nu23nesxfni464wb5cy4ehgagi
       '@aws-cdk/aws-sns': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/aws-sqs': 1.204.0_cttdkzy7hngahjug7jmkfylr2y
@@ -2242,7 +2241,7 @@ packages:
       '@aws-cdk/aws-lambda': 1.204.0_afnjft5qr3fswieaeg3dwwhnvm
       '@aws-cdk/aws-s3': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/aws-s3-notifications': 1.204.0_xguspq3b5n56mo6dsez57f32qa
-      '@aws-cdk/aws-secretsmanager': 1.204.0_2o53qceqenzlpxe4mjswmsqfiq
+      '@aws-cdk/aws-secretsmanager': 1.204.0_336juigttbrwz7tyvm6a6wfpy4
       '@aws-cdk/aws-sns': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
       '@aws-cdk/aws-sns-subscriptions': 1.204.0_bpkznh2gsccwq6qpaogbkb4psu
       '@aws-cdk/aws-sqs': 1.204.0_cttdkzy7hngahjug7jmkfylr2y
@@ -2275,7 +2274,7 @@ packages:
       '@aws-cdk/aws-cloudwatch': 1.204.0_w2xl3dexbzdynnzeafah4cuzfm
       '@aws-cdk/aws-codeguruprofiler': 1.204.0_w2xl3dexbzdynnzeafah4cuzfm
       '@aws-cdk/aws-ec2': 1.204.0_r4d2a6r7lnkv26zjzkdsvuam2a
-      '@aws-cdk/aws-ecr': 1.204.0_bi2u42js5xhxqcsg5gqefde4xi
+      '@aws-cdk/aws-ecr': 1.204.0_4bnk2gpayjo75fecjckge2dkni
       '@aws-cdk/aws-ecr-assets': 1.204.0_scjupxxta56mdpzkdveav52ufq
       '@aws-cdk/aws-efs': 1.204.0_r4d2a6r7lnkv26zjzkdsvuam2a
       '@aws-cdk/aws-events': 1.204.0_w2xl3dexbzdynnzeafah4cuzfm
@@ -2436,6 +2435,7 @@ packages:
       '@aws-cdk/aws-s3-assets': 1.204.0_l4ztnfmrjykhsbk6ow7yhidayu
       '@aws-cdk/core': 1.204.0_hol6usdabdbzhugfw355k4ebam
       '@aws-cdk/lambda-layer-awscli': 1.204.0_e7ybiu4yrrtvf3zlvzrvcjkvyy
+      case: 1.6.3
       constructs: 3.4.344
     transitivePeerDependencies:
       - '@aws-cdk/assets'
@@ -2511,7 +2511,7 @@ packages:
       constructs: 3.4.344
     dev: false
 
-  /@aws-cdk/aws-secretsmanager/1.204.0_2o53qceqenzlpxe4mjswmsqfiq:
+  /@aws-cdk/aws-secretsmanager/1.204.0_336juigttbrwz7tyvm6a6wfpy4:
     resolution: {integrity: sha512-ykpjYmP6qVOFbHtkaQBu3Xk7xp2UTR0ouzk7pb+zrEHKGmRvzGq+8J0IU+qXBJgQIVwFAPf2IgOSTzj6FJPdyA==}
     engines: {node: '>= 14.15.0'}
     deprecated: |-
@@ -2526,18 +2526,12 @@ packages:
       '@aws-cdk/cx-api': 1.204.0
       constructs: ^3.3.69
     dependencies:
-      '@aws-cdk/aws-ec2': 1.204.0_r4d2a6r7lnkv26zjzkdsvuam2a
       '@aws-cdk/aws-iam': 1.204.0_add7c2jq5lcc6idtuigbkwnzeu
-      '@aws-cdk/aws-kms': 1.204.0_cttdkzy7hngahjug7jmkfylr2y
       '@aws-cdk/aws-lambda': 1.204.0_afnjft5qr3fswieaeg3dwwhnvm
       '@aws-cdk/aws-sam': 1.204.0_add7c2jq5lcc6idtuigbkwnzeu
       '@aws-cdk/core': 1.204.0_hol6usdabdbzhugfw355k4ebam
       '@aws-cdk/cx-api': 1.203.0
       constructs: 3.4.344
-    transitivePeerDependencies:
-      - '@aws-cdk/assets'
-      - '@aws-cdk/aws-logs'
-      - '@aws-cdk/aws-s3'
     dev: false
 
   /@aws-cdk/aws-servicediscovery/1.204.0_nu23nesxfni464wb5cy4ehgagi:
@@ -2715,6 +2709,9 @@ packages:
   /@aws-cdk/cloud-assembly-schema/1.203.0:
     resolution: {integrity: sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==}
     engines: {node: '>= 14.15.0'}
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.6.3
     dev: false
     bundledDependencies:
       - jsonschema
@@ -2728,6 +2725,9 @@ packages:
       This package is no longer being updated, and users should migrate to AWS CDK v2.
 
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.6.3
     dev: false
     bundledDependencies:
       - jsonschema
@@ -2736,6 +2736,9 @@ packages:
   /@aws-cdk/cloud-assembly-schema/2.39.1:
     resolution: {integrity: sha512-lSVaaedXWeK08uoq0IXDCspz9U/H4qIERemdsMQrMUDTiUe/JBby7vtmyMvOdEscE8GMAmiOzoPmAE0Uf+yw5A==}
     engines: {node: '>= 14.15.0'}
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.6.3
     dev: false
     bundledDependencies:
       - jsonschema
@@ -2769,7 +2772,11 @@ packages:
       '@aws-cdk/cloud-assembly-schema': 1.204.0
       '@aws-cdk/cx-api': 1.203.0
       '@aws-cdk/region-info': 1.204.0
+      '@balena/dockerignore': 1.0.2
       constructs: 3.4.344
+      fs-extra: 9.1.0
+      ignore: 5.3.2
+      minimatch: 3.1.2
     dev: false
     bundledDependencies:
       - fs-extra
@@ -2812,6 +2819,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 1.203.0
+      semver: 7.6.3
     dev: false
     bundledDependencies:
       - semver
@@ -2826,6 +2834,7 @@ packages:
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 1.204.0
+      semver: 7.6.3
     dev: false
     bundledDependencies:
       - semver
@@ -2835,6 +2844,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 2.39.1
+      semver: 7.6.3
     dev: false
     bundledDependencies:
       - semver
@@ -3287,6 +3297,10 @@ packages:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+
+  /@balena/dockerignore/1.0.2:
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+    dev: false
 
   /@cdktf/cli-core/0.19.2_react@17.0.2:
     resolution: {integrity: sha512-kjgEUhrHx3kUPfL7KsTo6GrurVUPT77FmOUf7wWXt7ajNE5zCPvx/HKGmQruzt0n6eLZp1aKT+r/D6YRfXcIGA==}
@@ -5500,7 +5514,10 @@ packages:
     peerDependencies:
       constructs: ^10.0.25
     dependencies:
+      archiver: 5.3.2
       constructs: 10.3.0
+      json-stable-stringify: 1.1.1
+      semver: 7.6.3
     bundledDependencies:
       - archiver
       - json-stable-stringify
@@ -6392,7 +6409,7 @@ packages:
     dependencies:
       semver: 7.6.3
       shelljs: 0.8.5
-      typescript: 5.7.0-dev.20240904
+      typescript: 5.7.0-dev.20240924
 
   /duration/0.2.2:
     resolution: {integrity: sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==}
@@ -8566,6 +8583,15 @@ packages:
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  /json-stable-stringify/1.1.1:
+    resolution: {integrity: sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+
   /json-stringify-safe/5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
     dev: true
@@ -8593,6 +8619,13 @@ packages:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  /jsonify/0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
+
+  /jsonschema/1.4.1:
+    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
+    dev: false
 
   /jsonwebtoken/8.5.1:
     resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
@@ -11523,8 +11556,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript/5.7.0-dev.20240904:
-    resolution: {integrity: sha512-iGi6VWFGOuxPvDfwfK1/8C172NWzC5gtC4G2dxqCQehrr86WTfFkc9aWucynaxZdwQNMqG1Iu83bmXD7CNHCmg==}
+  /typescript/5.7.0-dev.20240924:
+    resolution: {integrity: sha512-Ij5R6dGDoRwlwMv0YAF0DSKOp2gGIv0SZNybFpAm05zZ/tktjetR7IrwuurvRlDEz7v91AC3ehs2lF7lJ8F/QA==}
     engines: {node: '>=14.17'}
     hasBin: true
 

--- a/packages/framework-provider-azure-infrastructure/package.json
+++ b/packages/framework-provider-azure-infrastructure/package.json
@@ -29,7 +29,7 @@
     "@boostercloud/framework-core": "workspace:^2.18.1",
     "@boostercloud/framework-provider-azure": "workspace:^2.18.1",
     "@boostercloud/framework-types": "workspace:^2.18.1",
-    "@cdktf/provider-azurerm": "11.2.0",
+    "@cdktf/provider-azurerm": "13.3.0",
     "@cdktf/provider-time": "9.0.2",
     "@types/archiver": "5.1.0",
     "@types/needle": "^2.0.4",

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/synth/application-synth.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/synth/application-synth.ts
@@ -52,7 +52,7 @@ export class ApplicationSynth {
   public constructor(terraformStack: TerraformStack) {
     this.config = readProjectConfig(process.cwd())
     const azurermProvider = new AzurermProvider(terraformStack, 'azureFeature', {
-      features: {},
+      features: [{}],
     })
     const appPrefix = buildAppPrefix(this.config)
     const resourceGroupName = createResourceGroupName(this.config.appName, this.config.environmentName)

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/synth/terraform-containers.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/synth/terraform-containers.ts
@@ -85,7 +85,7 @@ export class TerraformContainers {
       resourceGroupName: cosmosdbDatabaseResource.resourceGroupName,
       accountName: cosmosdbDatabaseResource.name,
       databaseName: cosmosdbSqlDatabaseResource.name,
-      partitionKeyPath: `/${eventsStoreAttributes.partitionKey}`,
+      partitionKeyPaths: [`/${eventsStoreAttributes.partitionKey}`],
       partitionKeyVersion: 2,
       autoscaleSettings: {
         maxThroughput: MAX_CONTAINER_THROUGHPUT,
@@ -108,7 +108,7 @@ export class TerraformContainers {
       resourceGroupName: cosmosdbDatabaseResource.resourceGroupName,
       accountName: cosmosdbDatabaseResource.name,
       databaseName: cosmosdbSqlDatabaseResource.name,
-      partitionKeyPath: '/eventId',
+      partitionKeyPaths: ['/eventId'],
       partitionKeyVersion: 2,
       uniqueKey: [{ paths: ['/eventId'] }],
       autoscaleSettings: {
@@ -134,7 +134,7 @@ export class TerraformContainers {
       resourceGroupName: cosmosdbDatabaseResource.resourceGroupName,
       accountName: cosmosdbDatabaseResource.name,
       databaseName: cosmosdbSqlDatabaseResource.name,
-      partitionKeyPath: '/id',
+      partitionKeyPaths: ['/id'],
       partitionKeyVersion: 2,
       autoscaleSettings: {
         maxThroughput: MAX_CONTAINER_THROUGHPUT,
@@ -157,7 +157,7 @@ export class TerraformContainers {
       resourceGroupName: cosmosdbDatabaseResource.resourceGroupName,
       accountName: cosmosdbDatabaseResource.name,
       databaseName: cosmosdbSqlDatabaseResource.name,
-      partitionKeyPath: `/${subscriptionsStoreAttributes.partitionKey}`,
+      partitionKeyPaths: [`/${subscriptionsStoreAttributes.partitionKey}`],
       partitionKeyVersion: 2,
       defaultTtl: -1,
       autoscaleSettings: {
@@ -181,7 +181,7 @@ export class TerraformContainers {
       resourceGroupName: cosmosdbDatabaseResource.resourceGroupName,
       accountName: cosmosdbDatabaseResource.name,
       databaseName: cosmosdbSqlDatabaseResource.name,
-      partitionKeyPath: `/${connectionsStoreAttributes.partitionKey}`,
+      partitionKeyPaths: [`/${connectionsStoreAttributes.partitionKey}`],
       partitionKeyVersion: 2,
       defaultTtl: -1,
       autoscaleSettings: {
@@ -207,7 +207,7 @@ export class TerraformContainers {
       resourceGroupName: cosmosdbDatabase.resourceGroupName,
       accountName: cosmosdbDatabase.name,
       databaseName: cosmosdbSqlDatabase.name,
-      partitionKeyPath: `/${dedupAttributes.partitionKey}`,
+      partitionKeyPaths: [`/${dedupAttributes.partitionKey}`],
       uniqueKey: [{ paths: [`/${dedupAttributes.partitionKey}`] }],
       partitionKeyVersion: 2,
       defaultTtl: -1,

--- a/packages/framework-provider-azure-infrastructure/src/infrastructure/synth/terraform-cosmosdb-database.ts
+++ b/packages/framework-provider-azure-infrastructure/src/infrastructure/synth/terraform-cosmosdb-database.ts
@@ -17,9 +17,9 @@ export class TerraformCosmosdbDatabase {
       resourceGroupName: resourceGroupName,
       offerType: 'Standard',
       kind: 'GlobalDocumentDB',
-      enableMultipleWriteLocations: false,
+      multipleWriteLocationsEnabled: false,
       isVirtualNetworkFilterEnabled: false,
-      enableAutomaticFailover: true,
+      automaticFailoverEnabled: true,
       geoLocation: [
         {
           location: resourceGroup.location,

--- a/packages/framework-provider-azure/package.json
+++ b/packages/framework-provider-azure/package.json
@@ -31,7 +31,8 @@
     "@boostercloud/framework-types": "workspace:^2.18.1",
     "tslib": "^2.4.0",
     "@effect-ts/core": "^0.60.4",
-    "@azure/web-pubsub": "~1.1.0"
+    "@azure/web-pubsub": "~1.1.0",
+    "@cdktf/provider-azurerm": "13.3.0"
   },
   "devDependencies": {
     "@boostercloud/eslint-config": "workspace:^2.18.1",

--- a/packages/framework-provider-azure/src/helpers/query-helper.ts
+++ b/packages/framework-provider-azure/src/helpers/query-helper.ts
@@ -322,16 +322,38 @@ function preprocessProjections(projections: ProjectionFor<unknown>): ProjectionF
 
   Object.values(projections).forEach((field: string) => {
     const parts = field.split('.')
-    const arrayIndex = parts.findIndex((part) => part.endsWith('[]'))
+    const arrayIndices = parts.reduce((acc, part, index) => {
+      if (part.endsWith('[]')) acc.push(index)
+      return acc
+    }, [] as number[])
 
-    if (arrayIndex !== -1 && arrayIndex >= 2) {
-      // This is an array nested at least two levels deep
-      // Remove the '[]' from the array part and join up to that point
-      const processedField = parts.slice(0, arrayIndex).join('.') + '.' + parts[arrayIndex].slice(0, -2)
-      processed.add(processedField)
-    } else {
-      // Keep the original field
+    if (arrayIndices.length === 0) {
+      // Case 1: No arrays in the projection
       processed.add(field)
+    } else if (arrayIndices[0] === 0) {
+      // Case 2.1 and 2.2: Array at the top level
+      if (arrayIndices.length === 1) {
+        // Case 2.1: Top-level array not followed by another array
+        processed.add(field)
+      } else {
+        // Case 2.2: Top-level array followed by a subarray
+        const processedField = parts.slice(0, arrayIndices[1] + 1).join('.')
+        processed.add(processedField.slice(0, -2)) // Remove '[]' from the last part
+      }
+    } else if (arrayIndices[0] === 1) {
+      // Case 2.3: Array nested within a top-level property
+      if (arrayIndices.length === 1) {
+        // Case 2.3.1: No arrays follow in the nesting
+        processed.add(field)
+      } else {
+        // Case 2.3.2: Nested arrays after it
+        const processedField = parts.slice(0, arrayIndices[1] + 1).join('.')
+        processed.add(processedField.slice(0, -2)) // Remove '[]' from the last part
+      }
+    } else {
+      // Case 2.4: Array nested deeper than a top-level property
+      const processedField = parts.slice(0, arrayIndices[0] + 1).join('.')
+      processed.add(processedField.slice(0, -2)) // Remove '[]' from the last part
     }
   })
 

--- a/packages/framework-provider-azure/test/helpers/query-helper.test.ts
+++ b/packages/framework-provider-azure/test/helpers/query-helper.test.ts
@@ -169,6 +169,35 @@ describe('Query helper', () => {
       )
     })
 
+    it('Executes a SQL query with a projectionFor projection that has a deeply nested array of objects', async () => {
+      await search(
+        mockCosmosDbClient as any,
+        mockConfig,
+        mockReadModelName,
+        {},
+        undefined,
+        undefined,
+        false,
+        undefined,
+        ['id', 'foo.bar.items[].id', 'foo.bar.baz.items[].id'] as ProjectionFor<unknown>
+      )
+
+      expect(mockCosmosDbClient.database).to.have.been.calledWithExactly(mockConfig.resourceNames.applicationStack)
+      expect(
+        mockCosmosDbClient.database(mockConfig.resourceNames.applicationStack).container
+      ).to.have.been.calledWithExactly(`${mockReadModelName}`)
+      expect(
+        mockCosmosDbClient.database(mockConfig.resourceNames.applicationStack).container(`${mockReadModelName}`).items
+          .query
+      ).to.have.been.calledWith(
+        match({
+          query:
+            'SELECT c["id"], c["foo"]["bar"]["items"] AS "foo.bar.items", c["foo"]["bar"]["baz"]["items"] AS "foo.bar.baz.items" FROM c ',
+          parameters: [],
+        })
+      )
+    })
+
     it('Executes a SQL query with a star projection in the read model table', async () => {
       await search(
         mockCosmosDbClient as any,

--- a/packages/framework-provider-azure/test/helpers/query-helper.test.ts
+++ b/packages/framework-provider-azure/test/helpers/query-helper.test.ts
@@ -179,7 +179,14 @@ describe('Query helper', () => {
         undefined,
         false,
         undefined,
-        ['id', 'foo.bar.items[].id', 'foo.bar.baz.items[].id'] as ProjectionFor<unknown>
+        [
+          'id',
+          'x.arr[].z',
+          'foo.bar.items[].id',
+          'foo.bar.baz.items[].id',
+          'arr[].subArr[].id',
+          'arr[].id',
+        ] as ProjectionFor<unknown>
       )
 
       expect(mockCosmosDbClient.database).to.have.been.calledWithExactly(mockConfig.resourceNames.applicationStack)
@@ -192,7 +199,11 @@ describe('Query helper', () => {
       ).to.have.been.calledWith(
         match({
           query:
-            'SELECT c["id"], c["foo"]["bar"]["items"] AS "foo.bar.items", c["foo"]["bar"]["baz"]["items"] AS "foo.bar.baz.items" FROM c ',
+            'SELECT c["id"], ' +
+            'ARRAY(SELECT item["z"] FROM item IN c["x"]["arr"]) AS "x.arr", ' +
+            'c["foo"]["bar"]["items"] AS "foo.bar.items", c["foo"]["bar"]["baz"]["items"] AS "foo.bar.baz.items", ' +
+            'ARRAY(SELECT item["subArr"], item["id"] FROM item IN c["arr"]) AS arr ' +
+            'FROM c ',
           parameters: [],
         })
       )

--- a/website/docs/06_graphql.md
+++ b/website/docs/06_graphql.md
@@ -891,7 +891,7 @@ Using `select` will skip any Read Models migrations that need to be applied to t
 :::
 
 :::warning
-Support for selecting fields from objects inside arrays is limited to arrays that are at most nested inside another property, e.g., `['category.relatedCategories[].name']`. Selecting fields from arrays that are nested deeper than that (e.g., `['foo.bar.items[].id']`) is not expected to yield the expected results.
+Support for selecting fields from objects inside arrays is limited to arrays that are at most nested inside another property, e.g., `['category.relatedCategories[].name']`. Selecting fields from arrays that are nested deeper than that (e.g., `['foo.bar.items[].id']`) will return the entire object.
 :::
 
 :::warning


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#github-flow
- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#publishing-your-pull-request

- Make sure you followed our Code style https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#code-style-guidelines

- Make sure everything works https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#getting-the-code

- Run tests 🐛 https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#running-unit-tests

-->

## Description
<Describe the purpose of this pull request>

The changes in this PR fix some issues when selecting fields in read model objects that are nested deeply. Previously, if one were to select a field from an object in an array nested deeper than a top-level property, e.g., `['foo.bar.arr[].id']`, it would generate the wrong SQL code. To keep things simple, when this case is encountered, it will retrieve all the properties of the objects in the array.

## Changes

<!-- 

Describe changes you have made:

- Added tests
- Described "amazingMethodName" purpose in the docs
- New method `amazingMethodName`

-->

* Modify `buildProjections` and add a `preprocessProjections` method to the Cosmos query helper to identify and alter the projections with deeply nested arrays.

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
