### PR TITLE
Trigger CI to publish pending version bump

### DIFF
--- a/common/changes/@boostercloud/framework-core/trigger-ci-publish_2026-03-23-14-55.json
+++ b/common/changes/@boostercloud/framework-core/trigger-ci-publish_2026-03-23-14-55.json
@@ -3,9 +3,9 @@
     {
       "comment": "Trigger CI publish",
       "type": "none",
-      "packageName": "@boostercloud/framework-types"
+      "packageName": "@boostercloud/framework-core"
     }
   ],
-  "packageName": "@boostercloud/framework-types",
+  "packageName": "@boostercloud/framework-core",
   "email": "mario@theagilemonkeys.com"
 }

--- a/common/changes/@boostercloud/framework-types/trigger-ci-publish_2026-03-23-14-20.json
+++ b/common/changes/@boostercloud/framework-types/trigger-ci-publish_2026-03-23-14-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Trigger CI publish",
+      "type": "none",
+      "packageName": "@boostercloud/framework-types"
+    }
+  ],
+  "packageName": "@boostercloud/framework-types",
+  "email": "mario@theagilemonkeys.com"
+}

--- a/packages/framework-types/src/index.ts
+++ b/packages/framework-types/src/index.ts
@@ -16,4 +16,5 @@ export * from './super-kind'
 export * from './instrumentation/trace-types'
 export * from './sensor/health-indicator-configuration'
 export * from './internal-info'
+
 export * from './stream-types'


### PR DESCRIPTION
## Summary
- The `@azure/identity` security bump (PR #1600) was never published to npm because the publish workflow had broken OIDC auth at the time (PR #1596)
- The workflow was fixed in PR #1601, but that commit only touched `.github/**` (which is in `paths-ignore`), so no publish run was triggered
- This cosmetic whitespace change triggers a new publish run to pick up the pending changeset and bump all lockstep packages from 4.0.1 → 4.0.2

## Test plan
- [ ] Verify the publish workflow triggers after merge
- [ ] Verify packages are published to npm with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)