### PR TITLE
feat: gracefully handle shutdown signals

### DIFF
--- a/packages/framework-core/src/booster.ts
+++ b/packages/framework-core/src/booster.ts
@@ -63,6 +63,7 @@ export class Booster {
    * Initializes the Booster project
    */
   public static start(codeRootPath: string): void {
+    registerShutdownSignalHandlers()
     const projectRootPath = codeRootPath.replace(new RegExp(this.config.codeRelativePath + '$'), '')
     this.config.userProjectRootPath = projectRootPath
     Importer.importUserProjectFiles(codeRootPath)
@@ -209,4 +210,23 @@ function checkAndGetCurrentEnv(): string {
     )
   }
   return env
+}
+
+function registerShutdownSignalHandlers(): void {
+  const signals = ['SIGINT', 'SIGTERM', 'SIGQUIT']
+  signals.forEach((signal) => {
+    process.on(signal, () => {
+      shutDownGracefully(signal)
+    })
+  })
+}
+
+function shutDownGracefully(signal: string): void {
+  console.log(`Received signal '${signal}'. Shutting down gracefully...`)
+  cleanup()
+  process.exit(0)
+}
+
+function cleanup(): void {
+  // Does Booster have dedicated clean up to do ?
 }


### PR DESCRIPTION
## Description

I was having trouble generating code coverage for my tests with `nyc`.
Took me some time but I found out that `nyc` requires the process it spawn to gracefully exit.
I was not completely sure what that meant, so I had to do some digging.
This PR adds handling of signals to gracefully shut down the process.

## Changes

- Added process signal listeners to gracefully shut down the server

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly

## Additional information

I added a `cleanup()` function that is currently empty, question is: does Booster have dedicated functions to close down the server, clean data, close connections ?
Didn't add docs on the functions as I find them self explanatory.

This fixes the issue for me locally, but I am not entirely sure if this is the way to go. (approach + location in Booster code itself)

Does this require any documentation to be updated ?
