### PR TITLE
Fix sensor errors related to empty GraphQL query

### DIFF
--- a/common/changes/@boostercloud/framework-core/fix_sensors_2025-03-24-19-38.json
+++ b/common/changes/@boostercloud/framework-core/fix_sensors_2025-03-24-19-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "Fixes issues with the sensors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         specifier: 3.7.13
         version: 3.7.13(graphql@16.10.0)(react@17.0.2)(subscriptions-transport-ws@0.11.0(graphql@16.10.0))
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -47,7 +47,7 @@ importers:
         version: 8.18.0
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@types/jsonwebtoken':
         specifier: 9.0.8
@@ -104,10 +104,10 @@ importers:
   ../../packages/cli:
     dependencies:
       '@boostercloud/framework-core':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-core
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -150,10 +150,10 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/application-tester':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../application-tester
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@oclif/test':
         specifier: ^4.1.10
@@ -264,7 +264,7 @@ importers:
   ../../packages/framework-common-helpers:
     dependencies:
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -280,7 +280,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@types/chai':
         specifier: 4.2.18
@@ -370,10 +370,10 @@ importers:
   ../../packages/framework-core:
     dependencies:
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@effect/cli':
         specifier: 0.56.2
@@ -437,10 +437,10 @@ importers:
         version: 8.18.0
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@boostercloud/metadata-booster':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../metadata-booster
       '@types/chai':
         specifier: 4.2.18
@@ -545,22 +545,22 @@ importers:
   ../../packages/framework-integration-tests:
     dependencies:
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-core':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-core
       '@boostercloud/framework-provider-aws':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-provider-aws
       '@boostercloud/framework-provider-azure':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-provider-azure
       '@boostercloud/framework-provider-local':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-provider-local
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -618,25 +618,25 @@ importers:
         specifier: 3.7.13
         version: 3.7.13(graphql@16.10.0)(react@17.0.2)(subscriptions-transport-ws@0.11.0(graphql@16.10.0))
       '@boostercloud/application-tester':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../application-tester
       '@boostercloud/cli':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../cli
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@boostercloud/framework-provider-aws-infrastructure':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-provider-aws-infrastructure
       '@boostercloud/framework-provider-azure-infrastructure':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-provider-azure-infrastructure
       '@boostercloud/framework-provider-local-infrastructure':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-provider-local-infrastructure
       '@boostercloud/metadata-booster':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../metadata-booster
       '@seald-io/nedb':
         specifier: 4.0.2
@@ -777,10 +777,10 @@ importers:
   ../../packages/framework-provider-aws:
     dependencies:
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -790,7 +790,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@types/aws-lambda':
         specifier: 8.10.48
@@ -943,13 +943,13 @@ importers:
         specifier: ^1.170.0
         version: 1.204.0
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-provider-aws':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-provider-aws
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -983,7 +983,7 @@ importers:
         version: 1.10.2
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@types/archiver':
         specifier: 5.1.0
@@ -1097,10 +1097,10 @@ importers:
         specifier: ~1.1.0
         version: 1.1.3
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -1110,7 +1110,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@types/chai':
         specifier: 4.2.18
@@ -1203,16 +1203,16 @@ importers:
         specifier: ~4.7.0
         version: 4.7.0
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-core':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-core
       '@boostercloud/framework-provider-azure':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-provider-azure
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@cdktf/provider-azurerm':
         specifier: 13.18.0
@@ -1279,7 +1279,7 @@ importers:
         version: 11.0.5
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@types/chai':
         specifier: 4.2.18
@@ -1360,10 +1360,10 @@ importers:
   ../../packages/framework-provider-local:
     dependencies:
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -1379,7 +1379,7 @@ importers:
         version: 8.18.0
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@types/chai':
         specifier: 4.2.18
@@ -1475,13 +1475,13 @@ importers:
   ../../packages/framework-provider-local-infrastructure:
     dependencies:
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-provider-local':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-provider-local
       '@boostercloud/framework-types':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -1500,7 +1500,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@types/chai':
         specifier: 4.2.18
@@ -1636,10 +1636,10 @@ importers:
         version: 8.18.0
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@boostercloud/metadata-booster':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../metadata-booster
       '@types/chai':
         specifier: 4.2.18
@@ -1733,7 +1733,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.0.0
+        specifier: workspace:^3.1.0
         version: link:../../tools/eslint-config
       '@types/node':
         specifier: ^20.17.17
@@ -7378,8 +7378,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.8.0-dev.20250218:
-    resolution: {integrity: sha512-ug24uoLMp4xZWUZOYi900L8VM9Tjpvm7+clJYYDY9OYOlveZf7en8ndF/kfZZ7QoODkFC/z6mvDdaD0ePD2fmQ==}
+  typescript@5.9.0-dev.20250324:
+    resolution: {integrity: sha512-qehVULhODb1IphPefX/jq0wAXpk6ifAt2lF3mxTsyR3yPDoPkiQdvxw9cURaDjJw6vCijSER6dU8kWmHdWaQnA==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10837,7 +10837,7 @@ snapshots:
     dependencies:
       semver: 7.6.3
       shelljs: 0.8.5
-      typescript: 5.8.0-dev.20250218
+      typescript: 5.9.0-dev.20250324
 
   dunder-proto@1.0.1:
     dependencies:
@@ -14302,7 +14302,7 @@ snapshots:
 
   typescript@5.7.3: {}
 
-  typescript@5.8.0-dev.20250218: {}
+  typescript@5.9.0-dev.20250324: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/packages/framework-provider-azure/src/library/health-adapter.ts
+++ b/packages/framework-provider-azure/src/library/health-adapter.ts
@@ -68,7 +68,13 @@ export async function areDatabaseReadModelsUp(cosmosDb: CosmosClient, config: Bo
 export async function isGraphQLFunctionUp(): Promise<boolean> {
   try {
     const restAPIUrl = await graphqlFunctionUrl()
-    const response = await request(restAPIUrl, 'POST')
+    const response = await request(
+      restAPIUrl,
+      'POST',
+      JSON.stringify({
+        query: 'query { __typename }',
+      })
+    )
     return response.status === 200
   } catch (e) {
     return false

--- a/packages/framework-provider-azure/src/library/health-adapter.ts
+++ b/packages/framework-provider-azure/src/library/health-adapter.ts
@@ -19,12 +19,22 @@ export async function isContainerUp(
   containerName: string
 ): Promise<boolean> {
   const container = getContainer(cosmosDb, config, containerName)
-  const { resources } = await container.items.query('SELECT TOP 1 1 FROM c', { maxItemCount: -1 }).fetchAll()
+  const { resources } = await container.items
+    .query({
+      query: 'SELECT TOP 1 1 FROM c',
+      parameters: [],
+    })
+    .fetchAll()
   return resources !== undefined
 }
 
 export async function countAll(container: Container): Promise<number> {
-  const { resources } = await container.items.query('SELECT VALUE COUNT(1) FROM c', { maxItemCount: -1 }).fetchAll()
+  const { resources } = await container.items
+    .query({
+      query: 'SELECT VALUE COUNT(1) FROM c',
+      parameters: [],
+    })
+    .fetchAll()
   return resources ? resources[0] : 0
 }
 

--- a/packages/framework-provider-local/src/library/health-adapter.ts
+++ b/packages/framework-provider-local/src/library/health-adapter.ts
@@ -43,7 +43,13 @@ export async function areDatabaseReadModelsUp(): Promise<boolean> {
 export async function isGraphQLFunctionUp(): Promise<boolean> {
   try {
     const url = await graphqlFunctionUrl()
-    const response = await request(url, 'POST')
+    const response = await request(
+      url,
+      'POST',
+      JSON.stringify({
+        query: 'query { __typename }',
+      })
+    )
     return response.status === 200
   } catch (e) {
     return false

--- a/packages/framework-provider-local/src/library/health-adapter.ts
+++ b/packages/framework-provider-local/src/library/health-adapter.ts
@@ -11,6 +11,7 @@ export async function databaseUrl(): Promise<Array<string>> {
 }
 
 export async function countAll(database: Nedb): Promise<number> {
+  await database.loadDatabaseAsync()
   const count = await database.countAsync({})
   return count ?? 0
 }


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#github-flow
- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#publishing-your-pull-request

- Make sure you followed our Code style https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#code-style-guidelines

- Make sure everything works https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#getting-the-code

- Run tests 🐛 https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#running-unit-tests

-->

## Description

Some health sensor endpoints require making an empty request to the GraphQL endpoint. Making this request with an empty body caused errors which caused other sensors to appear without response. (e.g., returned an empty array):

```text
error: [Booster]|BoosterGraphQLDispatcher#runGraphQLOperation: Received an empty GraphQL query
```

This PR fixes this error by sending a minimal GraphQL query in the request body.

## Changes

* Modifies `health-adapter.ts`  in both Azure and local providers so that `isGraphQLFunctionUp` method sends the following in the request body:

```json
{
  "query": "query { __typename }",
}
```

<!-- 
## Additional information

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
