### PR TITLE
Fix SortFor case sensitivity

### DIFF
--- a/common/changes/@boostercloud/framework-core/fix_sortby_case_sensitivity_2025-09-05-17-03.json
+++ b/common/changes/@boostercloud/framework-core/fix_sortby_case_sensitivity_2025-09-05-17-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@boostercloud/framework-core",
+      "comment": "Makes SortFor case-insentitive (allows lowercased 'asc' and 'desc')",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@boostercloud/framework-core"
+}

--- a/packages/framework-types/src/searcher.ts
+++ b/packages/framework-types/src/searcher.ts
@@ -167,7 +167,7 @@ type DataProperties<T> = {
 }[keyof T]
 
 export type SortFor<TType> = {
-  [TProp in DataProperties<TType>]?: SortFor<TType[TProp]> | 'ASC' | 'DESC'
+  [TProp in DataProperties<TType>]?: SortFor<TType[TProp]> | 'ASC' | 'DESC' | 'asc' | 'desc'
 }
 
 export type FilterFor<TType> = {


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#github-flow
- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#publishing-your-pull-request

- Make sure you followed our Code style https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#code-style-guidelines

- Make sure everything works https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#getting-the-code

- Run tests 🐛 https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md#running-unit-tests

-->

## Description

The changes introduced in #1584 caused compilation errors in applications that were using lowercased `'asc'` or `'desc'` when using `sortBy` on nested properties. e.g.,

```typescript
.sortBy({
  someProp: {
    nestedProp: {
      createdAt: 'desc',
    }
  }
})
```

To keep backwards compatibility, `SortFor` is modified to be case-insensitive.

## Changes

* Changes the `SortFor` type to allow lowercased `asc` and `desc`.

## Checks
- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
