### PR TITLE
Fix logger name in event stream consumer

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron

--- a/common/changes/@boostercloud/framework-core/codex-find-and-fix-a-bug-in-codebase_2025-05-20-12-19.json
+++ b/common/changes/@boostercloud/framework-core/codex-find-and-fix-a-bug-in-codebase_2025-05-20-12-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         specifier: 3.7.13
         version: 3.7.13(graphql@16.10.0)(react@17.0.2)(subscriptions-transport-ws@0.11.0(graphql@16.10.0))
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -47,7 +47,7 @@ importers:
         version: 8.18.0
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@types/jsonwebtoken':
         specifier: 9.0.8
@@ -104,10 +104,10 @@ importers:
   ../../packages/cli:
     dependencies:
       '@boostercloud/framework-core':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-core
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -150,10 +150,10 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/application-tester':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../application-tester
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@oclif/test':
         specifier: ^4.1.10
@@ -264,7 +264,7 @@ importers:
   ../../packages/framework-common-helpers:
     dependencies:
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -280,7 +280,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@types/chai':
         specifier: 4.2.18
@@ -370,10 +370,10 @@ importers:
   ../../packages/framework-core:
     dependencies:
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@effect/cli':
         specifier: 0.56.2
@@ -437,10 +437,10 @@ importers:
         version: 8.18.0
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@boostercloud/metadata-booster':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../metadata-booster
       '@types/chai':
         specifier: 4.2.18
@@ -545,22 +545,22 @@ importers:
   ../../packages/framework-integration-tests:
     dependencies:
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-core':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-core
       '@boostercloud/framework-provider-aws':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-provider-aws
       '@boostercloud/framework-provider-azure':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-provider-azure
       '@boostercloud/framework-provider-local':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-provider-local
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -618,25 +618,25 @@ importers:
         specifier: 3.7.13
         version: 3.7.13(graphql@16.10.0)(react@17.0.2)(subscriptions-transport-ws@0.11.0(graphql@16.10.0))
       '@boostercloud/application-tester':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../application-tester
       '@boostercloud/cli':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../cli
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@boostercloud/framework-provider-aws-infrastructure':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-provider-aws-infrastructure
       '@boostercloud/framework-provider-azure-infrastructure':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-provider-azure-infrastructure
       '@boostercloud/framework-provider-local-infrastructure':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-provider-local-infrastructure
       '@boostercloud/metadata-booster':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../metadata-booster
       '@seald-io/nedb':
         specifier: 4.0.2
@@ -777,10 +777,10 @@ importers:
   ../../packages/framework-provider-aws:
     dependencies:
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -790,7 +790,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@types/aws-lambda':
         specifier: 8.10.48
@@ -943,13 +943,13 @@ importers:
         specifier: ^1.170.0
         version: 1.204.0
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-provider-aws':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-provider-aws
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -983,7 +983,7 @@ importers:
         version: 1.10.2
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@types/archiver':
         specifier: 5.1.0
@@ -1097,10 +1097,10 @@ importers:
         specifier: ~1.1.0
         version: 1.1.3
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -1110,7 +1110,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@types/chai':
         specifier: 4.2.18
@@ -1203,16 +1203,16 @@ importers:
         specifier: ~4.7.0
         version: 4.7.0
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-core':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-core
       '@boostercloud/framework-provider-azure':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-provider-azure
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@cdktf/provider-azurerm':
         specifier: 13.18.0
@@ -1279,7 +1279,7 @@ importers:
         version: 11.0.5
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@types/chai':
         specifier: 4.2.18
@@ -1360,10 +1360,10 @@ importers:
   ../../packages/framework-provider-local:
     dependencies:
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -1379,7 +1379,7 @@ importers:
         version: 8.18.0
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@types/chai':
         specifier: 4.2.18
@@ -1475,13 +1475,13 @@ importers:
   ../../packages/framework-provider-local-infrastructure:
     dependencies:
       '@boostercloud/framework-common-helpers':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-common-helpers
       '@boostercloud/framework-provider-local':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-provider-local
       '@boostercloud/framework-types':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../framework-types
       '@effect-ts/core':
         specifier: ^0.60.4
@@ -1500,7 +1500,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@types/chai':
         specifier: 4.2.18
@@ -1636,10 +1636,10 @@ importers:
         version: 8.18.0
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@boostercloud/metadata-booster':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../metadata-booster
       '@types/chai':
         specifier: 4.2.18
@@ -1733,7 +1733,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@boostercloud/eslint-config':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.2.0
         version: link:../../tools/eslint-config
       '@types/node':
         specifier: ^20.17.17
@@ -7378,8 +7378,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.0-dev.20250417:
-    resolution: {integrity: sha512-1/Lqu1vRxNv1wOBoUQMu/z8jsFmPGGZSaSuaEWRWJVcQy7Pxoy16Zil3pzhLdw+C6Jx30iq1IcsCn8ZmUfUl+A==}
+  typescript@5.9.0-dev.20250520:
+    resolution: {integrity: sha512-2xyK59gIyyjHf2/QKcjNXKhLt/Haj9N4D+YPUgDBlzFzuGMH0s8vLU4kkSAlYx4YHKW8pgKRaj3VJzr42XCF3g==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10837,7 +10837,7 @@ snapshots:
     dependencies:
       semver: 7.6.3
       shelljs: 0.8.5
-      typescript: 5.9.0-dev.20250417
+      typescript: 5.9.0-dev.20250520
 
   dunder-proto@1.0.1:
     dependencies:
@@ -14302,7 +14302,7 @@ snapshots:
 
   typescript@5.7.3: {}
 
-  typescript@5.9.0-dev.20250417: {}
+  typescript@5.9.0-dev.20250520: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/packages/framework-core/src/booster-event-stream-consumer.ts
+++ b/packages/framework-core/src/booster-event-stream-consumer.ts
@@ -12,7 +12,7 @@ import { BoosterEventProcessor } from './booster-event-processor'
 export class BoosterEventStreamConsumer {
   @Trace(TraceActionTypes.CONSUME_STREAM_EVENTS)
   public static async consume(rawEvents: unknown, config: BoosterConfig): Promise<void> {
-    const logger = getLogger(config, 'BoosterEventDispatcher#dispatch')
+    const logger = getLogger(config, 'BoosterEventStreamConsumer#consume')
     const eventStore = new EventStore(config)
     const readModelStore = new ReadModelStore(config)
     logger.debug(


### PR DESCRIPTION
## Summary
- fix incorrect logger identifier in BoosterEventStreamConsumer

## Testing
- `node common/scripts/install-run-rush.js test` *(fails: EHOSTUNREACH)*
- `npm test` in `packages/framework-core` *(fails: cross-env not found)*