### PR TITLE
Update re_test-integration-prepare.yml

### DIFF
--- a/.github/workflows/re_test-integration-prepare.yml
+++ b/.github/workflows/re_test-integration-prepare.yml
@@ -69,3 +69,8 @@ jobs:
           path: packages/framework-integration-tests/.booster
           retention-days: 1
           include-hidden-files: true
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: latest


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#github-flow
- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#publishing-your-pull-request

- Make sure you followed our Code style https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#code-style-guidelines

- Make sure everything works https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#getting-the-code

- Run tests 🐛 https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#running-unit-tests

-->

## Description
<Describe the purpose of this pull request>

Integration tests have been failing due to the following error:

```
Unable to determine Terraform version: Error: Terraform CLI not present - Please install a current version https://learn.hashicorp.com/terraform/getting-started/install.html
```

It seems to be related to the fact that Terraform is no longer part of the `ubuntu-latest` image being used by the actions runner (see [this discussion](https://github.com/actions/runner-images/issues/10796)).

## Changes

<!-- 

Describe changes you have made:

- Added tests
- Described "amazingMethodName" purpose in the docs
- New method `amazingMethodName`

-->

- Adds a step for installing Terraform to `re_test-integration-prepare.yml`.

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
