### PR TITLE
fix: check if property exists on object without executing

### DIFF
--- a/common/changes/@boostercloud/framework-core/fix-uncaught-promise-error_2024-12-17-16-07.json
+++ b/common/changes/@boostercloud/framework-core/fix-uncaught-promise-error_2024-12-17-16-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "Fix a bug where Booster would crash if an error was thrown in an async getter on a ReadModel",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/packages/framework-common-helpers/src/instances.ts
+++ b/packages/framework-common-helpers/src/instances.ts
@@ -100,7 +100,7 @@ async function processProperties(source: any, result: any, propertiesMap: any): 
   for (const key of Object.keys(propertiesMap)) {
     if (key === '__isArray' || key === '__children') continue
 
-    if (source[key] !== undefined) {
+    if (key in source) {
       if (propertiesMap[key].__isArray) {
         result[key] = []
         const value = source[key]


### PR DESCRIPTION
## Description
When populating the getters on a ReadModel, the getters are executed twice. Once where you would expect it, and once in an `if` statement to check if the property exists on the ReadModel. In this `if` statement, there is no check to see if the getter is a promise or not, so it is never awaited. When the getter-promise would eventually return an error, the whole Booster application crashes. 

This PR thus fixes two things:
- Stops unnecessarily executing all getters on ReadModels twice
- Prevents the app from crashing when an async getter throws an error

## Changes

Replaced `source[key] !== undefined` with `key in source`.

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly